### PR TITLE
fix: isolate demo bundle for bookmarklet/script injection

### DIFF
--- a/packages/page-agent/package.json
+++ b/packages/page-agent/package.json
@@ -38,7 +38,7 @@
     "homepage": "https://alibaba.github.io/page-agent/",
     "scripts": {
         "build": "vite build && npm run build:demo",
-        "build:demo": "vite build --config vite.iife.config.js",
+        "build:demo": "vite build --config vite.iife.config.js && node scripts/verify-iife-bundle.mjs",
         "dev:demo": "concurrently \"vite build --config vite.iife.config.js --watch\" \"npx serve dist/iife -p 5174\"",
         "prepublishOnly": "node -e \"const fs=require('fs');['README.md','LICENSE'].forEach(f=>fs.copyFileSync('../../'+f,f))\"",
         "postpublish": "node -e \"['README.md','LICENSE'].forEach(f=>{try{require('fs').unlinkSync(f)}catch{}})\""

--- a/packages/page-agent/scripts/verify-iife-bundle.mjs
+++ b/packages/page-agent/scripts/verify-iife-bundle.mjs
@@ -1,0 +1,16 @@
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url))
+const bundlePath = resolve(__dirname, '../dist/iife/page-agent.demo.js')
+const code = readFileSync(bundlePath, 'utf8').trimStart()
+
+if (!code.startsWith('(function(){')) {
+	console.error(
+		'Expected IIFE demo bundle to be wrapped in an isolated closure for bookmarklet injection safety.'
+	)
+	process.exit(1)
+}
+
+console.log('IIFE demo bundle is isolated.')

--- a/packages/page-agent/vite.iife.config.js
+++ b/packages/page-agent/vite.iife.config.js
@@ -1,5 +1,6 @@
 // @ts-check
 import { config as dotenvConfig } from 'dotenv'
+import { readFileSync, writeFileSync } from 'fs'
 import { dirname, resolve } from 'path'
 import { fileURLToPath } from 'url'
 import { defineConfig } from 'vite'
@@ -7,6 +8,19 @@ import { defineConfig } from 'vite'
 import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
+const IIFE_BUNDLE_PATH = resolve(__dirname, 'dist', 'iife', 'page-agent.demo.js')
+
+function isolateBookmarkletBundle() {
+	return {
+		name: 'isolate-bookmarklet-bundle',
+		apply: 'build',
+		closeBundle() {
+			const code = readFileSync(IIFE_BUNDLE_PATH, 'utf8')
+			const wrappedCode = `(function(){\n${code}\n})();\n`
+			writeFileSync(IIFE_BUNDLE_PATH, wrappedCode)
+		},
+	}
+}
 
 // Load .env from repo root
 dotenvConfig({ path: resolve(__dirname, '../../.env'), quiet: true })
@@ -18,6 +32,7 @@ dotenvConfig({ path: resolve(__dirname, '../../.env'), quiet: true })
 export default defineConfig(() => ({
 	plugins: [
 		cssInjectedByJsPlugin({ relativeCSSInjection: true }),
+		isolateBookmarkletBundle(),
 		// analyzer()
 	],
 	publicDir: false,


### PR DESCRIPTION
## Summary
- wrap the generated `page-agent.demo.js` output in a final closure so injected bookmarklet usage does not leak helper identifiers like `St` into the page global scope
- add a small build verification script so future demo bundle builds fail if the output stops being isolated

## Testing
- npm run build:demo --workspace=page-agent

Fixes #426
