### PR TITLE
feat(extension): expose tab group control via hub WS protocol

### DIFF
--- a/packages/extension/src/agent/MultiPageAgent.ts
+++ b/packages/extension/src/agent/MultiPageAgent.ts
@@ -22,6 +22,13 @@ interface MultiPageAgentConfig extends AgentConfig {
  * - can be used from a side panel or a content script
  */
 export class MultiPageAgent extends PageAgentCore {
+	private readonly tabsController: TabsController
+
+	/** Id of the tab group created for the current task, or null if none yet. */
+	get tabGroupId(): number | null {
+		return this.tabsController.activeTabGroupId
+	}
+
 	constructor(config: MultiPageAgentConfig) {
 		// multi page controller
 		const tabsController = new TabsController()
@@ -98,5 +105,7 @@ export class MultiPageAgent extends PageAgentCore {
 				tabsController.dispose()
 			},
 		})
+
+		this.tabsController = tabsController
 	}
 }

--- a/packages/extension/src/agent/TabsController.ts
+++ b/packages/extension/src/agent/TabsController.ts
@@ -34,6 +34,11 @@ export class TabsController {
 	private experimentalIncludeAllTabs = false
 	private task: string = ''
 
+	/** Id of the tab group created for the current task, or null if none yet. */
+	get activeTabGroupId(): number | null {
+		return this.tabGroupId
+	}
+
 	async init(task: string, options: TabsInitOptions = {}) {
 		const { includeInitialTab = true, experimentalIncludeAllTabs = false } = options
 		debug('init', task, options)

--- a/packages/extension/src/agent/useAgent.ts
+++ b/packages/extension/src/agent/useAgent.ts
@@ -38,6 +38,8 @@ export interface UseAgentResult {
 	execute: (task: string) => Promise<ExecutionResult>
 	stop: () => void
 	configure: (config: ExtConfig) => Promise<void>
+	/** Id of the tab group created for the current task, or null if none yet. */
+	getTabGroupId: () => number | null
 }
 
 export function useAgent(): UseAgentResult {
@@ -120,6 +122,8 @@ export function useAgent(): UseAgentResult {
 		agentRef.current?.stop()
 	}, [])
 
+	const getTabGroupId = useCallback(() => agentRef.current?.tabGroupId ?? null, [])
+
 	const configure = useCallback(
 		async ({
 			language,
@@ -158,5 +162,6 @@ export function useAgent(): UseAgentResult {
 		execute,
 		stop,
 		configure,
+		getTabGroupId,
 	}
 }

--- a/packages/extension/src/entrypoints/hub/App.tsx
+++ b/packages/extension/src/entrypoints/hub/App.tsx
@@ -10,8 +10,18 @@ import { Switch } from '@/components/ui/switch'
 import { useHubWs } from './hub-ws'
 
 export default function App() {
-	const { status, history, activity, currentTask, config, execute, stop, configure } = useAgent()
-	const { wsState } = useHubWs(execute, stop, configure, config)
+	const {
+		status,
+		history,
+		activity,
+		currentTask,
+		config,
+		execute,
+		stop,
+		configure,
+		getTabGroupId,
+	} = useAgent()
+	const { wsState } = useHubWs(execute, stop, configure, config, getTabGroupId)
 
 	const historyRef = useRef<HTMLDivElement>(null)
 

--- a/packages/extension/src/entrypoints/hub/hub-ws.ts
+++ b/packages/extension/src/entrypoints/hub/hub-ws.ts
@@ -7,11 +7,29 @@
  * Inbound (Caller → Hub):
  *   { type: "execute", task: string, config?: object }
  *   { type: "stop" }
+ *   { type: "tab_group",
+ *       groupId: number,
+ *       action: "close" | "ungroup" | "collapse" | "expand" }
+ *     // Operate on a tab group (typically the one returned in a prior `result`).
+ *     // "close"    - close every tab in the group (group disappears)
+ *     // "ungroup"  - detach tabs from the group, keep them open
+ *     // "collapse" - collapse the group
+ *     // "expand"   - expand the group
+ *     // Fire-and-forget: the hub applies the action best-effort and does not
+ *     // respond. Failures are logged on the hub side only.
  *
  * Outbound (Hub → Caller):
  *   { type: "ready" }
- *   { type: "result", success: boolean, data: string }
+ *   { type: "result",
+ *       success: boolean,
+ *       data: string,
+ *       tabGroupId?: number }   // id of the tab group created for this task, if any
  *   { type: "error", message: string }
+ *
+ * Policy is intentionally left to the caller: the hub never cleans up tab
+ * groups on its own. Callers that care about cleanup read `tabGroupId` from
+ * `result` and send a `tab_group` action based on their own policy
+ * (e.g. close on success, keep on failure).
  */
 import type { ExecutionResult } from '@page-agent/core'
 import { useEffect, useRef, useState } from 'react'
@@ -30,7 +48,15 @@ interface StopMessage {
 	type: 'stop'
 }
 
-type InboundMessage = ExecuteMessage | StopMessage
+export type TabGroupAction = 'close' | 'ungroup' | 'collapse' | 'expand'
+
+interface TabGroupMessage {
+	type: 'tab_group'
+	groupId: number
+	action: TabGroupAction
+}
+
+type InboundMessage = ExecuteMessage | StopMessage | TabGroupMessage
 
 interface ReadyMessage {
 	type: 'ready'
@@ -40,6 +66,7 @@ interface ResultMessage {
 	type: 'result'
 	success: boolean
 	data: string
+	tabGroupId?: number
 }
 
 interface ErrorMessage {
@@ -57,8 +84,9 @@ export interface HubWsHandlers {
 	onExecute: (
 		task: string,
 		config?: Record<string, unknown>
-	) => Promise<{ success: boolean; data: string }>
+	) => Promise<{ success: boolean; data: string; tabGroupId?: number }>
 	onStop: () => void
+	onTabGroupAction: (groupId: number, action: TabGroupAction) => Promise<void>
 }
 
 /**
@@ -153,6 +181,13 @@ export class HubWs {
 			case 'stop':
 				this.#handlers.onStop()
 				break
+			case 'tab_group':
+				// Fire-and-forget. Surface failures in the hub console but do not
+				// emit `error` (reserved for task-scoped errors).
+				this.#handlers.onTabGroupAction(msg.groupId, msg.action).catch((err) => {
+					console.error('[HubWs] tab_group action failed', msg, err)
+				})
+				break
 		}
 	}
 
@@ -181,12 +216,42 @@ export class HubWs {
 		this.#busy = true
 		try {
 			const result = await this.#handlers.onExecute(msg.task, msg.config)
-			this.#send({ type: 'result', success: result.success, data: result.data })
+			this.#send({
+				type: 'result',
+				success: result.success,
+				data: result.data,
+				tabGroupId: result.tabGroupId,
+			})
 		} catch (err) {
 			this.#send({ type: 'error', message: err instanceof Error ? err.message : String(err) })
 		} finally {
 			this.#busy = false
 		}
+	}
+}
+
+// --- Tab group actions (hub page has direct chrome API access) ---
+
+async function applyTabGroupAction(groupId: number, action: TabGroupAction): Promise<void> {
+	switch (action) {
+		case 'close': {
+			const tabs = await chrome.tabs.query({ groupId })
+			const ids = tabs.map((t) => t.id).filter((id): id is number => id != null)
+			if (ids.length) await chrome.tabs.remove(ids)
+			return
+		}
+		case 'ungroup': {
+			const tabs = await chrome.tabs.query({ groupId })
+			const ids = tabs.map((t) => t.id).filter((id): id is number => id != null)
+			if (ids.length) await chrome.tabs.ungroup(ids as [number, ...number[]])
+			return
+		}
+		case 'collapse':
+			await chrome.tabGroups.update(groupId, { collapsed: true })
+			return
+		case 'expand':
+			await chrome.tabGroups.update(groupId, { collapsed: false })
+			return
 	}
 }
 
@@ -200,15 +265,16 @@ export function useHubWs(
 	execute: (task: string) => Promise<ExecutionResult>,
 	stop: () => void,
 	configure: (config: ExtConfig) => Promise<void>,
-	config: ExtConfig | null
+	config: ExtConfig | null,
+	getTabGroupId: () => number | null
 ): { wsState: HubWsState } {
 	const wsPort = new URLSearchParams(location.search).get('ws')
 	const [wsState, setWsState] = useState<HubWsState>(() => (wsPort ? 'connecting' : 'disconnected'))
 	const hubWsRef = useRef<HubWs | null>(null)
 
-	const latestRef = useRef({ execute, stop, configure, config })
+	const latestRef = useRef({ execute, stop, configure, config, getTabGroupId })
 	useEffect(() => {
-		latestRef.current = { execute, stop, configure, config }
+		latestRef.current = { execute, stop, configure, config, getTabGroupId }
 	})
 
 	useEffect(() => {
@@ -218,14 +284,19 @@ export function useHubWs(
 			Number(wsPort),
 			{
 				onExecute: async (task, incomingConfig) => {
-					const { execute, configure, config } = latestRef.current
+					const { execute, configure, config, getTabGroupId } = latestRef.current
 					if (incomingConfig) {
 						await configure({ ...config, ...incomingConfig } as ExtConfig)
 					}
 					const result = await execute(task)
-					return { success: result.success, data: result.data }
+					return {
+						success: result.success,
+						data: result.data,
+						tabGroupId: getTabGroupId() ?? undefined,
+					}
 				},
 				onStop: () => latestRef.current.stop(),
+				onTabGroupAction: applyTabGroupAction,
 			},
 			setWsState
 		)


### PR DESCRIPTION
## Motivation

Every call to the hub's `execute` creates a new tab group named `PageAgent(${task})` with a random color. The hub never cleans these up on its own, so callers that drive many tasks in a row end up with a long list of visually-identical groups and:

- no way to tell which group is the one currently running, and
- no way to free them afterwards (tab group APIs are not reachable from outside the extension — not via AppleScript, not via CDP for external callers).

Instead of baking a specific cleanup / visibility policy into the extension (auto-collapse? auto-ungroup? keep forever?), this PR exposes the underlying mechanism over the existing hub WS protocol and lets **callers decide policy**.

## Protocol additions

### Outbound: `result` carries `tabGroupId`

```ts
{ type: "result", success: boolean, data: string, tabGroupId?: number }
```

`tabGroupId` is the id of the tab group created for the task that just finished, or `undefined` if no group was created (e.g. `includeInitialTab: false` with no new tabs opened).

### Inbound: new `tab_group` action

```ts
{ type: "tab_group", groupId: number,
  action: "close" | "ungroup" | "collapse" | "expand" }
```

- `close` — close every tab in the group (the empty group disappears)
- `ungroup` — detach tabs from the group, keep them open
- `collapse` / `expand` — change visual collapsed state

Fire-and-forget: the hub applies the action best-effort and does not reply. Failures are logged on the hub side only; `error` stays reserved for task-scoped errors.

### Compatibility

Purely additive. Callers that don't read `tabGroupId` or send `tab_group` see zero behavior change. The reference caller `packages/mcp/src/hub-bridge.js` ignores unknown message types and doesn't break.

## Example (caller policy)

```ts
// close on success, collapse on failure so you can inspect it later
ws.on('message', (raw) => {
  const msg = JSON.parse(raw)
  if (msg.type !== 'result' || msg.tabGroupId == null) return
  ws.send(JSON.stringify({
    type: 'tab_group',
    groupId: msg.tabGroupId,
    action: msg.success ? 'close' : 'collapse',
  }))
})
```

## Implementation notes

- `TabsController` exposes `activeTabGroupId`; `MultiPageAgent` and `useAgent` forward it up so `useHubWs` can read it without peeking into agent internals.
- `applyTabGroupAction` uses `chrome.tabs` / `chrome.tabGroups` directly from the hub extension page — `tabGroups` permission already exists in `wxt.config.js`.
- Previously private field `tabGroupId` on `TabsController` stays private; a read-only getter `activeTabGroupId` is added so no internal code paths change.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npx eslint` clean on all touched files
- [ ] Manual: run a task, observe `result.tabGroupId` is present
- [ ] Manual: send each of `close` / `ungroup` / `collapse` / `expand` and verify the corresponding Chrome behavior
- [ ] Manual: old caller (only branches on `result` / `error`) still works unchanged