### PR TITLE
fix(scroll): prefer last-interacted container in multi-scroll layouts

### DIFF
--- a/packages/core/src/tools/index.ts
+++ b/packages/core/src/tools/index.ts
@@ -131,7 +131,8 @@ tools.set(
 tools.set(
 	'scroll',
 	tool({
-		description: 'Scroll the page vertically. Use index for scroll elements (dropdowns/custom UI).',
+		description:
+		'Scroll the page or a specific container vertically. When the page has multiple independent scrollable panels (e.g. left list + right detail), pass the index of an element inside the target container so the correct panel is scrolled. Without index, the scroll targets the container that was last interacted with.',
 		inputSchema: z.object({
 			down: z.boolean().default(true),
 			num_pages: z.number().min(0).max(10).optional().default(0.1),

--- a/packages/page-controller/src/actions.ts
+++ b/packages/page-controller/src/actions.ts
@@ -46,7 +46,7 @@ export function getElementByIndex(
 	return element
 }
 
-let lastClickedElement: HTMLElement | null = null
+export let lastClickedElement: HTMLElement | null = null
 
 function blurLastClickedElement() {
 	if (lastClickedElement) {
@@ -298,16 +298,27 @@ export async function scrollVertically(
 		el.scrollHeight > el.clientHeight &&
 		bigEnough(el)
 
-	let el: HTMLElement | null = document.activeElement as HTMLElement | null
-	while (el && !canScroll(el) && el !== document.body) el = el.parentElement
+	// Prefer the scrollable ancestor of the last interacted element to avoid
+	// accidentally scrolling the wrong container in multi-scroll layouts (#303)
+	const findScrollableAncestor = (start: HTMLElement | null): HTMLElement | null => {
+		let cur = start
+		while (cur && cur !== document.body) {
+			if (canScroll(cur)) return cur
+			cur = cur.parentElement
+		}
+		return null
+	}
 
-	el = canScroll(el)
-		? el
-		: Array.from(document.querySelectorAll<HTMLElement>('*')).find(canScroll) ||
-			(document.scrollingElement as HTMLElement) ||
-			(document.documentElement as HTMLElement)
+	let el: HTMLElement | null =
+		findScrollableAncestor(lastClickedElement) ||
+		findScrollableAncestor(document.activeElement as HTMLElement | null) ||
+		Array.from(document.querySelectorAll<HTMLElement>('*')).find(canScroll) ||
+		null
 
-	if (el === document.scrollingElement || el === document.documentElement || el === document.body) {
+	const isPageLevel =
+		!el || el === document.scrollingElement || el === document.documentElement || el === document.body
+
+	if (isPageLevel) {
 		// Page-level scroll
 		const scrollBefore = window.scrollY
 		const scrollMax = document.documentElement.scrollHeight - window.innerHeight
@@ -331,29 +342,29 @@ export async function scrollVertically(
 		return `✅ Scrolled page by ${scrolled}px.`
 	} else {
 		// Container scroll
-		const scrollBefore = el!.scrollTop
-		const scrollMax = el!.scrollHeight - el!.clientHeight
+		const scrollBefore = el.scrollTop
+		const scrollMax = el.scrollHeight - el.clientHeight
 
-		el!.scrollBy({ top: dy, behavior: 'smooth' })
+		el.scrollBy({ top: dy, behavior: 'smooth' })
 		await waitFor(0.1)
 
-		const scrollAfter = el!.scrollTop
+		const scrollAfter = el.scrollTop
 		const scrolled = scrollAfter - scrollBefore
 
 		if (Math.abs(scrolled) < 1) {
 			return dy > 0
-				? `⚠️ Already at the bottom of container (${el!.tagName}), cannot scroll down further.`
-				: `⚠️ Already at the top of container (${el!.tagName}), cannot scroll up further.`
+				? `⚠️ Already at the bottom of container (${el.tagName}), cannot scroll down further.`
+				: `⚠️ Already at the top of container (${el.tagName}), cannot scroll up further.`
 		}
 
 		const reachedBottom = dy > 0 && scrollAfter >= scrollMax - 1
 		const reachedTop = dy < 0 && scrollAfter <= 1
 
 		if (reachedBottom)
-			return `✅ Scrolled container (${el!.tagName}) by ${scrolled}px. Reached the bottom.`
+			return `✅ Scrolled container (${el.tagName}) by ${scrolled}px. Reached the bottom.`
 		if (reachedTop)
-			return `✅ Scrolled container (${el!.tagName}) by ${scrolled}px. Reached the top.`
-		return `✅ Scrolled container (${el!.tagName}) by ${scrolled}px.`
+			return `✅ Scrolled container (${el.tagName}) by ${scrolled}px. Reached the top.`
+		return `✅ Scrolled container (${el.tagName}) by ${scrolled}px.`
 	}
 }
 


### PR DESCRIPTION

Fixes #303

## Problem
  When a page has multiple independent scrollable panels (e.g. left job list + right job detail), the scroll fallback used `document.activeElement` then a DOM-order `querySelectorAll().find()`, which would pick the wrong container — typically the first one in the DOM, not the intended one.

  ## Fix
  - `scrollVertically` now walks up from `lastClickedElement` first, then `document.activeElement`, before falling back to DOM-order search. This ensures scroll targets the panel the user most recently interacted with.
  - `lastClickedElement` is exported so the helper can reference it.
  - Improved `scroll` tool description to guide the LLM to pass `index` when targeting a specific panel in multi-scroll layouts.

  ## Changes
  - `packages/page-controller/src/actions.ts`
  - `packages/core/src/tools/index.ts`

