### PR TITLE
fix(core): correct autoFixer wait fallback action format

### DIFF
--- a/packages/core/src/utils/autoFixer.ts
+++ b/packages/core/src/utils/autoFixer.ts
@@ -93,7 +93,7 @@ export function normalizeResponse(response: any, tools?: Map<string, PageAgentTo
 	// fix incomplete formats
 	if (!resolvedArguments.action) {
 		log(`#5: fixing tool_call`)
-		resolvedArguments.action = { name: 'wait', input: { seconds: 1 } }
+		resolvedArguments.action = { wait: { seconds: 1 } }
 	}
 
 	// pack back to standard format


### PR DESCRIPTION
## What

Fix incorrect action format in autoFixer's missing-action fallback. The old format `{ name: 'wait', input: { seconds: 1 } }` does not match the expected `{ toolName: toolInput }` structure used by the macro tool, causing Zod schema validation to fail silently.

## Type

- [ ] Breaking change
- [x] Bug fix
- [ ] Feature / Improvement
- [ ] Refactor / Chores
- [ ] Documentation / Website / Demo / Testing

## Testing

- [x] Tested in modern browsers
- [x] No console errors
- [ ] Types/doc added

## Requirements / 要求

- [x] I have read and follow the [Code of Conduct](../docs/CODE_OF_CONDUCT.md) and [Contributing Guide](../CONTRIBUTING.md) . / 我已阅读并遵守行为准则。
- [x] This PR is NOT generated by a bot or AI agent acting autonomously. I have authored or meaningfully reviewed every change. / 此 PR 不是由 bot 或 AI 自主生成的，我已亲自编写或充分审查了每一处变更。