### PR TITLE
fix(ui): unblock ask_user promise when Stop is clicked (fixes #183)

### DIFF
--- a/packages/ui/src/panel/Panel.ts
+++ b/packages/ui/src/panel/Panel.ts
@@ -42,6 +42,7 @@ export class Panel {
 	#isExpanded = false
 	#i18n: I18n
 	#userAnswerResolver: ((input: string) => void) | null = null
+	#userAnswerRejecter: ((error: Error) => void) | null = null
 	#isWaitingForUserAnswer: boolean = false
 	#headerUpdateTimer: ReturnType<typeof setInterval> | null = null
 	#pendingHeaderText: string | null = null
@@ -172,10 +173,11 @@ export class Panel {
 	 * Ask for user input (internal, called by agent via onAskUser)
 	 */
 	#askUser(question: string): Promise<string> {
-		return new Promise((resolve) => {
+		return new Promise((resolve, reject) => {
 			// Set `waiting for user answer` state
 			this.#isWaitingForUserAnswer = true
 			this.#userAnswerResolver = resolve
+			this.#userAnswerRejecter = reject
 
 			// Expand history panel
 			if (!this.#isExpanded) {
@@ -221,6 +223,7 @@ export class Panel {
 		// Reset user input state
 		this.#isWaitingForUserAnswer = false
 		this.#userAnswerResolver = null
+		this.#userAnswerRejecter = null
 		// Show input area
 		this.#showInputArea()
 	}
@@ -243,8 +246,12 @@ export class Panel {
 		this.#agent.removeEventListener('activity', this.#onActivity)
 		this.#agent.removeEventListener('dispose', this.#onAgentDispose)
 
+		// Cancel any pending user-answer promise to prevent memory leaks.
+		// Listeners are already removed above, so status-change events from the
+		// resulting abort will not cause any further UI updates.
+		this.#cancelUserAnswer()
+
 		// Clean up UI
-		this.#isWaitingForUserAnswer = false
 		this.#stopHeaderUpdateLoop()
 		this.wrapper.remove()
 	}
@@ -278,6 +285,12 @@ export class Panel {
 	 */
 	#handleActionButton(): void {
 		if (this.#agent.status === 'running') {
+			// Unblock any pending ask_user promise before stopping,
+			// otherwise the agent's execute() loop stays stuck and the panel
+			// never transitions to a closeable state.
+			if (this.#isWaitingForUserAnswer) {
+				this.#cancelUserAnswer()
+			}
 			this.#agent.stop()
 		} else {
 			this.#agent.dispose()
@@ -321,7 +334,34 @@ export class Panel {
 		if (this.#userAnswerResolver) {
 			this.#userAnswerResolver(input)
 			this.#userAnswerResolver = null
+			this.#userAnswerRejecter = null
 		}
+	}
+
+	/**
+	 * Cancel a pending user-answer prompt (e.g. when the user clicks Stop).
+	 *
+	 * Rejects the Promise returned by #askUser with an AbortError-shaped error so
+	 * that the LLM layer treats it the same as a user-initiated abort (no retries,
+	 * error message = "Task stopped").
+	 */
+	#cancelUserAnswer(): void {
+		if (this.#userAnswerRejecter) {
+			const abortError = new Error('Task stopped by user')
+			abortError.name = 'AbortError'
+			this.#userAnswerRejecter(abortError)
+		}
+
+		// Remove temporary question cards
+		Array.from(this.#historySection.children).forEach((child) => {
+			if (child.getAttribute('data-temp-card') === 'true') {
+				child.remove()
+			}
+		})
+
+		this.#isWaitingForUserAnswer = false
+		this.#userAnswerResolver = null
+		this.#userAnswerRejecter = null
 	}
 
 	/**


### PR DESCRIPTION
Fixes #183

## Problem

When the agent invokes the `ask_user` tool and the user clicks **Stop** before typing an answer, the panel becomes permanently stuck:

1. `Panel.#askUser()` returns a `Promise` and stores only its `resolve` callback.
2. The LLM layer (`OpenAIClient`) `await`s `tool.execute()`, which in turn `await`s `onAskUser()` — **without** passing the abort signal to that inner await.
3. Clicking Stop calls `agent.stop()` → `abortController.abort()`, which cancels the outgoing HTTP request but has no effect on an already-running tool execution.
4. As a result, `execute()` stays blocked at `await tool.execute()` with `status = 'running'` forever.
5. The action button never morphs from ■ (stop) to X (close), so the user cannot close the panel.

## Solution

Introduce `#cancelUserAnswer()` which rejects the pending `#askUser` promise with an **AbortError-shaped error** (`error.name = 'AbortError'`).

The LLM retry layer already checks `rawError.name === 'AbortError'` to skip retries for user aborts, so the error propagates immediately to `execute()`'s catch block → `#onDone(false)` → `status = 'error'`. The panel button then becomes X, allowing the user to close it.

Changes in `packages/ui/src/panel/Panel.ts`:
- Add `#userAnswerRejecter` field alongside the existing `#userAnswerResolver`.
- Capture `reject` in `#askUser()`.
- Add `#cancelUserAnswer()` — rejects the promise, clears state, and removes temporary question cards from the history panel.
- Call `#cancelUserAnswer()` in `#handleActionButton()` before `agent.stop()` when `#isWaitingForUserAnswer` is true.
- Call `#cancelUserAnswer()` in `dispose()` (after removing event listeners) to prevent memory leaks if the agent is disposed while waiting for user input.
- Clear `#userAnswerRejecter` in `reset()` and `#handleUserAnswer()`.

## Testing

1. Start a task that triggers the `ask_user` tool (e.g. configure the agent so the LLM asks a clarifying question).
2. When the question prompt appears in the panel, click **■ (Stop)** without typing anything.
3. **Before fix:** the button stays ■ and the panel cannot be closed.
4. **After fix:** the button changes to **X** and clicking it closes the panel cleanly.