### PR TITLE
fix(llms): make apiKey optional when customFetch is provided

### DIFF
--- a/packages/llms/src/OpenAIClient.ts
+++ b/packages/llms/src/OpenAIClient.ts
@@ -46,12 +46,18 @@ export class OpenAIClient implements LLMClient {
 		// 2. Call API
 		let response: Response
 		try {
+			// Only include Authorization header when an API key is present.
+			// When customFetch handles auth (e.g. via cookies/proxy), apiKey may be empty.
+			const headers: Record<string, string> = {
+				'Content-Type': 'application/json',
+			}
+			if (this.config.apiKey) {
+				headers['Authorization'] = `Bearer ${this.config.apiKey}`
+			}
+
 			response = await this.fetch(`${this.config.baseURL}/chat/completions`, {
 				method: 'POST',
-				headers: {
-					'Content-Type': 'application/json',
-					Authorization: `Bearer ${this.config.apiKey}`,
-				},
+				headers,
 				body: JSON.stringify(requestBody),
 				signal: abortSignal,
 			})

--- a/packages/llms/src/index.ts
+++ b/packages/llms/src/index.ts
@@ -7,17 +7,23 @@ export { InvokeError, InvokeErrorType }
 export type { InvokeOptions, InvokeResult, LLMClient, LLMConfig, Message, Tool }
 
 export function parseLLMConfig(config: LLMConfig): Required<LLMConfig> {
-	// Runtime validation as defensive programming (types already guarantee these)
-	if (!config.baseURL || !config.apiKey || !config.model) {
+	// When customFetch is provided the caller handles auth themselves, so apiKey
+	// is not required.  Otherwise all three fields must be present.
+	const needsApiKey = !config.customFetch
+	if (!config.baseURL || !config.model || (needsApiKey && !config.apiKey)) {
+		const missing: string[] = []
+		if (!config.baseURL) missing.push('baseURL')
+		if (!config.model) missing.push('model')
+		if (needsApiKey && !config.apiKey) missing.push('apiKey')
 		throw new Error(
-			'[PageAgent] LLM configuration required. Please provide: baseURL, apiKey, model. ' +
+			`[PageAgent] LLM configuration required. Please provide: ${missing.join(', ')}. ` +
 				'See: https://alibaba.github.io/page-agent/docs/features/models'
 		)
 	}
 
 	return {
 		baseURL: config.baseURL,
-		apiKey: config.apiKey,
+		apiKey: config.apiKey ?? '',
 		model: config.model,
 		temperature: config.temperature ?? DEFAULT_TEMPERATURE,
 		maxRetries: config.maxRetries ?? LLM_MAX_RETRIES,

--- a/packages/llms/src/types.ts
+++ b/packages/llms/src/types.ts
@@ -89,7 +89,13 @@ export interface InvokeResult<TResult = unknown> {
  */
 export interface LLMConfig {
 	baseURL: string
-	apiKey: string
+	/**
+	 * API key for authentication.
+	 * Optional when `customFetch` is provided (e.g. the custom fetch handles auth
+	 * via cookies, proxy headers, or another mechanism that does not require a key).
+	 * Required otherwise.
+	 */
+	apiKey?: string
 	model: string
 
 	temperature?: number


### PR DESCRIPTION
## Problem

When users provide a `customFetch` function to handle authentication themselves (e.g. via cookies, session tokens, or a proxy), they do not have an API key to pass. However, `parseLLMConfig` unconditionally required `apiKey`, throwing:

```
Uncaught Error: [PageAgent] LLM configuration required. Please provide: baseURL, apiKey, model.
```

This makes `customFetch` effectively broken for any use-case that replaces API-key auth entirely.

## Fix

### `packages/llms/src/types.ts`
- `apiKey` changed from `string` (required) to `string | undefined` (optional)
- Added JSDoc clarifying when it is and isn't required

### `packages/llms/src/index.ts` — `parseLLMConfig`
- Only require `apiKey` when `customFetch` is **not** provided
- Error message now lists exactly which fields are missing (e.g. `"baseURL, model"`) instead of always printing all three
- Fall back to empty string (`apiKey ?? ''`) so the `Required<LLMConfig>` return type is satisfied

### `packages/llms/src/OpenAIClient.ts`
- Omit the `Authorization` header entirely when `apiKey` is empty, preventing `Authorization: Bearer ` from being sent to the server

## Before / After

```ts
// BEFORE — throws
new PageAgent({
  baseURL: 'https://my-proxy.example.com/v1',
  model: 'gpt-4o',
  customFetch: myAuthenticatedFetch, // handles auth via session cookie
  // ❌ Error: apiKey required
})

// AFTER — works
new PageAgent({
  baseURL: 'https://my-proxy.example.com/v1',
  model: 'gpt-4o',
  customFetch: myAuthenticatedFetch, // ✅ apiKey not required
})
```

## Tests
- Existing validation still throws when neither `apiKey` nor `customFetch` is supplied
- Error message is now more informative (lists only missing fields)

Closes #200