### PR TITLE
feat(extension): add clear context button to side panel

### DIFF
--- a/packages/extension/src/agent/useAgent.ts
+++ b/packages/extension/src/agent/useAgent.ts
@@ -34,6 +34,7 @@ export interface UseAgentResult {
 	config: ExtConfig | null
 	execute: (task: string) => Promise<void>
 	stop: () => void
+	clear: () => void
 	configure: (config: ExtConfig) => Promise<void>
 }
 
@@ -117,6 +118,14 @@ export function useAgent(): UseAgentResult {
 		agentRef.current?.stop()
 	}, [])
 
+	const clear = useCallback(() => {
+		if (status === 'running') return
+		setCurrentTask('')
+		setHistory([])
+		setActivity(null)
+		setStatus('idle')
+	}, [status])
+
 	const configure = useCallback(
 		async ({
 			language,
@@ -146,6 +155,7 @@ export function useAgent(): UseAgentResult {
 		config,
 		execute,
 		stop,
+		clear,
 		configure,
 	}
 }

--- a/packages/extension/src/entrypoints/sidepanel/App.tsx
+++ b/packages/extension/src/entrypoints/sidepanel/App.tsx
@@ -1,4 +1,4 @@
-import { History, Send, Settings, Square } from 'lucide-react'
+import { Eraser, History, Send, Settings, Square } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { Button } from '@/components/ui/button'
@@ -29,7 +29,8 @@ export default function App() {
 	const historyRef = useRef<HTMLDivElement>(null)
 	const textareaRef = useRef<HTMLTextAreaElement>(null)
 
-	const { status, history, activity, currentTask, config, execute, stop, configure } = useAgent()
+	const { status, history, activity, currentTask, config, execute, stop, clear, configure } =
+		useAgent()
 
 	// Persist session when task finishes
 	const prevStatusRef = useRef(status)
@@ -127,6 +128,18 @@ export default function App() {
 				</div>
 				<div className="flex items-center gap-1">
 					<StatusDot status={status} />
+					{!showEmptyState && (
+						<Button
+							variant="ghost"
+							size="icon-sm"
+							onClick={clear}
+							disabled={isRunning}
+							className="cursor-pointer"
+							title="Clear Context"
+						>
+							<Eraser className="size-3.5" />
+						</Button>
+					)}
 					<Button
 						variant="ghost"
 						size="icon-sm"


### PR DESCRIPTION
## What

Closes #217

I added a "Clear Context" feature to the extension's side panel. This includes a new clear() method in the useAgent hook that resets the current task, history, and activity state. In the UI (App.tsx), I added an Eraser button next to the settings icons that triggers this clear action. The button is automatically disabled while the agent is running and hidden when the context is already empty.



## Type

- [ ] Bug fix
- [✓] Feature / Improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Website
- [ ] Demo / Testing
- [ ] Breaking change

## Testing

- [✓] Tested in modern browsers
- [✓] No console errors
- [ ] Types/doc added

Closes #(217)

## Requirements / 要求

- [✓] I have read and follow the [Code of Conduct](../docs/CODE_OF_CONDUCT.md) and [Contributing Guide](../CONTRIBUTING.md) . / 我已阅读并遵守行为准则。
- [✓] This PR is NOT generated by a bot or AI agent acting autonomously. I have authored or meaningfully reviewed every change. / 此 PR 不是由 bot 或 AI 自主生成的，我已亲自编写或充分审查了每一处变更。
