### PR TITLE
feat: improve scroll performance

### DIFF
--- a/packages/core/src/PageAgentCore.ts
+++ b/packages/core/src/PageAgentCore.ts
@@ -511,7 +511,8 @@ export class PageAgentCore extends EventTarget {
 		// Accumulated wait time warning
 		if (this.#states.totalWaitTime >= 3) {
 			this.pushObservation(
-				`You have waited ${this.#states.totalWaitTime} seconds accumulatively. DO NOT wait any longer unless you have a good reason.`
+				`You have waited ${this.#states.totalWaitTime} seconds accumulatively. ` +
+					`DO NOT wait any longer unless you have a good reason.`
 			)
 		}
 
@@ -527,7 +528,8 @@ export class PageAgentCore extends EventTarget {
 		const remaining = this.config.maxSteps - step
 		if (remaining === 5) {
 			this.pushObservation(
-				`⚠️ Only ${remaining} steps remaining. Consider wrapping up or calling done with partial results.`
+				`⚠️ Only ${remaining} steps remaining. ` +
+					`Consider wrapping up or calling done with partial results.`
 			)
 		} else if (remaining === 2) {
 			this.pushObservation(

--- a/packages/page-controller/src/actions.ts
+++ b/packages/page-controller/src/actions.ts
@@ -10,6 +10,52 @@ async function waitFor(seconds: number): Promise<void> {
 	await new Promise((resolve) => setTimeout(resolve, seconds * 1000))
 }
 
+/**
+ * Find a scrollable container without scanning the entire DOM.
+ * Tries common selectors first, then falls back to viewport elements.
+ */
+function findScrollableContainer(
+	canScroll: (el: HTMLElement | null) => boolean
+): HTMLElement | undefined {
+	// Try common scrollable container selectors first (fast path)
+	const commonSelectors = [
+		'[data-scrollable="true"]',
+		'.scrollable',
+		'.overflow-auto',
+		'.overflow-scroll',
+		'[class*="scroll"]',
+		'main',
+		'article',
+		'section',
+		'aside',
+	]
+
+	for (const selector of commonSelectors) {
+		const containers = document.querySelectorAll<HTMLElement>(selector)
+		for (const container of containers) {
+			if (canScroll(container)) return container
+		}
+	}
+
+	// Fallback: check elements near viewport center (more likely to be visible)
+	const viewportElements = document.elementsFromPoint(
+		window.innerWidth / 2,
+		window.innerHeight / 2
+	) as HTMLElement[]
+
+	for (const el of viewportElements) {
+		if (canScroll(el)) return el
+		// Check ancestors up to 3 levels
+		let parent = el.parentElement
+		for (let i = 0; i < 3 && parent; i++) {
+			if (canScroll(parent)) return parent
+			parent = parent.parentElement
+		}
+	}
+
+	return undefined
+}
+
 // ======= dom utils =======
 
 export async function movePointerToElement(element: HTMLElement) {
@@ -299,7 +345,7 @@ export async function scrollVertically(
 
 	el = canScroll(el)
 		? el
-		: Array.from(document.querySelectorAll<HTMLElement>('*')).find(canScroll) ||
+		: findScrollableContainer(canScroll) ||
 			(document.scrollingElement as HTMLElement) ||
 			(document.documentElement as HTMLElement)
 
@@ -427,7 +473,7 @@ export async function scrollHorizontally(
 
 	el = canScroll(el)
 		? el
-		: Array.from(document.querySelectorAll<HTMLElement>('*')).find(canScroll) ||
+		: findScrollableContainer(canScroll) ||
 			(document.scrollingElement as HTMLElement) ||
 			(document.documentElement as HTMLElement)
 


### PR DESCRIPTION
Replace full DOM scans with targeted container lookup.

Changes:
- Add findScrollableContainer() helper
- Try common selectors first (fast path)
- Fallback to viewport-centered elements
- Avoids querySelectorAll('*') on large pages

## What

Brief description of changes.

## Type

- [ ] Bug fix
- [ ] Feature / Improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Website
- [ ] Demo / Testing
- [ ] Breaking change

## Testing

- [ ] Tested in modern browsers
- [ ] No console errors
- [ ] Types/doc added

Closes #(issue)

## Requirements / 要求

- [ ] I have read and follow the [Code of Conduct](../docs/CODE_OF_CONDUCT.md) and [Contributing Guide](../CONTRIBUTING.md) . / 我已阅读并遵守行为准则。
- [ ] This PR is NOT generated by a bot or AI agent acting autonomously. I have authored or meaningfully reviewed every change. / 此 PR 不是由 bot 或 AI 自主生成的，我已亲自编写或充分审查了每一处变更。
