### PR TITLE
docs: fix documentation typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ const agent = new PageAgent({
 await agent.execute('Click the login button')
 ```
 
-For more programmatic usage, see [📖 Documentations](https://alibaba.github.io/page-agent/docs/introduction/overview).
+For more programmatic usage, see [📖 Documentation](https://alibaba.github.io/page-agent/docs/introduction/overview).
 
 ## 🌟 Awesome Page Agent
 


### PR DESCRIPTION
## Summary
- fix the README description link text for the documentation reference to match the actual url preview

## Testing
- none