### PR TITLE
fix: close panel after stopping a pending ask_user prompt

### DIFF
--- a/packages/core/src/PageAgentCore.ts
+++ b/packages/core/src/PageAgentCore.ts
@@ -189,6 +189,9 @@ export class PageAgentCore extends EventTarget {
 	stop() {
 		this.pageController.cleanUpHighlights()
 		this.pageController.hideMask()
+		if (this.#status === 'running') {
+			this.#setStatus('error')
+		}
 		this.#abortController.abort()
 	}
 

--- a/packages/ui/src/panel/Panel.ts
+++ b/packages/ui/src/panel/Panel.ts
@@ -173,9 +173,37 @@ export class Panel {
 	 */
 	#askUser(question: string): Promise<string> {
 		return new Promise((resolve) => {
+			const cleanup = () => {
+				this.#agent.removeEventListener('statuschange', onCancel)
+				this.#agent.removeEventListener('dispose', onCancel)
+			}
+			const resolveAndCleanup = (input: string) => {
+				cleanup()
+				resolve(input)
+			}
+			const onCancel = (event: Event) => {
+				if (!this.#isWaitingForUserAnswer) {
+					cleanup()
+					return
+				}
+				if (event.type === 'statuschange' && this.#agent.status === 'running') {
+					return
+				}
+
+				this.#clearPendingQuestionCard()
+				this.#isWaitingForUserAnswer = false
+				this.#userAnswerResolver = null
+				if (this.#shouldShowInputArea()) {
+					this.#showInputArea()
+				}
+				resolveAndCleanup('')
+			}
+
 			// Set `waiting for user answer` state
 			this.#isWaitingForUserAnswer = true
-			this.#userAnswerResolver = resolve
+			this.#userAnswerResolver = resolveAndCleanup
+			this.#agent.addEventListener('statuschange', onCancel)
+			this.#agent.addEventListener('dispose', onCancel)
 
 			// Expand history panel
 			if (!this.#isExpanded) {
@@ -307,12 +335,7 @@ export class Panel {
 	 * Handle user answer
 	 */
 	#handleUserAnswer(input: string): void {
-		// Remove temporary question cards (only direct children for safety)
-		Array.from(this.#historySection.children).forEach((child) => {
-			if (child.getAttribute('data-temp-card') === 'true') {
-				child.remove()
-			}
-		})
+		this.#clearPendingQuestionCard()
 
 		// Reset state
 		this.#isWaitingForUserAnswer = false
@@ -322,6 +345,15 @@ export class Panel {
 			this.#userAnswerResolver(input)
 			this.#userAnswerResolver = null
 		}
+	}
+
+	#clearPendingQuestionCard(): void {
+		// Remove temporary question cards (only direct children for safety)
+		Array.from(this.#historySection.children).forEach((child) => {
+			if (child.getAttribute('data-temp-card') === 'true') {
+				child.remove()
+			}
+		})
 	}
 
 	/**


### PR DESCRIPTION
## What


Fixes a panel state bug when the agent is waiting on an `ask_user` prompt.

When the user clicks stop while the panel is waiting for an answer:
- the agent now leaves the `running` state immediately,
- the pending question UI is cleared,
- the waiting promise is resolved cleanly,
- and the panel can be closed or reused normally.


## Type


- [x] Bug fix
- [ ] Feature / Improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Website
- [ ] Demo / Testing
- [ ] Breaking change


## Testing


- [ ] Tested in modern browsers
- [ ] No console errors
- [ ] Types/doc added

Local validation:
- `npm ci`
- `npm run build -w @page-agent/ui`
- `npm run build -w page-agent` (completed locally; the repo still prints existing package type-resolution diagnostics during build)
- `git diff --check`

Closes #183


## Requirements / 要求


- [x] I have read and follow the [Code of Conduct](../docs/CODE_OF_CONDUCT.md) and [Contributing Guide](../CONTRIBUTING.md) . / 我已阅读并遵守行为准则。

## Checklist


- [ ] This PR is NOT generated by a bot or AI agent acting autonomously. I have authored or meaningfully reviewed every change. / 此 PR 不是由 bot 或 AI 自主生成的，我已亲自编写或充分审查了每一处变更。
