### PR TITLE
fix: prefer menu items over ARIA menu containers in DOM detection

### DIFF
--- a/packages/page-controller/src/dom/dom_tree/index.js
+++ b/packages/page-controller/src/dom/dom_tree/index.js
@@ -866,8 +866,7 @@ export default (
 		const interactiveRoles = new Set([
 			'button', // Directly clickable element
 			// 'link',            // Clickable link
-			'menu', // Menu container (ARIA menus)
-			'menubar', // Menu bar container
+			// Composite container roles like menu/menubar/listbox should defer to their child items.
 			'menuitem', // Clickable menu item
 			'menuitemradio', // Radio-style menu item (selectable)
 			'menuitemcheckbox', // Checkbox-style menu item (toggleable)
@@ -880,7 +879,6 @@ export default (
 			'combobox', // Dropdown with text input
 			'searchbox', // Search input field
 			'textbox', // Text input field
-			'listbox', // Selectable list
 			'option', // Selectable option in a list
 			'scrollbar', // Scrollable control
 		])


### PR DESCRIPTION
## Summary
- stop treating composite ARIA container roles (`menu`, `menubar`, `listbox`) as directly clickable targets
- let their child menu items / options be highlighted instead

## Verification
- npm run build -w @page-agent/page-controller
- commit hook ran prettier + eslint on the touched file

Closes #193