### PR TITLE
feat: add a standard CDN bundle without demo auto-start

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,26 @@ Fastest way to try PageAgent with our free Demo LLM:
 
 > **⚠️ For technical evaluation only.** This demo CDN uses our free [testing LLM API](https://alibaba.github.io/page-agent/docs/features/models#free-testing-api). By using it, you agree to its [terms](https://github.com/alibaba/page-agent/blob/main/docs/terms-and-privacy.md).
 
-| Mirrors | URL                                                                                |
-| ------- | ---------------------------------------------------------------------------------- |
-| Global  | https://cdn.jsdelivr.net/npm/page-agent@1.7.1/dist/iife/page-agent.demo.js         |
-| China   | https://registry.npmmirror.com/page-agent/1.7.1/files/dist/iife/page-agent.demo.js |
+| Bundle | Use case | Global | China |
+| ------ | -------- | ------ | ----- |
+| Demo bundle (`page-agent.demo.js`) | Auto-mounts the panel and uses the built-in demo API for quick evaluation | https://cdn.jsdelivr.net/npm/page-agent@1.7.1/dist/iife/page-agent.demo.js | https://registry.npmmirror.com/page-agent/1.7.1/files/dist/iife/page-agent.demo.js |
+| Standard bundle (`page-agent.js`) | Exposes `window.PageAgent` without auto-running a demo instance | https://cdn.jsdelivr.net/npm/page-agent@1.7.1/dist/iife/page-agent.js | https://registry.npmmirror.com/page-agent/1.7.1/files/dist/iife/page-agent.js |
+
+Example with the standard CDN bundle:
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/page-agent@1.7.1/dist/iife/page-agent.js" crossorigin="true"></script>
+<script>
+  const agent = new window.PageAgent({
+    model: 'qwen3.5-plus',
+    baseURL: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+    apiKey: 'YOUR_API_KEY',
+    language: 'en-US',
+  })
+
+  agent.panel.show()
+</script>
+```
 
 ### NPM Installation
 

--- a/docs/README-zh.md
+++ b/docs/README-zh.md
@@ -47,10 +47,26 @@
 
 > **⚠️ 仅用于技术评估。** 该 Demo CDN 使用了免费的[测试 LLM API](https://alibaba.github.io/page-agent/docs/features/models#free-testing-api)，使用即表示您同意其[条款](https://github.com/alibaba/page-agent/blob/main/docs/terms-and-privacy.md)。
 
-| Mirrors | URL                                                                                |
-| ------- | ---------------------------------------------------------------------------------- |
-| Global  | https://cdn.jsdelivr.net/npm/page-agent@1.7.1/dist/iife/page-agent.demo.js         |
-| China   | https://registry.npmmirror.com/page-agent/1.7.1/files/dist/iife/page-agent.demo.js |
+| Bundle | 用途 | Global | China |
+| ------ | ---- | ------ | ----- |
+| Demo bundle (`page-agent.demo.js`) | 自动挂载面板，并使用内置 Demo API，适合快速体验 | https://cdn.jsdelivr.net/npm/page-agent@1.7.1/dist/iife/page-agent.demo.js | https://registry.npmmirror.com/page-agent/1.7.1/files/dist/iife/page-agent.demo.js |
+| Standard bundle (`page-agent.js`) | 只暴露 `window.PageAgent`，不会自动运行 Demo 实例 | https://cdn.jsdelivr.net/npm/page-agent@1.7.1/dist/iife/page-agent.js | https://registry.npmmirror.com/page-agent/1.7.1/files/dist/iife/page-agent.js |
+
+标准 CDN bundle 示例：
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/page-agent@1.7.1/dist/iife/page-agent.js" crossorigin="true"></script>
+<script>
+  const agent = new window.PageAgent({
+    model: 'qwen3.5-plus',
+    baseURL: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+    apiKey: 'YOUR_API_KEY',
+    language: 'zh-CN',
+  })
+
+  agent.panel.show()
+</script>
+```
 
 ### NPM 安装
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -94,11 +94,15 @@ npm run zip -w @page-agent/ext
 
 ### Testing on Other Websites
 
-- Start and serve a local `iife` script
+- Start and serve local `iife` scripts
 
     ```bash
-    npm run dev:demo # Serving IIFE with auto rebuild at http://localhost:5174/page-agent.demo.js
+    npm run dev:demo # Serving IIFE bundles with auto rebuild at http://localhost:5174/
     ```
+
+    This produces both:
+    - `http://localhost:5174/page-agent.demo.js` for the auto-start demo bundle
+    - `http://localhost:5174/page-agent.js` for the standard CDN bundle that only exposes `window.PageAgent`
 
 - Add a new bookmark
 

--- a/packages/page-agent/package.json
+++ b/packages/page-agent/package.json
@@ -48,8 +48,8 @@
     "homepage": "https://alibaba.github.io/page-agent/",
     "scripts": {
         "build": "vite build && npm run build:demo",
-        "build:demo": "vite build --config vite.iife.config.js",
-        "dev:demo": "concurrently \"vite build --config vite.iife.config.js --watch\" \"npx serve dist/iife -p 5174\"",
+        "build:demo": "rm -rf dist/iife && vite build --config vite.iife.config.js && vite build --config vite.iife.demo.config.js",
+        "dev:demo": "concurrently \"vite build --config vite.iife.config.js --watch\" \"vite build --config vite.iife.demo.config.js --watch\" \"npx serve dist/iife -p 5174\"",
         "prepublishOnly": "node ../../scripts/pre-publish.js",
         "postpublish": "node ../../scripts/post-publish.js"
     },

--- a/packages/page-agent/src/cdn.ts
+++ b/packages/page-agent/src/cdn.ts
@@ -1,0 +1,12 @@
+/**
+ * IIFE CDN entry - exposes PageAgent without auto-initializing a demo instance.
+ */
+import { PageAgent } from './PageAgent'
+
+window.PageAgent = PageAgent
+
+console.log(
+	'🚀 page-agent.js loaded! Create an agent with `new window.PageAgent(config)` to get started.'
+)
+
+export { PageAgent }

--- a/packages/page-agent/vite.iife.demo.config.js
+++ b/packages/page-agent/vite.iife.demo.config.js
@@ -19,9 +19,9 @@ export default defineConfig({
 	build: {
 		emptyOutDir: false,
 		lib: {
-			entry: resolve(__dirname, 'src/cdn.ts'),
+			entry: resolve(__dirname, 'src/demo.ts'),
 			name: 'PageAgent',
-			fileName: () => 'page-agent.js',
+			fileName: () => 'page-agent.demo.js',
 			formats: ['iife'],
 		},
 		outDir: resolve(__dirname, 'dist', 'iife'),


### PR DESCRIPTION
## Summary
- add a standard CDN IIFE bundle that exposes `window.PageAgent` without auto-starting a demo instance
- keep the existing demo bundle as a separate build output for quick evaluation
- document both CDN entry points in the English and Chinese READMEs and developer guide

## Testing
- npm run build:demo -w page-agent

Closes #433