### PR TITLE
Handle stop while awaiting user input

### DIFF
--- a/packages/ui/src/panel/Panel.ts
+++ b/packages/ui/src/panel/Panel.ts
@@ -237,6 +237,7 @@ export class Panel {
 	 * Dispose panel and clean up event listeners
 	 */
 	dispose(): void {
+		this.#cancelPendingUserAnswer()
 		// Remove agent event listeners
 		this.#agent.removeEventListener('statuschange', this.#onStatusChange)
 		this.#agent.removeEventListener('historychange', this.#onHistoryChange)
@@ -278,6 +279,9 @@ export class Panel {
 	 */
 	#handleActionButton(): void {
 		if (this.#agent.status === 'running') {
+			if (this.#isWaitingForUserAnswer) {
+				this.#cancelPendingUserAnswer()
+			}
 			this.#agent.stop()
 		} else {
 			this.#agent.dispose()
@@ -322,6 +326,19 @@ export class Panel {
 			this.#userAnswerResolver(input)
 			this.#userAnswerResolver = null
 		}
+	}
+
+	#cancelPendingUserAnswer(): void {
+		if (!this.#isWaitingForUserAnswer) return
+
+		this.#isWaitingForUserAnswer = false
+
+		if (this.#userAnswerResolver) {
+			this.#userAnswerResolver('')
+			this.#userAnswerResolver = null
+		}
+
+		this.#hideInputArea()
 	}
 
 	/**


### PR DESCRIPTION
## 背景

这个 PR 用来修复默认 UI 在 `ask_user` 等待用户输入期间，点击停止后面板状态没有正确收敛，导致随后点击关闭时 panel 不能正常关闭的问题，Closes #183。

issue 里的复现路径是：

- UI 正在询问用户问题
- 此时不输入内容，直接点击停止
- 停止本身生效，mask 消失
- 但随后再点击关闭，panel 没有正常关闭

## 根因

问题的核心不是 `stop()` 没有执行，而是 **Panel 仍然保留着“等待用户输入”的悬挂状态**：

- `#isWaitingForUserAnswer` 没有被清掉
- `#userAnswerResolver` 仍然悬挂
- 输入区域也没有在停止/销毁路径里统一收起

这样会导致 UI 状态和 agent 实际状态脱节：表面上已经停止，但 panel 内部还像是在等一次用户回答，后续关闭路径就会表现异常。

## 修复思路

这次改动把“取消 pending user answer”的收口逻辑放到一个统一方法里：`#cancelPendingUserAnswer()`。

具体包括：

- 当 panel 处于等待用户输入状态时，点击 Stop 会先取消这次 pending answer，再调用 `agent.stop()`
- 在 `dispose()` 路径里也会执行同样的取消逻辑，避免销毁时残留未完成的 resolver
- 取消时会同步：
  - 清掉 `#isWaitingForUserAnswer`
  - resolve 掉 pending answer（空字符串）
  - 清空 resolver 引用
  - 收起输入区域

这样 Stop 和 Close 两条路径都会看到一致、已收敛的 panel 状态。

## 验证

本地尝试过：

```bash
npm run lint -- --max-warnings=0
```

当前工作树里这个命令没有跑通，因为环境里缺少 `eslint`（not installed），所以这次没有得到有效的 lint 结果。

另外从改动路径看，这次只触及 `packages/ui/src/panel/Panel.ts`，属于面板状态清理与等待态收敛逻辑的局部修复。

## 影响范围

影响集中在默认 UI panel 的交互状态管理：

- 修复停止后无法正常关闭的问题
- 避免 pending user answer 在 stop/dispose 后继续残留
- 不涉及 core agent 逻辑与其他 package 的行为变更
