### PR TITLE
fix(ui): Panel.hide() CSS 淡出动画因 display:none 而不可见

### DIFF
--- a/packages/ui/src/panel/Panel.ts
+++ b/packages/ui/src/panel/Panel.ts
@@ -210,7 +210,13 @@ export class Panel {
 	hide(): void {
 		this.wrapper.style.opacity = '0'
 		this.wrapper.style.transform = 'translateX(-50%) translateY(20px)'
-		this.wrapper.style.display = 'none'
+		this.wrapper.addEventListener(
+			'transitionend',
+			() => {
+				this.wrapper.style.display = 'none'
+			},
+			{ once: true }
+		)
 	}
 
 	reset(): void {


### PR DESCRIPTION
## What

修复 Agent 控制面板 Panel.hide() 中 display: none 与 CSS 过渡动画同步执行，导致淡出/滑出效果对用户完全不可见的问题。

## Type

- [x] Bug fix

## 问题描述

Panel.hide() 设置了三个 inline style：
1. opacity: 0 — 期望触发 0.3s 淡出动画
2. 	ransform: translateY(20px) — 期望触发 0.3s 滑出动画
3. display: none — 立即从布局中移除元素

但浏览器在同一帧内应用所有三个变更。由于 display: none 会立即移除元素，用户看不到 opacity 和 transform 的过渡动画，面板直接消失。

## 修复方案

将 display: none 延迟到 	ransitionend 事件回调中执行。浏览器会在 CSS transition 结束后自动触发该事件，不需要硬编码等待时间。

关键点：
- 	ransitionend 在 CSS transition 结束后触发（wrapper CSS 定义了 	ransition: all 0.3s ease-in-out）
- { once: true } 使监听器触发后自动移除，不需要手动清理
- 不依赖任何硬编码的时间值，自动适配 CSS transition 时长

## Testing

- [x] Tested in modern browsers
- [x] No console errors

## Requirements / 要求

- [x] 我已阅读并遵守行为准则和贡献指南
- [x] 此 PR 非 bot 或 AI 自主生成，我已亲自编写并充分审查了每一处变更

---

@gaomeng1900 麻烦 review 一下，感谢！
