### PR TITLE
fix(page-agent): add separate UMD library entry without auto-init

### DIFF
--- a/packages/page-agent/package.json
+++ b/packages/page-agent/package.json
@@ -37,8 +37,9 @@
     },
     "homepage": "https://alibaba.github.io/page-agent/",
     "scripts": {
-        "build": "vite build && npm run build:demo",
+        "build": "vite build && npm run build:demo && npm run build:umd",
         "build:demo": "vite build --config vite.iife.config.js",
+        "build:umd": "vite build --config vite.umd.config.js",
         "dev:demo": "concurrently \"vite build --config vite.iife.config.js --watch\" \"npx serve dist/iife -p 5174\"",
         "prepublishOnly": "node -e \"const fs=require('fs');['README.md','LICENSE'].forEach(f=>fs.copyFileSync('../../'+f,f))\"",
         "postpublish": "node -e \"['README.md','LICENSE'].forEach(f=>{try{require('fs').unlinkSync(f)}catch{}})\""

--- a/packages/page-agent/src/page-agent.ts
+++ b/packages/page-agent/src/page-agent.ts
@@ -1,0 +1,10 @@
+/**
+ * Copyright (C) 2025 Alibaba Group Holding Limited
+ * All rights reserved.
+ */
+import { PageAgent } from './PageAgent'
+import type { PageAgentConfig } from './PageAgent'
+
+export { PageAgent, type PageAgentConfig }
+
+;(window as Window & typeof globalThis).PageAgent = PageAgent

--- a/packages/page-agent/vite.umd.config.js
+++ b/packages/page-agent/vite.umd.config.js
@@ -1,0 +1,41 @@
+// @ts-check
+import { dirname, resolve } from 'path'
+import { fileURLToPath } from 'url'
+import { defineConfig } from 'vite'
+import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+export default defineConfig(() => ({
+	plugins: [
+		cssInjectedByJsPlugin({ relativeCSSInjection: true }),
+	],
+	publicDir: false,
+	esbuild: {
+		keepNames: true,
+	},
+	resolve: {
+		alias: {
+			'@page-agent/page-controller': resolve(__dirname, '../page-controller/src/PageController.ts'),
+			'@page-agent/llms': resolve(__dirname, '../llms/src/index.ts'),
+			'@page-agent/core': resolve(__dirname, '../core/src/PageAgentCore.ts'),
+			'@page-agent/ui': resolve(__dirname, '../ui/src/index.ts'),
+		},
+	},
+	build: {
+		lib: {
+			entry: resolve(__dirname, 'src/page-agent.ts'),
+			name: 'PageAgent',
+			fileName: () => `page-agent.js`,
+			formats: ['iife'],
+		},
+		outDir: resolve(__dirname, 'dist', 'umd'),
+		cssCodeSplit: true,
+		rollupOptions: {
+			onwarn: function (message, handler) {
+				if (message.code === 'EVAL') return
+				handler(message)
+			},
+		},
+	},
+}))


### PR DESCRIPTION
## Context

Fixes #337 - UMD bundle auto-executes demo instead of exporting library.

Users loading `https://cdn.jsdelivr.net/npm/page-agent@latest/dist/umd/page-agent.js` expect a programmatic library, but the IIFE bundle was built from `demo.ts` which auto-initializes with demo credentials (`qwen3.5-plus`).

## Technical Decision

Added a separate entry point for the library UMD build:

- **`packages/page-agent/src/page-agent.ts`**: New entry that exports `PageAgent` class without auto-initialization
- **`packages/page-agent/vite.umd.config.js`**: Vite config to build library UMD to `dist/umd/page-agent.js`
- **`packages/page-agent/package.json`**: Updated build scripts to generate both bundles:
  - `dist/umd/page-agent.js` - Library (no auto-init)
  - `dist/iife/page-agent.demo.js` - Demo (with auto-init)

The approach follows existing patterns in the repo (same alias strategy as `vite.iife.config.js`).

## Verification

```bash
cd packages/page-agent
npm run build:umd    # Builds dist/umd/page-agent.js
npm run build:demo    # Builds dist/iife/page-agent.demo.js

# Verify library bundle has no demo code
grep "qwen3.5-plus" dist/umd/page-agent.js   # Returns nothing ✓
grep "qwen3.5-plus" dist/iife/page-agent.demo.js  # Returns result ✓
```

**Before**: Loading `page-agent.js` from CDN would auto-run demo with demo API
**After**: Loading `page-agent.js` from CDN exposes `window.PageAgent` class for programmatic use