### PR TITLE
fix: add maxSiblingElements to prevent HTTP 413 with large dropdowns

### DIFF
--- a/packages/page-controller/src/PageController.ts
+++ b/packages/page-controller/src/PageController.ts
@@ -196,7 +196,8 @@ export class PageController extends EventTarget {
 		this.simplifiedHTML = dom.flatTreeToString(
 			this.flatTree,
 			this.config.includeAttributes,
-			this.config.keepSemanticTags
+			this.config.keepSemanticTags,
+			this.config.maxSiblingElements
 		)
 
 		this.selectorMap.clear()

--- a/packages/page-controller/src/dom/index.ts
+++ b/packages/page-controller/src/dom/index.ts
@@ -34,6 +34,15 @@ export interface DomConfig {
 	 * @note maybe confusing for LLM combining with page scrolling, use with caution
 	 **/
 	keepSemanticTags?: boolean
+
+	/**
+	 * Maximum number of same-tag siblings to include per parent node.
+	 * Useful to prevent HTTP 413 Payload Too Large errors when dropdowns
+	 * with many options are open (e.g., a country selector with 200 entries).
+	 * Truncated items are replaced with a summary line.
+	 * @default undefined (no limit)
+	 */
+	maxSiblingElements?: number
 }
 
 // TODO: corresponding roles
@@ -193,7 +202,8 @@ interface TreeNode {
 export function flatTreeToString(
 	flatTree: FlatDomTree,
 	includeAttributes: string[] = [],
-	keepSemanticTags = false
+	keepSemanticTags = false,
+	maxSiblingElements?: number
 ): string {
 	const DEFAULT_INCLUDE_ATTRIBUTES = [
 		'title',
@@ -428,8 +438,30 @@ export function flatTreeToString(
 				nextDepth += 1
 			}
 
-			for (const child of node.children) {
-				processNode(child, nextDepth, result)
+			if (maxSiblingElements !== undefined && node.children.length > maxSiblingElements) {
+				// Count per-tag occurrences to truncate large groups of same-tag siblings
+				const tagCount = new Map<string, number>()
+				const skipped = new Map<string, number>()
+				for (const child of node.children) {
+					const tag =
+						child.type === 'element' ? (child.tagName ?? '__text__') : '__text__'
+					const count = tagCount.get(tag) ?? 0
+					if (count >= maxSiblingElements) {
+						skipped.set(tag, (skipped.get(tag) ?? 0) + 1)
+						continue
+					}
+					tagCount.set(tag, count + 1)
+					processNode(child, nextDepth, result)
+				}
+				for (const [tag, count] of skipped) {
+					result.push(
+						`${'\t'.repeat(nextDepth)}... ${count} more <${tag}> items not shown (maxSiblingElements=${maxSiblingElements})`
+					)
+				}
+			} else {
+				for (const child of node.children) {
+					processNode(child, nextDepth, result)
+				}
 			}
 
 			if (emitSemantic) {


### PR DESCRIPTION
Fixes #348

## Problem

When a dropdown with many options is open (e.g. a country selector with 200+ entries), all visible option elements get indexed as interactive elements and included in the dehydrated HTML sent to the LLM. This causes the LLM API to return HTTP 413: Payload Too Large.

The maintainer confirmed this in the issue comments: *"听起来所有的 options 都被放在了清洗后的数据里"* (it sounds like all options are being put into the cleaned data).

## Solution

Add a `maxSiblingElements` option to `DomConfig` (and consequently `PageControllerConfig`). When set, the `flatTreeToString` function limits how many same-tag children are rendered per parent node. Excess items are replaced with a single summary line, e.g.:

```
... 150 more <li> items not shown (maxSiblingElements=50)
```

This tells the LLM there are more options available, so it can scroll or search the dropdown instead of expecting all items upfront.

The option is `undefined` by default (no limit), preserving full backward compatibility.

## Usage

```ts
const controller = new PageController({
  maxSiblingElements: 50,  // show at most 50 same-tag siblings per parent
})
```

## Testing

- Option is `undefined` by default: existing behavior is unchanged
- When set, verifiable by logging `simplifiedHTML` on a page with a large dropdown open and confirming the output is truncated with a descriptive summary line
- No existing tests broken (feature is additive)