### PR TITLE
fix: add loop detection to prevent agent from repeating identical actions

### DIFF
--- a/packages/core/src/PageAgentCore.ts
+++ b/packages/core/src/PageAgentCore.ts
@@ -505,7 +505,6 @@ export class PageAgentCore extends EventTarget {
 
 	/**
 	 * Generate system observations before each step
-	 * @todo loop detection
 	 * @todo console error
 	 */
 	async #handleObservations(step: number): Promise<void> {
@@ -515,6 +514,24 @@ export class PageAgentCore extends EventTarget {
 				`You have waited ${this.#states.totalWaitTime} seconds accumulatively. ` +
 					`DO NOT wait any longer unless you have a good reason.`
 			)
+		}
+
+		// Loop detection: warn if the same action has been repeated consecutively
+		const LOOP_DETECTION_WINDOW = 4
+		const stepHistory = this.history.filter((e): e is AgentStepEvent => e.type === 'step')
+		if (stepHistory.length >= LOOP_DETECTION_WINDOW) {
+			const recentSteps = stepHistory.slice(-LOOP_DETECTION_WINDOW)
+			const actionKeys = recentSteps.map(
+				(e) => `${e.action.name}:${JSON.stringify(e.action.input)}`
+			)
+			if (actionKeys.every((key) => key === actionKeys[0])) {
+				const { name } = recentSteps[0].action
+				this.pushObservation(
+					`⚠️ Loop detected: "${name}" has been called ${LOOP_DETECTION_WINDOW} times in a row ` +
+						`with identical input. This approach is not working. ` +
+						`Try a completely different strategy to achieve your goal.`
+				)
+			}
 		}
 
 		// Detect URL change


### PR DESCRIPTION
Fixes #112

## Problem

The agent can get stuck in an infinite loop, repeatedly calling the same action with the same input (e.g., clicking the same button or entering the same text 4+ times in a row) without making progress. There was already a `@todo loop detection` comment in `#handleObservations` acknowledging this.

## Solution

Added loop detection logic in `PageAgentCore.#handleObservations()`. After each step, the agent checks the last 4 consecutive history entries. If all 4 share the identical action name and input, a system observation is pushed into the agent's history:

```
⚠️ Loop detected: "click_element_by_index" has been called 4 times in a row with identical input. This approach is not working. Try a completely different strategy to achieve your goal.
```

This warning is included in the next LLM invocation as part of `<agent_history>`, prompting the model to reconsider its approach.

## Testing

- Loop is triggered only after 4 consecutive identical actions (not 2–3, which may be intentional retries).
- Detection uses `JSON.stringify(action.input)` for deep equality on the action payload.
- Works for all tool types (`click_element_by_index`, `input_text`, `scroll_down`, etc.).
- Non-looping repeated scrolls (e.g., scroll 3 times to read content) are not falsely flagged.