### PR TITLE
feat(ext): add `systemInstruction` to ExecuteConfig

### DIFF
--- a/packages/extension/docs/extension_api.md
+++ b/packages/extension/docs/extension_api.md
@@ -118,6 +118,10 @@ export interface ExecuteConfig {
   model: string
   apiKey?: string
 
+  // Global system-level instructions for the agent.
+  // Equivalent to AgentConfig.instructions.system.
+  systemInstruction?: string
+
   // Include the initial tab where page JS starts. Default: true.
   includeInitialTab?: boolean
 
@@ -212,6 +216,9 @@ interface ExecuteConfig {
   baseURL: string
   model: string
   apiKey?: string
+
+  systemInstruction?: string
+
   includeInitialTab?: boolean
   experimentalIncludeAllTabs?: boolean
   onStatusChange?: (status: AgentStatus) => void

--- a/packages/extension/src/entrypoints/content.ts
+++ b/packages/extension/src/entrypoints/content.ts
@@ -70,11 +70,15 @@ async function exposeAgentToPage() {
 
 				try {
 					const { task, config } = payload
+					const { systemInstruction, ...agentConfig } = config
 
 					// Dispose old instance before creating new one
 					multiPageAgent?.dispose()
 
-					multiPageAgent = new MultiPageAgent(config)
+					multiPageAgent = new MultiPageAgent({
+						...agentConfig,
+						instructions: systemInstruction ? { system: systemInstruction } : undefined,
+					})
 
 					// events
 

--- a/packages/extension/src/entrypoints/main-world.ts
+++ b/packages/extension/src/entrypoints/main-world.ts
@@ -8,6 +8,12 @@ export interface ExecuteConfig {
 	apiKey?: string
 
 	/**
+	 * Global system-level instructions for the agent.
+	 * Equivalent to `AgentConfig.instructions.system`.
+	 */
+	systemInstruction?: string
+
+	/**
 	 * Whether to include the initial tab (that holds this main world script) in the task.
 	 * @default true
 	 */
@@ -89,6 +95,7 @@ export default defineUnlistedScript(() => {
 						baseURL: config.baseURL,
 						model: config.model,
 						apiKey: config.apiKey,
+						systemInstruction: config.systemInstruction,
 						includeInitialTab: config.includeInitialTab,
 						experimentalIncludeAllTabs: config.experimentalIncludeAllTabs,
 					},

--- a/packages/website/src/pages/docs/features/chrome-extension/page.tsx
+++ b/packages/website/src/pages/docs/features/chrome-extension/page.tsx
@@ -199,6 +199,7 @@ interface ExecuteConfig {
 	model: string     // Model name
 	apiKey?: string   // LLM AK
 
+	systemInstruction?: string // Global system-level instructions
 	includeInitialTab?: boolean
 	experimentalIncludeAllTabs?: boolean // Control all unpinned tabs in the window
 	onStatusChange?: (status: AgentStatus) => void


### PR DESCRIPTION
## What

Add a `systemInstruction` string field to the page-facing `ExecuteConfig` API, equivalent to `AgentConfig.instructions.system`. Functions cannot be serialized across the `postMessage` boundary, so this flat string field is the serializable alternative.

## Type

- [ ] Bug fix
- [x] Feature / Improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Website
- [ ] Demo / Testing
- [ ] Breaking change

## Testing

- [ ] Tested in modern browsers
- [x] No console errors
- [x] Types/doc added

Closes #359

## Requirements / 要求

- [x] I have read and follow the [Code of Conduct](../docs/CODE_OF_CONDUCT.md) and [Contributing Guide](../CONTRIBUTING.md) . / 我已阅读并遵守行为准则。
- [x] This PR is NOT generated by a bot or AI agent acting autonomously. I have authored or meaningfully reviewed every change. / 此 PR 不是由 bot 或 AI 自主生成的，我已亲自编写或充分审查了每一处变更。