### PR TITLE
fix: add tab handling rules to prevent infinite loops

### DIFF
--- a/packages/core/src/prompts/system_prompt.md
+++ b/packages/core/src/prompts/system_prompt.md
@@ -86,9 +86,12 @@ Strictly follow these rules while using the browser and navigating the web:
 </browser_rules>
 
 <capability>
-- You can only handle single page app. Do not jump out of current page.
-- Do not click on link if it will open in a new page (etc. <a target="_blank">)
-- It is ok to fail the task.
+- If you need to handle multiple pages/tabs, use the switch_to_tab action to switch between open tabs.
+- When clicking an element that may open a new tab (e.g., links with target="_blank", buttons that trigger window.open()), check the "Open Tabs" section in browser_state AFTER the click.
+- If a new tab was opened, use switch_to_tab to switch to it and continue the task there.
+- Do not repeatedly click the same element expecting the current tab to change - if a new tab opens, you must switch to it.
+- Watch for warning signs of getting stuck in a loop: clicking the same element multiple times without any change in browser_state.
+</capability>
 	- User can be wrong. If the request of user is not achievable, inappropriate or you do not have enough information or tools to achieve it. Tell user to make a better request.
 	- Webpage can be broken. All webpages or apps have bugs. Some bug will make it hard for your job. It's encouraged to tell user the problem of current page. Your feedbacks (including failing) are valuable for user.
 	- Trying to hard can be harmful. Repeating some action back and forth or pushing for a complex procedure with little knowledge can cause unwanted result and harmful side-effects. User would rather you to complete the task with a fail.

--- a/packages/extension/src/agent/system_prompt.md
+++ b/packages/extension/src/agent/system_prompt.md
@@ -87,6 +87,16 @@ Strictly follow these rules while using the browser and navigating the web:
 - If you get stuck e.g. with logins or captcha in open-ended tasks you can re-evaluate the task and try alternative ways, e.g. sometimes accidentally login pops up, even though there some part of the page is accessible or you get some information via web search.
 </browser_rules>
 
+<tab_handling_rules>
+CRITICAL: Properly handle new tabs when clicking elements:
+- After clicking any element, ALWAYS check the "Open Tabs" section in browser_state for newly opened tabs.
+- If a new tab was opened (e.g., link with target="_blank", window.open(), or buttons that trigger new tabs), use switch_to_tab to switch to the new tab.
+- Do NOT repeatedly click the same element expecting the current tab to change - if a new tab opens, you MUST switch to it to continue.
+- Warning signs of getting stuck in a loop: clicking the same element multiple times while the current tab URL remains unchanged.
+- When you see "Multiple attempts to click all open in new tabs" in the history, this indicates the agent should switch tabs instead of re-clicking.
+- Use switch_to_tab with the appropriate tab index to continue the task on the newly opened tab.
+</tab_handling_rules>
+
 <task_completion_rules>
 You must call the `done` action in one of three cases:
 - When you have fully completed the USER REQUEST.


### PR DESCRIPTION
Fixes issue #201: Agent gets stuck in infinite loop when clicking links that open in new tabs.

## Problem
The current system prompt explicitly forbids clicking links that open new tabs but provides no guidance on how to handle them properly.

## Solution
Added proper tab handling instructions to both system prompt files:
1. packages/core/src/prompts/system_prompt.md - Updated capability section
2. packages/extension/src/agent/system_prompt.md - Added tab_handling_rules section