### PR TITLE
fix: add prefers-color-scheme media query to dark mode detection

### DIFF
--- a/packages/page-controller/src/mask/checkDarkMode.ts
+++ b/packages/page-controller/src/mask/checkDarkMode.ts
@@ -88,8 +88,16 @@ function isBackgroundDark() {
 }
 
 /**
+ * Checks the prefers-color-scheme media query for dark mode.
+ * @returns {boolean} - True if the system prefers a dark color scheme.
+ */
+function prefersDarkColorScheme() {
+	return window.matchMedia?.('(prefers-color-scheme: dark)').matches ?? false
+}
+
+/**
  * A comprehensive function to determine if the page is currently in a dark theme.
- * It combines class checking and background color analysis.
+ * It combines class checking, system preference, and background color analysis.
  * @returns {boolean} - True if the page is likely dark.
  */
 export function isPageDark() {
@@ -99,13 +107,15 @@ export function isPageDark() {
 			return true
 		}
 
-		// Strategy 2: Analyze the computed background color
-		if (isBackgroundDark()) {
+		// Strategy 2: Check system-level prefers-color-scheme
+		if (prefersDarkColorScheme()) {
 			return true
 		}
 
-		// @TODO add more checks here, e.g., analyzing text color,
-		// or checking the background of major layout elements like <main> or #app.
+		// Strategy 3: Analyze the computed background color
+		if (isBackgroundDark()) {
+			return true
+		}
 
 		return false
 	} catch (error) {


### PR DESCRIPTION
## Summary

Addresses the existing `@TODO` comment in `isPageDark()` by adding support for the `prefers-color-scheme: dark` CSS media query as a new detection strategy.

## What Changed

- Added a new `prefersDarkColorScheme()` helper that checks `window.matchMedia('(prefers-color-scheme: dark)')`
- Integrated it as Strategy 2 in the `isPageDark()` pipeline (between class-based detection and background color analysis)
- Uses optional chaining (`window.matchMedia?.()`) for safe fallback in environments where the API is unavailable

## Why

Many modern websites rely on the OS-level dark mode preference without setting dark mode CSS classes or data attributes on `<html>`/\<body>. This change ensures `isPageDark()` correctly identifies such pages, which is important for rendering appropriate UI (e.g., mask/highlight overlays) in the Page Agent.

## Risk

- Minimal: `window.matchMedia` is guarded with optional chaining and falls back to `false`
- Pre-existing typecheck errors in `antd.ts` and `react.ts` are unrelated to this change