### PR TITLE
ci: add GitHub Pages deploy pipeline and update docs URL

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,44 @@
+name: Deploy Pages
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build website
+        run: npm run build:website
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: packages/website/dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/packages/website/vite.config.js
+++ b/packages/website/vite.config.js
@@ -36,7 +36,7 @@ const SPA_ROUTES = [
 	'docs/advanced/security-permissions',
 ]
 
-const SITE_URL = 'https://alibaba.github.io/page-agent'
+const SITE_URL = 'https://cemdrk.github.io/page-agent'
 
 function spaRoutes() {
 	return {


### PR DESCRIPTION
- Add .github/workflows/deploy-pages.yml for manual GitHub Pages deployment to cemdrk.github.io/page-agent
- Update SITE_URL in packages/website/vite.config.js from alibaba.github.io to cemdrk.github.io
- Replace CDN quick-start section in README with GitHub Pages demo link
- Update all documentation links to point to cemdrk.github.io/page-agent

## What

Brief description of changes.

## Type

- [ ] Bug fix
- [ ] Feature / Improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Website
- [ ] Demo / Testing
- [ ] Breaking change

## Testing

- [ ] Tested in modern browsers
- [ ] No console errors
- [ ] Types/doc added

Closes #(issue)

## Requirements / 要求

- [ ] I have read and follow the [Code of Conduct](../docs/CODE_OF_CONDUCT.md) and [Contributing Guide](../CONTRIBUTING.md) . / 我已阅读并遵守行为准则。
- [ ] This PR is NOT generated by a bot or AI agent acting autonomously. I have authored or meaningfully reviewed every change. / 此 PR 不是由 bot 或 AI 自主生成的，我已亲自编写或充分审查了每一处变更。
