### PR TITLE
fix(page-agent): wrap demo bundle helpers in local scope

### DIFF
--- a/packages/page-agent/vite.iife.config.js
+++ b/packages/page-agent/vite.iife.config.js
@@ -18,6 +18,16 @@ dotenvConfig({ path: resolve(__dirname, '../../.env'), quiet: true })
 export default defineConfig(() => ({
 	plugins: [
 		cssInjectedByJsPlugin({ relativeCSSInjection: true }),
+		{
+			name: 'wrap-demo-bundle-scope',
+			generateBundle(_options, bundle) {
+				for (const chunk of Object.values(bundle)) {
+					if (chunk.type === 'chunk' && chunk.fileName.endsWith('.js')) {
+						chunk.code = `(() => {\n${chunk.code}\n})()\n`
+					}
+				}
+			},
+		},
 		// analyzer()
 	],
 	publicDir: false,
@@ -43,10 +53,6 @@ export default defineConfig(() => ({
 		cssCodeSplit: true,
 		// minify: false,
 		rollupOptions: {
-			// output: {
-			// 	// force use .js as extension
-			// 	entryFileNames: 'page-agent.js',
-			// },
 			onwarn: function (message, handler) {
 				if (message.code === 'EVAL') return
 				handler(message)


### PR DESCRIPTION
## Summary
- wrap the generated `page-agent.demo.js` chunk in an extra function scope during bundling
- keep Vite/esbuild helper variables out of the global scope on repeated script injection
- preserve the existing runtime behavior while avoiding redeclaration collisions in reinjected pages

## Why
Issue #426 reports `"St has already been declared"` after re-injecting the built script on some pages.

I traced this to helper variables emitted before the current IIFE prelude, for example:

```js
var St = Object.defineProperty
...
(function(){ ... })()
```

Those top-level helpers can leak into the page realm and collide when the same bundle is injected again. Wrapping the final emitted chunk gives the whole bundle, including helper prelude code, its own local scope.

## Validation
- `npm install --ignore-scripts`
- `npm run build:demo`
- verified the built file now starts with `(() => {`
- parsed the built bundle twice in the same VM script without redeclaration errors
