### PR TITLE
fix(dom): treat readonly inputs as interactive elements

### DIFF
--- a/packages/page-controller/src/dom/dom_tree/index.js
+++ b/packages/page-controller/src/dom/dom_tree/index.js
@@ -798,7 +798,7 @@ export default (
 		const explicitDisableTags = new Set([
 			'disabled', // Standard disabled attribute
 			// 'aria-disabled',      // ARIA disabled state
-			'readonly', // Read-only state
+			// 'readonly', // Read-only state
 			// 'aria-readonly',     // ARIA read-only state
 			// 'aria-hidden',       // Hidden from accessibility
 			// 'hidden',            // Hidden attribute
@@ -832,9 +832,9 @@ export default (
 			}
 
 			// Check for readonly property on form elements
-			if (element.readOnly) {
-				return false
-			}
+			// if (element.readOnly) {
+			// 	return false
+			// }
 
 			// Check for inert property
 			if (element.inert) {


### PR DESCRIPTION
## What

1.将 readonly 输入框识别为可交互元素，Element Plus 的日期区间选择器使用 readonly 属性阻止手动输入，但输入框仍可点击打开日历面板。当前代码将 readonly 等同于 disabled，导致 这类输入框对agent不可见。

2.对于issue的清空按钮问题没有修复，因为 agent 可以通过 input_text(index, "") 实现清空。

## Type

- [x] Bug fix
- [ ] Feature / Improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Website
- [ ] Demo / Testing
- [ ] Breaking change

## Testing

- [x] Tested in modern browsers
- [x] No console errors
- [ ] Types/doc added

Closes #346 

## Requirements / 要求

- [x] I have read and follow the [Code of Conduct](../docs/CODE_OF_CONDUCT.md) and [Contributing Guide](../CONTRIBUTING.md) . / 我已阅读并遵守行为准则。
- [x] This PR is NOT generated by a bot or AI agent acting autonomously. I have authored or meaningfully reviewed every change. / 此 PR 不是由 bot 或 AI 自主生成的，我已亲自编写或充分审查了每一处变更。
