### PR TITLE
fix: reusable agent after stop

### DIFF
--- a/packages/core/src/PageAgentCore.ts
+++ b/packages/core/src/PageAgentCore.ts
@@ -187,9 +187,12 @@ export class PageAgentCore extends EventTarget {
 
 	/** Stop the current task. Agent remains reusable. */
 	stop() {
+		if (this.#abortController.signal.aborted) return // Already stopped
 		this.pageController.cleanUpHighlights()
 		this.pageController.hideMask()
 		this.#abortController.abort()
+		this.#setStatus('idle')
+		this.#abortController = new AbortController()
 	}
 
 	async execute(task: string): Promise<ExecutionResult> {
@@ -511,7 +514,8 @@ export class PageAgentCore extends EventTarget {
 		// Accumulated wait time warning
 		if (this.#states.totalWaitTime >= 3) {
 			this.pushObservation(
-				`You have waited ${this.#states.totalWaitTime} seconds accumulatively. DO NOT wait any longer unless you have a good reason.`
+				`You have waited ${this.#states.totalWaitTime} seconds accumulatively. ` +
+					`DO NOT wait any longer unless you have a good reason.`
 			)
 		}
 
@@ -527,7 +531,8 @@ export class PageAgentCore extends EventTarget {
 		const remaining = this.config.maxSteps - step
 		if (remaining === 5) {
 			this.pushObservation(
-				`⚠️ Only ${remaining} steps remaining. Consider wrapping up or calling done with partial results.`
+				`⚠️ Only ${remaining} steps remaining. ` +
+					`Consider wrapping up or calling done with partial results.`
 			)
 		} else if (remaining === 2) {
 			this.pushObservation(


### PR DESCRIPTION
Reset AbortController and status when stop() is called. Agent can now be reused for subsequent tasks.

Changes:
- Check if already stopped to prevent double-abort
- Reset status to 'idle'
- Create new AbortController for next task

## What

Brief description of changes.

## Type

- [ ] Bug fix
- [ ] Feature / Improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Website
- [ ] Demo / Testing
- [ ] Breaking change

## Testing

- [ ] Tested in modern browsers
- [ ] No console errors
- [ ] Types/doc added

Closes #(issue)

## Requirements / 要求

- [ ] I have read and follow the [Code of Conduct](../docs/CODE_OF_CONDUCT.md) and [Contributing Guide](../CONTRIBUTING.md) . / 我已阅读并遵守行为准则。
- [ ] This PR is NOT generated by a bot or AI agent acting autonomously. I have authored or meaningfully reviewed every change. / 此 PR 不是由 bot 或 AI 自主生成的，我已亲自编写或充分审查了每一处变更。
