### PR TITLE
feat(extension): render Markdown in Result cards

### DIFF
--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -43,7 +43,8 @@
         "@page-agent/page-controller": "1.5.9",
         "@page-agent/ui": "1.5.9",
         "ai-motion": "^0.4.8",
-        "chalk": "^5.6.2"
+        "chalk": "^5.6.2",
+        "react-markdown": "^9.0.0"
     },
     "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/packages/extension/src/components/cards.tsx
+++ b/packages/extension/src/components/cards.tsx
@@ -19,6 +19,7 @@ import {
 	Zap,
 } from 'lucide-react'
 import { Fragment, useState } from 'react'
+import ReactMarkdown from 'react-markdown'
 
 import { cn } from '@/lib/utils'
 
@@ -54,7 +55,77 @@ function ResultCard({
 					Result: {success ? 'Success' : 'Failed'}
 				</span>
 			</div>
-			<p className="text-xs text-[11px] text-muted-foreground pl-5 whitespace-pre-wrap">{text}</p>
+			<div className="text-xs text-[11px] text-muted-foreground pl-5">
+				<ReactMarkdown
+					components={{
+						// Style code blocks
+						code({ className, children, ...props }) {
+							return (
+								<code
+									className={cn(
+										'bg-muted px-1 py-0.5 rounded text-[10px]',
+										className
+									)}
+									{...props}
+								>
+									{children}
+								</code>
+							)
+						},
+						// Style paragraphs
+						p({ children, ...props }) {
+							return (
+								<p className="mb-2 last:mb-0" {...props}>
+									{children}
+								</p>
+							)
+						},
+						// Style headings
+						h1({ children, ...props }) {
+							return (
+								<h1 className="text-sm font-bold mb-2" {...props}>
+									{children}
+								</h1>
+							)
+						},
+						h2({ children, ...props }) {
+							return (
+								<h2 className="text-xs font-bold mb-1.5" {...props}>
+									{children}
+								</h2>
+							)
+						},
+						// Style lists
+						ul({ children, ...props }) {
+							return (
+								<ul className="list-disc pl-4 mb-2" {...props}>
+									{children}
+								</ul>
+							)
+						},
+						ol({ children, ...props }) {
+							return (
+								<ol className="list-decimal pl-4 mb-2" {...props}>
+									{children}
+								</ol>
+							)
+						},
+						// Style blockquotes
+						blockquote({ children, ...props }) {
+							return (
+								<blockquote
+									className="border-l-2 border-muted-foreground pl-2 italic text-muted-foreground mb-2"
+									{...props}
+								>
+									{children}
+								</blockquote>
+							)
+						},
+					}}
+				>
+					{text}
+				</ReactMarkdown>
+			</div>
 			{children}
 		</div>
 	)


### PR DESCRIPTION
## Summary
This PR adds Markdown rendering support to the Result cards in the page-agent extension, addressing feature request #287.

## Changes
- Add `react-markdown` dependency to `@page-agent/ext`
- Update `ResultCard` component to use `ReactMarkdown` for rendering result content
- Custom styling for code blocks, headings, lists, paragraphs, and blockquotes

## Before
Result content was displayed as raw text (Markdown source)

## After
Result content is now properly rendered with Markdown styling

Closes #287