### PR TITLE
feat: upgrade MiniMax default model to M2.7

### DIFF
--- a/packages/website/src/pages/docs/features/models/page.tsx
+++ b/packages/website/src/pages/docs/features/models/page.tsx
@@ -34,7 +34,7 @@ const MODEL_GROUPS: Record<string, string[]> = {
 		'claude-sonnet-3.5',
 	],
 	xAI: ['grok-4.1-fast', 'grok-4', 'grok-code-fast'],
-	MiniMax: ['MiniMax-M2.5', 'MiniMax-M2.5-highspeed'],
+	MiniMax: ['MiniMax-M2.7', 'MiniMax-M2.7-highspeed', 'MiniMax-M2.5', 'MiniMax-M2.5-highspeed'],
 	MoonshotAI: ['kimi-k2.5'],
 	'Z.AI': ['glm-5', 'glm-4.7'],
 }
@@ -126,7 +126,7 @@ const pageAgent = new PageAgent({
 const pageAgent = new PageAgent({
   baseURL: 'https://api.minimax.io/v1',
   apiKey: 'your-minimax-api-key',
-  model: 'MiniMax-M2.5'
+  model: 'MiniMax-M2.7'
 });
 
 // Self-hosted models (e.g., Ollama)


### PR DESCRIPTION
## Summary
- Add MiniMax-M2.7 and MiniMax-M2.7-highspeed to the tested model list
- Set MiniMax-M2.7 as the new default model in the code example
- Retain all previous MiniMax models (M2.5, M2.5-highspeed) as available alternatives

## Why
MiniMax-M2.7 is the latest flagship model with enhanced reasoning and coding capabilities, and should be the recommended default.

## Changes
- `packages/website/src/pages/docs/features/models/page.tsx`: Added M2.7 models to MODEL_GROUPS, updated code example

## Testing
- No logic changes; only model list and documentation updates
- Existing MiniMax temperature clamping in `utils.ts` already handles all MiniMax models generically
