### PR TITLE
feat(website): basic SEO

### DIFF
--- a/packages/website/public/robots.txt
+++ b/packages/website/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://alibaba.github.io/page-agent/sitemap.xml

--- a/packages/website/src/lib/useDocumentTitle.ts
+++ b/packages/website/src/lib/useDocumentTitle.ts
@@ -1,0 +1,9 @@
+import { useEffect } from 'react'
+
+const DEFAULT_TITLE = 'PageAgent - The GUI Agent Living in Your Webpage'
+
+export function useDocumentTitle(title?: string) {
+	useEffect(() => {
+		document.title = title ? `${title} - PageAgent` : DEFAULT_TITLE
+	}, [title])
+}

--- a/packages/website/src/pages/docs/Layout.tsx
+++ b/packages/website/src/pages/docs/Layout.tsx
@@ -4,6 +4,7 @@ import { Link, useLocation } from 'wouter'
 
 import { SparklesText } from '@/components/ui/sparkles-text'
 import { useLanguage } from '@/i18n/context'
+import { useDocumentTitle } from '@/lib/useDocumentTitle'
 
 interface DocsLayoutProps {
 	children: ReactNode
@@ -64,6 +65,12 @@ export default function DocsLayout({ children }: DocsLayoutProps) {
 			],
 		},
 	]
+
+	const activeTitle = navigationSections
+		.flatMap((s) => s.items)
+		.find((item) => item.path === location)?.title
+
+	useDocumentTitle(activeTitle)
 
 	return (
 		<div className="max-w-7xl mx-auto px-6 py-8 overflow-x-auto">

--- a/packages/website/src/pages/home/index.tsx
+++ b/packages/website/src/pages/home/index.tsx
@@ -1,5 +1,7 @@
 import { Suspense, lazy } from 'react'
 
+import { useDocumentTitle } from '@/lib/useDocumentTitle'
+
 import HeroSection from './HeroSection'
 
 const FeaturesSection = lazy(() => import('./FeaturesSection'))
@@ -7,6 +9,8 @@ const ScenariosSection = lazy(() => import('./ScenariosSection'))
 const OneMoreThingSection = lazy(() => import('./OneMoreThingSection'))
 
 export default function HomePage() {
+	useDocumentTitle()
+
 	return (
 		<>
 			<HeroSection />

--- a/packages/website/vite.config.js
+++ b/packages/website/vite.config.js
@@ -1,7 +1,7 @@
 import tailwindcss from '@tailwindcss/vite'
 import react from '@vitejs/plugin-react-swc'
 import { config as dotenvConfig } from 'dotenv'
-import { copyFileSync, mkdirSync, readFileSync } from 'node:fs'
+import { copyFileSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import process from 'node:process'
 import { dirname, join, resolve } from 'path'
 import { fileURLToPath } from 'url'
@@ -35,6 +35,8 @@ const SPA_ROUTES = [
 	'docs/advanced/security-permissions',
 ]
 
+const SITE_URL = 'https://alibaba.github.io/page-agent'
+
 function spaRoutes() {
 	return {
 		name: 'spa-routes',
@@ -47,6 +49,19 @@ function spaRoutes() {
 				copyFileSync(src, join(dir, 'index.html'))
 			}
 			console.log(`  ✓ Copied index.html to ${SPA_ROUTES.length} SPA routes`)
+
+			const today = new Date().toISOString().split('T')[0]
+			const urls = ['', ...SPA_ROUTES]
+				.map(
+					(route) =>
+						`  <url>\n    <loc>${SITE_URL}/${route}</loc>\n    <lastmod>${today}</lastmod>\n  </url>`
+				)
+				.join('\n')
+			writeFileSync(
+				join(dist, 'sitemap.xml'),
+				`<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls}\n</urlset>\n`
+			)
+			console.log(`  ✓ Generated sitemap.xml with ${SPA_ROUTES.length + 1} URLs`)
 		},
 	}
 }


### PR DESCRIPTION
- Add `robots.txt` pointing crawlers to sitemap
- Auto-generate `sitemap.xml` at build time from the existing `SPA_ROUTES` array (17 URLs)
- Add `useDocumentTitle` hook for per-page `<title>` tags (e.g. "Quick Start - PageAgent")
- Wire up dynamic titles in docs Layout (derived from active nav item) and home page