### PR TITLE
feat(extension): add get_status request to hub WS protocol

### DIFF
--- a/packages/extension/src/entrypoints/hub/hub-ws.ts
+++ b/packages/extension/src/entrypoints/hub/hub-ws.ts
@@ -7,16 +7,21 @@
  * Inbound (Caller → Hub):
  *   { type: "execute", task: string, config?: object }
  *   { type: "stop" }
+ *   { type: "get_status" }   // query whether a task is currently running
  *
  * Outbound (Hub → Caller):
  *   { type: "ready" }
  *   { type: "result", success: boolean, data: string }
  *   { type: "error", message: string }
- *   { type: "heartbeat", at: number }   // periodic, only while a task is running
+ *   { type: "status", busy: boolean }   // reply to `get_status`
  *
- * Heartbeats let the caller distinguish a long-running task from a dead hub
- * (e.g. throttled tab, blocked main thread) without relying on a fixed
- * wall-clock timeout. Callers that don't care may safely ignore this type.
+ * `get_status` lets a caller confirm the hub's own view of whether a task is
+ * still in flight — useful to detect state drift (e.g. the `result` message
+ * was lost while both sides believe the task is still running). This is an
+ * application-level check: WS-level liveness is already guaranteed by the
+ * protocol's ping/pong frames, which browsers auto-respond to, so callers
+ * should rely on those for dead-connection detection and use `get_status`
+ * only when in doubt.
  */
 import type { ExecutionResult } from '@page-agent/core'
 import { useEffect, useRef, useState } from 'react'
@@ -35,7 +40,11 @@ interface StopMessage {
 	type: 'stop'
 }
 
-type InboundMessage = ExecuteMessage | StopMessage
+interface GetStatusMessage {
+	type: 'get_status'
+}
+
+type InboundMessage = ExecuteMessage | StopMessage | GetStatusMessage
 
 interface ReadyMessage {
 	type: 'ready'
@@ -52,16 +61,14 @@ interface ErrorMessage {
 	message: string
 }
 
-interface HeartbeatMessage {
-	type: 'heartbeat'
-	at: number
+interface StatusMessage {
+	type: 'status'
+	busy: boolean
 }
 
-type OutboundMessage = ReadyMessage | ResultMessage | ErrorMessage | HeartbeatMessage
+type OutboundMessage = ReadyMessage | ResultMessage | ErrorMessage | StatusMessage
 
 export type HubWsState = 'connecting' | 'connected' | 'disconnected'
-
-const HEARTBEAT_INTERVAL_MS = 5000
 
 // --- HubWs class ---
 
@@ -165,6 +172,9 @@ export class HubWs {
 			case 'stop':
 				this.#handlers.onStop()
 				break
+			case 'get_status':
+				this.#send({ type: 'status', busy: this.#busy })
+				break
 		}
 	}
 
@@ -191,16 +201,12 @@ export class HubWs {
 		}
 
 		this.#busy = true
-		const heartbeat = setInterval(() => {
-			this.#send({ type: 'heartbeat', at: Date.now() })
-		}, HEARTBEAT_INTERVAL_MS)
 		try {
 			const result = await this.#handlers.onExecute(msg.task, msg.config)
 			this.#send({ type: 'result', success: result.success, data: result.data })
 		} catch (err) {
 			this.#send({ type: 'error', message: err instanceof Error ? err.message : String(err) })
 		} finally {
-			clearInterval(heartbeat)
 			this.#busy = false
 		}
 	}

--- a/packages/extension/src/entrypoints/hub/hub-ws.ts
+++ b/packages/extension/src/entrypoints/hub/hub-ws.ts
@@ -12,6 +12,11 @@
  *   { type: "ready" }
  *   { type: "result", success: boolean, data: string }
  *   { type: "error", message: string }
+ *   { type: "heartbeat", at: number }   // periodic, only while a task is running
+ *
+ * Heartbeats let the caller distinguish a long-running task from a dead hub
+ * (e.g. throttled tab, blocked main thread) without relying on a fixed
+ * wall-clock timeout. Callers that don't care may safely ignore this type.
  */
 import type { ExecutionResult } from '@page-agent/core'
 import { useEffect, useRef, useState } from 'react'
@@ -47,9 +52,16 @@ interface ErrorMessage {
 	message: string
 }
 
-type OutboundMessage = ReadyMessage | ResultMessage | ErrorMessage
+interface HeartbeatMessage {
+	type: 'heartbeat'
+	at: number
+}
+
+type OutboundMessage = ReadyMessage | ResultMessage | ErrorMessage | HeartbeatMessage
 
 export type HubWsState = 'connecting' | 'connected' | 'disconnected'
+
+const HEARTBEAT_INTERVAL_MS = 5000
 
 // --- HubWs class ---
 
@@ -179,12 +191,16 @@ export class HubWs {
 		}
 
 		this.#busy = true
+		const heartbeat = setInterval(() => {
+			this.#send({ type: 'heartbeat', at: Date.now() })
+		}, HEARTBEAT_INTERVAL_MS)
 		try {
 			const result = await this.#handlers.onExecute(msg.task, msg.config)
 			this.#send({ type: 'result', success: result.success, data: result.data })
 		} catch (err) {
 			this.#send({ type: 'error', message: err instanceof Error ? err.message : String(err) })
 		} finally {
+			clearInterval(heartbeat)
 			this.#busy = false
 		}
 	}


### PR DESCRIPTION
> Updated per maintainer feedback. Original heartbeat-push proposal is preserved as commit 1; commit 2 pivots to a `get_status` request/response design. The discussion thread tracks the rationale.

## Motivation

The hub-WS protocol currently has no way for a caller to confirm the hub's view of "is a task still running". A caller can be stuck waiting for `result` while the hub already considers itself idle (e.g. the `result` message was lost, or local state on the caller drifted). There is no protocol affordance to verify.

## Recommended caller layering (from JSDoc)

| Layer | Purpose | Mechanism | Cost |
|------|--------|-----------|------|
| 1 | Dead-connection detection (frozen tab, closed window, blocked main thread) | WS-level `ws.ping()` — browsers auto-respond at protocol layer | zero protocol changes; works today |
| 2 | Application-level state-drift check | `get_status` (this PR) — sent **on demand**, not periodically | one round-trip when the caller is in doubt |

Layer 1 already works for any caller — the WS server can call `ws.ping()` and rely on the browser's automatic pong. So **this PR only adds layer 2**, and only the bits the protocol needs.

## Protocol additions

```ts
Inbound:  { type: "get_status" }
Outbound: { type: "status", busy: boolean }
```

`busy` reflects the hub's `#busy` flag — true while a task is in flight, false otherwise.

## Compatibility

Purely additive. Existing callers (e.g. `packages/mcp/src/hub-bridge.js`) silently ignore unknown message types and are unaffected.

## Commit history

1. `feat(extension): emit periodic heartbeat from hub while task is running` — initial heartbeat-push proposal
2. `refactor(extension): replace heartbeat push with get_status request` — pivot to pull-based per discussion below

## Test plan

- [x] `npm run typecheck` passes
- [x] `npx eslint` clean
- [ ] Manual: send `{type:'get_status'}` while hub idle → receive `{type:'status', busy:false}`
- [ ] Manual: send `{type:'get_status'}` mid-task → receive `{type:'status', busy:true}`