### PR TITLE
fix: isolate demo bundle globals for injected demo script

### DIFF
--- a/packages/page-agent/package.json
+++ b/packages/page-agent/package.json
@@ -48,7 +48,8 @@
     "homepage": "https://alibaba.github.io/page-agent/",
     "scripts": {
         "build": "vite build && npm run build:demo",
-        "build:demo": "vite build --config vite.iife.config.js",
+        "build:demo": "vite build --config vite.iife.config.js && node scripts/wrap-demo-bundle.js",
+        "test:demo-bundle": "node scripts/assert-demo-bundle.js",
         "dev:demo": "concurrently \"vite build --config vite.iife.config.js --watch\" \"npx serve dist/iife -p 5174\"",
         "prepublishOnly": "node ../../scripts/pre-publish.js",
         "postpublish": "node ../../scripts/post-publish.js"

--- a/packages/page-agent/scripts/assert-demo-bundle.js
+++ b/packages/page-agent/scripts/assert-demo-bundle.js
@@ -1,0 +1,24 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const bundlePath = resolve(process.cwd(), 'dist/iife/page-agent.demo.js')
+const bundle = readFileSync(bundlePath, 'utf8').trimStart()
+
+const wrapperPrefix = bundle.startsWith('(function() {')
+	? '(function() {'
+	: bundle.startsWith('(function(){')
+		? '(function(){'
+		: null
+
+if (!wrapperPrefix) {
+	console.error('Expected demo bundle to be wrapped in an outer IIFE.')
+	process.exit(1)
+}
+
+const firstInnerLine = bundle.slice(wrapperPrefix.length).trimStart().split('\n', 1)[0]?.trim()
+if (!firstInnerLine?.startsWith('var St=') && !firstInnerLine?.startsWith('(function()')) {
+	console.error('Expected bundle helpers to stay inside the outer IIFE wrapper.')
+	process.exit(1)
+}
+
+console.log('Demo bundle wrapper looks correct.')

--- a/packages/page-agent/scripts/wrap-demo-bundle.js
+++ b/packages/page-agent/scripts/wrap-demo-bundle.js
@@ -1,0 +1,14 @@
+import { readFileSync, writeFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const bundlePath = resolve(process.cwd(), 'dist/iife/page-agent.demo.js')
+const bundle = readFileSync(bundlePath, 'utf8')
+const trimmed = bundle.trimStart()
+
+if (trimmed.startsWith('(function(){') || trimmed.startsWith('(function() {')) {
+	console.log('Demo bundle is already wrapped.')
+	process.exit(0)
+}
+
+writeFileSync(bundlePath, `(function() {\n${bundle}\n})();\n`)
+console.log('Wrapped demo bundle in an outer IIFE.')


### PR DESCRIPTION
## Summary
- wrap the built demo bundle in an outer IIFE after Vite emits it
- add a regression check that verifies the wrapper is present
- keep the fix in the demo build pipeline so injected CDN/bookmarklet usage does not leak helper symbols globally

## Testing
- npm run build:demo
- npm run test:demo-bundle

## Context
Fixes the injected demo script regression reported in #426, where helper symbols from the generated bundle could collide with page-level bindings and trigger errors like `Identifier 'St' has already been declared`.