### PR TITLE
fix: extract attributes for heuristically-detected interactive elements

### DIFF
--- a/packages/page-controller/src/dom/dom_tree/index.js
+++ b/packages/page-controller/src/dom/dom_tree/index.js
@@ -17,6 +17,7 @@
  * @edit add `data-browser-use-ignore` attribute
  * @edit improve `sampleRect`, filter out rects with 0 area
  * @edit exclude aria-hidden elements
+ * @edit make sure attributes exist for interactive candidates.
  */
 
 export default (
@@ -1609,10 +1610,10 @@ export default (
 					 */
 					nodeData.ref = node
 
-					// Extract attributes for heuristically-detected interactive elements
-					// isInteractiveCandidate() only covers standard tags and ARIA attributes,
-					// so elements detected via cursor:pointer, class names, or event listeners
-					// may have empty attributes. Fill them in so include_attributes works.
+					/**
+					 * @edit make sure attributes exist for interactive candidates.
+					 * @note if the element failed the isInteractiveCandidate, attributes would be empty.
+					 */
 					if (nodeData.isInteractive && Object.keys(nodeData.attributes).length === 0) {
 						const attributeNames = node.getAttributeNames?.() || []
 						for (const name of attributeNames) {


### PR DESCRIPTION
## Summary

Fixes #124

Elements detected as interactive via **heuristic methods** (e.g. `cursor: pointer` style, interactive class names like `nav-search-btn`, event listeners) had **empty `attributes`** in the DOM tree. This caused `includeAttributes` (e.g. `['class']`) to have no effect on these elements, making it impossible for LLMs to identify them by class name.

### Root Cause

In `buildDomTree()`, attribute extraction (line 1569) uses `isInteractiveCandidate()` as the gate condition. This function only recognizes:
- Standard HTML tags (`a`, `button`, `input`, etc.)
- Elements with `onclick`, `role`, `tabindex`, `aria-*`, or `data-action` attributes

It does **not** cover elements detected by `isInteractiveElement()` via:
- `cursor: pointer` computed style
- Interactive class name patterns (e.g. `button`, `dropdown-toggle`)
- Attached event listeners

Since attribute extraction happens **before** interactivity detection (line 1603), heuristically-detected elements end up with `attributes: {}`, and `includeAttributes` has nothing to include.

### Fix

After `isInteractiveElement()` confirms an element is interactive, backfill its attributes if they were not already extracted by `isInteractiveCandidate()`. This is done by checking `Object.keys(nodeData.attributes).length === 0` to avoid redundant work for elements already handled.

### Example: Bilibili Search Button

```html
<div class="nav-search-btn">
  <svg>...</svg>
</div>
```

- **Before**: Detected as interactive (via `cursor: pointer`), but `attributes` is `{}`. With `includeAttributes: ['class']`, LLM sees no class info → cannot find the search button.
- **After**: `attributes` includes `{ class: "nav-search-btn" }`. LLM can now identify it.

## Test Plan

- [x] `npm run build` passes
- [x] `npm run lint` passes
- [ ] Manual test: configure `includeAttributes: ['class']`, verify class appears in DOM snapshot for `cursor: pointer` elements

🤖 Generated with [Claude Code](https://claude.com/claude-code)