### PR TITLE
feat(core): add internationalization (i18n) support for console messages

### DIFF
--- a/packages/core/src/PageAgentCore.ts
+++ b/packages/core/src/PageAgentCore.ts
@@ -7,6 +7,7 @@ import type { BrowserState, PageController } from '@page-agent/page-controller'
 import chalk from 'chalk'
 import * as z from 'zod/v4'
 
+import { type Language, createTranslator } from './i18n'
 import SYSTEM_PROMPT from './prompts/system_prompt.md?raw'
 import { tools } from './tools'
 import type {
@@ -26,6 +27,9 @@ export { tool, type PageAgentTool } from './tools'
 export type * from './types'
 
 export type PageAgentCoreConfig = AgentConfig & { pageController: PageController }
+
+/** Default language */
+const DEFAULT_LANGUAGE: Language = 'en'
 
 /**
  * AI agent for browser automation.
@@ -82,6 +86,8 @@ export class PageAgentCore extends EventTarget {
 	#llm: LLM
 	#abortController = new AbortController()
 	#observations: string[] = []
+	/** Translator function for i18n */
+	#t: ReturnType<typeof createTranslator>
 
 	/** internal states during a single task execution */
 	#states = {
@@ -97,6 +103,11 @@ export class PageAgentCore extends EventTarget {
 		super()
 
 		this.config = { ...config, maxSteps: config.maxSteps ?? 40 }
+
+		// Initialize translator based on language config
+		const configLang = config.language || 'en-US'
+		const language: Language = configLang === 'zh-CN' ? 'zh-CN' : 'en'
+		this.#t = createTranslator(language)
 
 		this.#llm = new LLM(this.config)
 		this.tools = new Map(tools)
@@ -236,7 +247,7 @@ export class PageAgentCore extends EventTarget {
 
 				// observe
 
-				console.log(chalk.blue.bold('👀 Observing...'))
+				console.log(chalk.blue.bold(this.#t('observing')))
 
 				this.#states.browserState = await this.pageController.getBrowserState()
 				await this.#handleObservations(step)
@@ -252,7 +263,7 @@ export class PageAgentCore extends EventTarget {
 
 				// invoke LLM
 
-				console.log(chalk.blue.bold('🧠 Thinking...'))
+				console.log(chalk.blue.bold(this.#t('thinking')))
 				this.#emitActivity({ type: 'thinking' })
 
 				const result = await this.#llm.invoke(messages, macroTool, this.#abortController.signal, {
@@ -299,7 +310,7 @@ export class PageAgentCore extends EventTarget {
 				if (actionName === 'done') {
 					const success = action.input?.success ?? false
 					const text = action.input?.text || 'no text provided'
-					console.log(chalk.green.bold('Task completed'), success, text)
+					console.log(chalk.green.bold(this.#t('taskCompleted')), success, text)
 					this.#onDone(success)
 					const result: ExecutionResult = {
 						success,
@@ -313,8 +324,8 @@ export class PageAgentCore extends EventTarget {
 				console.groupEnd() // to prevent nested groups
 				const isAbortError = (error as any)?.rawError?.name === 'AbortError'
 
-				console.error('Task failed', error)
-				const errorMessage = isAbortError ? 'Task stopped' : String(error)
+				console.error(this.#t('taskFailed'), error)
+				const errorMessage = isAbortError ? this.#t('taskStopped') : String(error)
 				this.#emitActivity({ type: 'error', message: errorMessage })
 				this.history.push({ type: 'error', message: errorMessage, rawResponse: error })
 				this.#emitHistoryChange()
@@ -330,7 +341,7 @@ export class PageAgentCore extends EventTarget {
 
 			step++
 			if (step > this.config.maxSteps) {
-				const errorMessage = 'Step count exceeded maximum limit'
+				const errorMessage = this.#t('stepExceeded')
 				this.history.push({ type: 'error', message: errorMessage })
 				this.#emitHistoryChange()
 				this.#onDone(false)
@@ -380,7 +391,7 @@ export class PageAgentCore extends EventTarget {
 				// abort
 				if (this.#abortController.signal.aborted) throw new Error('AbortError')
 
-				console.log(chalk.blue.bold('MacroTool input'), input)
+				console.log(chalk.blue.bold(this.#t('macroToolInput')), input)
 				const action = input.action
 
 				const toolName = Object.keys(action)[0]
@@ -401,9 +412,9 @@ export class PageAgentCore extends EventTarget {
 
 				// Find the corresponding tool
 				const tool = tools.get(toolName)
-				assert(tool, `Tool ${toolName} not found`)
+				assert(tool, this.#t('toolNotFound', { toolName }))
 
-				console.log(chalk.blue.bold(`Executing tool: ${toolName}`), toolInput)
+				console.log(chalk.blue.bold(`${this.#t('executingTool')}: ${toolName}`), toolInput)
 
 				// Emit executing activity
 				this.#emitActivity({ type: 'executing', tool: toolName, input: toolInput })
@@ -414,7 +425,7 @@ export class PageAgentCore extends EventTarget {
 				const result = await tool.execute.bind(this)(toolInput)
 
 				const duration = Date.now() - startTime
-				console.log(chalk.green.bold(`Tool (${toolName}) executed for ${duration}ms`), result)
+				console.log(chalk.green.bold(`${this.#t('toolExecuted')} ${duration}ms`), result)
 
 				// Emit executed activity
 				this.#emitActivity({
@@ -472,10 +483,7 @@ export class PageAgentCore extends EventTarget {
 			try {
 				pageInstructions = instructions.getPageInstructions(url)?.trim()
 			} catch (error) {
-				console.error(
-					chalk.red('[PageAgent] Failed to execute getPageInstructions callback:'),
-					error
-				)
+				console.error(chalk.red(this.#t('pageInstructionsError')), error)
 			}
 		}
 
@@ -510,15 +518,13 @@ export class PageAgentCore extends EventTarget {
 	async #handleObservations(step: number): Promise<void> {
 		// Accumulated wait time warning
 		if (this.#states.totalWaitTime >= 3) {
-			this.pushObservation(
-				`You have waited ${this.#states.totalWaitTime} seconds accumulatively. DO NOT wait any longer unless you have a good reason.`
-			)
+			this.pushObservation(this.#t('waitTimeWarning', { seconds: this.#states.totalWaitTime }))
 		}
 
 		// Detect URL change
 		const currentURL = this.#states.browserState?.url || ''
 		if (currentURL !== this.#states.lastURL) {
-			this.pushObservation(`Page navigated to → ${currentURL}`)
+			this.pushObservation(this.#t('pageNavigated', { url: currentURL }))
 			this.#states.lastURL = currentURL
 			await waitFor(0.5) // wait for page to stabilize
 		}
@@ -526,20 +532,16 @@ export class PageAgentCore extends EventTarget {
 		// Remaining steps warning
 		const remaining = this.config.maxSteps - step
 		if (remaining === 5) {
-			this.pushObservation(
-				`⚠️ Only ${remaining} steps remaining. Consider wrapping up or calling done with partial results.`
-			)
+			this.pushObservation(this.#t('remainingStepsWarning', { remaining }))
 		} else if (remaining === 2) {
-			this.pushObservation(
-				`⚠️ Critical: Only ${remaining} steps left! You must finish the task or call done immediately.`
-			)
+			this.pushObservation(this.#t('criticalStepsWarning', { remaining }))
 		}
 
 		// Push observations to history and emit
 		if (this.#observations.length > 0) {
 			for (const content of this.#observations) {
 				this.history.push({ type: 'observation', content })
-				console.log(chalk.cyan('Observation:'), content)
+				console.log(chalk.cyan(this.#t('observation')), content)
 			}
 			this.#observations = []
 			this.#emitHistoryChange()
@@ -624,7 +626,7 @@ export class PageAgentCore extends EventTarget {
 	}
 
 	dispose() {
-		console.log('Disposing PageAgent...')
+		console.log(this.#t('disposing'))
 		this.disposed = true
 		this.pageController.dispose()
 		// this.history = []

--- a/packages/core/src/i18n.ts
+++ b/packages/core/src/i18n.ts
@@ -1,0 +1,114 @@
+/**
+ * Copyright (C) 2025 Alibaba Group Holding Limited
+ * All rights reserved.
+ */
+
+/**
+ * Internationalization (i18n) module for PageAgent
+ * Provides multi-language support for UI strings and console messages
+ */
+
+export type Language = 'en' | 'zh-CN'
+
+/** Supported languages in AgentConfig */
+export type SupportedLanguage = 'en-US' | 'zh-CN'
+
+export interface Translations {
+	// Console messages
+	observing: string
+	thinking: string
+	taskCompleted: string
+	taskFailed: string
+	taskStopped: string
+	stepExceeded: string
+	macroToolInput: string
+	executingTool: string
+	toolExecuted: string
+	observation: string
+	disposing: string
+
+	// Observations/Warnings
+	waitTimeWarning: string
+	pageNavigated: string
+	remainingStepsWarning: string
+	criticalStepsWarning: string
+
+	// Errors
+	toolNotFound: string
+	pageInstructionsError: string
+}
+
+const translations: Record<Language, Translations> = {
+	en: {
+		observing: '👀 Observing...',
+		thinking: '🧠 Thinking...',
+		taskCompleted: 'Task completed',
+		taskFailed: 'Task failed',
+		taskStopped: 'Task stopped',
+		stepExceeded: 'Step count exceeded maximum limit',
+		macroToolInput: 'MacroTool input',
+		executingTool: 'Executing tool',
+		toolExecuted: 'Tool executed for',
+		observation: 'Observation:',
+		disposing: 'Disposing PageAgent...',
+
+		waitTimeWarning:
+			'You have waited {seconds} seconds accumulatively. DO NOT wait any longer unless you have a good reason.',
+		pageNavigated: 'Page navigated to → {url}',
+		remainingStepsWarning:
+			'⚠️ Only {remaining} steps remaining. Consider wrapping up or calling done with partial results.',
+		criticalStepsWarning:
+			'⚠️ Critical: Only {remaining} steps left! You must finish the task or call done immediately.',
+
+		toolNotFound: 'Tool {toolName} not found',
+		pageInstructionsError: '[PageAgent] Failed to execute getPageInstructions callback:',
+	},
+	'zh-CN': {
+		observing: '👀 观察中...',
+		thinking: '🧠 思考中...',
+		taskCompleted: '任务完成',
+		taskFailed: '任务失败',
+		taskStopped: '任务已停止',
+		stepExceeded: '步数超过最大限制',
+		macroToolInput: 'MacroTool 输入',
+		executingTool: '执行工具',
+		toolExecuted: '工具执行耗时',
+		observation: '观察:',
+		disposing: '正在释放 PageAgent...',
+
+		waitTimeWarning: '您已累计等待 {seconds} 秒。除非有充分理由，否则请勿继续等待。',
+		pageNavigated: '页面已导航至 → {url}',
+		remainingStepsWarning: '⚠️ 仅剩 {remaining} 步。请考虑完成或调用 done 返回部分结果。',
+		criticalStepsWarning: '⚠️ 紧急：仅剩 {remaining} 步！您必须立即完成任务或调用 done。',
+
+		toolNotFound: '未找到工具 {toolName}',
+		pageInstructionsError: '[PageAgent] 执行 getPageInstructions 回调失败：',
+	},
+}
+
+/**
+ * Get translation for the specified language
+ */
+export function getTranslations(language: Language): Translations {
+	return translations[language] || translations.en
+}
+
+/**
+ * Create a translation function for the specified language
+ */
+export function createTranslator(language: Language) {
+	const t = translations[language] || translations.en
+
+	return function translate(
+		key: keyof Translations,
+		params?: Record<string, string | number>
+	): string {
+		let text = t[key] || key
+		if (params) {
+			for (const [param, value] of Object.entries(params)) {
+				text = text.replace(`{${param}}`, String(value))
+			}
+		}
+		return text
+	}
+}


### PR DESCRIPTION
## Summary

This PR adds internationalization (i18n) support to PageAgent, addressing feature request #195.

### Changes

- Added `i18n.ts` module with translations for English and Chinese
- Updated `PageAgentCore` to use translator for all user-facing strings
- Support language config via `AgentConfig.language` (en-US/zh-CN)
- Translated console messages, observations, and error messages

### Usage

```typescript
import { PageAgent } from "@page-agent/core";

const agent = new PageAgent({
  language: "zh-CN", // or "en-US"
  // ...other config
});
```

With `language: "zh-CN"`, console output will be in Chinese:
- 👀 观察中...
- 🧠 思考中...
- 任务完成

## Related Issue

Closes #195