### PR TITLE
fix(llms): allow customFetch auth without apiKey

### DIFF
--- a/packages/llms/src/OpenAIClient.ts
+++ b/packages/llms/src/OpenAIClient.ts
@@ -4,17 +4,18 @@
 import * as z from 'zod/v4'
 
 import { InvokeError, InvokeErrorType } from './errors'
-import type { InvokeOptions, InvokeResult, LLMClient, LLMConfig, Message, Tool } from './types'
+import type { ParsedLLMConfig } from './index'
+import type { InvokeOptions, InvokeResult, LLMClient, Message, Tool } from './types'
 import { modelPatch, zodToOpenAITool } from './utils'
 
 /**
  * Client for OpenAI compatible APIs
  */
 export class OpenAIClient implements LLMClient {
-	config: Required<LLMConfig>
+	config: ParsedLLMConfig
 	private fetch: typeof globalThis.fetch
 
-	constructor(config: Required<LLMConfig>) {
+	constructor(config: ParsedLLMConfig) {
 		this.config = config
 		this.fetch = config.customFetch
 	}
@@ -50,7 +51,7 @@ export class OpenAIClient implements LLMClient {
 				method: 'POST',
 				headers: {
 					'Content-Type': 'application/json',
-					Authorization: `Bearer ${this.config.apiKey}`,
+					...(this.config.apiKey ? { Authorization: `Bearer ${this.config.apiKey}` } : {}),
 				},
 				body: JSON.stringify(requestBody),
 				signal: abortSignal,

--- a/packages/llms/src/index.ts
+++ b/packages/llms/src/index.ts
@@ -6,18 +6,28 @@ import type { InvokeOptions, InvokeResult, LLMClient, LLMConfig, Message, Tool }
 export { InvokeError, InvokeErrorType }
 export type { InvokeOptions, InvokeResult, LLMClient, LLMConfig, Message, Tool }
 
-export function parseLLMConfig(config: LLMConfig): Required<LLMConfig> {
-	// Runtime validation as defensive programming (types already guarantee these)
-	if (!config.baseURL || !config.apiKey || !config.model) {
+export interface ParsedLLMConfig extends Omit<Required<LLMConfig>, 'apiKey'> {
+	apiKey: string
+}
+
+export function parseLLMConfig(config: LLMConfig): ParsedLLMConfig {
+	if (!config.baseURL || !config.model) {
 		throw new Error(
-			'[PageAgent] LLM configuration required. Please provide: baseURL, apiKey, model. ' +
+			'[PageAgent] LLM configuration required. Please provide: baseURL, model, and either apiKey or customFetch-auth. ' +
+				'See: https://alibaba.github.io/page-agent/docs/features/models'
+		)
+	}
+
+	if (!config.apiKey && !config.customFetch) {
+		throw new Error(
+			'[PageAgent] LLM configuration required. Please provide an apiKey, or use customFetch to handle authentication. ' +
 				'See: https://alibaba.github.io/page-agent/docs/features/models'
 		)
 	}
 
 	return {
 		baseURL: config.baseURL,
-		apiKey: config.apiKey,
+		apiKey: config.apiKey ?? '',
 		model: config.model,
 		temperature: config.temperature ?? DEFAULT_TEMPERATURE,
 		maxRetries: config.maxRetries ?? LLM_MAX_RETRIES,
@@ -26,7 +36,7 @@ export function parseLLMConfig(config: LLMConfig): Required<LLMConfig> {
 }
 
 export class LLM extends EventTarget {
-	config: Required<LLMConfig>
+	config: ParsedLLMConfig
 	client: LLMClient
 
 	constructor(config: LLMConfig) {

--- a/packages/llms/src/types.ts
+++ b/packages/llms/src/types.ts
@@ -89,7 +89,11 @@ export interface InvokeResult<TResult = unknown> {
  */
 export interface LLMConfig {
 	baseURL: string
-	apiKey: string
+	/**
+	 * API key for Authorization header injection.
+	 * Optional when customFetch handles authentication itself.
+	 */
+	apiKey?: string
 	model: string
 
 	temperature?: number

--- a/packages/website/src/pages/docs/features/models/page.tsx
+++ b/packages/website/src/pages/docs/features/models/page.tsx
@@ -259,20 +259,20 @@ LLM_MODEL_NAME="qwen3:14b"`}
 					{isZh ? (
 						<>
 							如果你计划将它集成到你的 Web 应用中，建议搭建一个后端代理来转发 LLM 请求，并使用{' '}
-							<code>customFetch</code> 携带 Cookie 或其他鉴权信息：
+							<code>customFetch</code> 携带 Cookie 或其他鉴权信息；这种模式下可以省略{' '}
+							<code>apiKey</code>：
 						</>
 					) : (
 						<>
 							If you plan to integrate it into your web app, it's better to have a backend proxy for
 							the LLM and use <code>customFetch</code> to authenticate the request with cookies or
-							other methods:
+							other methods. In this mode, <code>apiKey</code> can be omitted:
 						</>
 					)}
 				</p>
 				<CodeEditor
 					code={`const agent = new PageAgent({
   baseURL: '/api/llm-proxy',
-  apiKey: 'NA',
   model: 'gpt-5.1',
   customFetch: (url, init) =>
     fetch(url, { ...init, credentials: 'include' }),


### PR DESCRIPTION
## Summary
- allow `PageAgent` / `LLM` configs to omit `apiKey` when `customFetch` is provided
- skip injecting the `Authorization` header when no API key is configured
- update the production-auth docs to show the `customFetch`-only flow

## Verification
- `npm run build --workspace=@page-agent/llms`
- `npm run build:website --workspace=@page-agent/website`
- `npx eslint packages/llms/src/index.ts packages/llms/src/OpenAIClient.ts packages/llms/src/types.ts packages/website/src/pages/docs/features/models/page.tsx`

Closes #200
