### PR TITLE
fix(ui): allow closing panel immediately after stop

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -242,7 +242,7 @@ PageAgent is now ready for production use. The API is stable and breaking change
 
 - Single-page application only (cannot navigate across pages)
 - No visual recognition (relies on DOM structure)
-- Limited interaction support (no hover, drag-drop, canvas operations)
+- Limited interaction support (no drag-drop, canvas operations)
 - See [Limitations](https://alibaba.github.io/page-agent/docs/introduction/limitations) for details
 
 ### Acknowledgments

--- a/packages/core/src/tools/index.ts
+++ b/packages/core/src/tools/index.ts
@@ -95,6 +95,21 @@ tools.set(
 )
 
 tools.set(
+	'hover_element_by_index',
+	tool({
+		description:
+			'Hover over an element by index to reveal menus, tooltips, previews, or other hover-triggered UI before the next action.',
+		inputSchema: z.object({
+			index: z.int().min(0),
+		}),
+		execute: async function (this: PageAgentCore, input) {
+			const result = await this.pageController.hoverElement(input.index)
+			return result.message
+		},
+	})
+)
+
+tools.set(
 	'input_text',
 	tool({
 		description: 'Click and type text into an interactive input element',

--- a/packages/extension/src/agent/RemotePageController.content.ts
+++ b/packages/extension/src/agent/RemotePageController.content.ts
@@ -77,6 +77,7 @@ export function initPageController() {
 			case 'update_tree':
 			case 'clean_up_highlights':
 			case 'click_element':
+			case 'hover_element':
 			case 'input_text':
 			case 'select_option':
 			case 'scroll':
@@ -118,6 +119,8 @@ function getMethodName(action: string): string {
 
 		case 'click_element':
 			return 'clickElement' as const
+		case 'hover_element':
+			return 'hoverElement' as const
 		case 'input_text':
 			return 'inputText' as const
 		case 'select_option':

--- a/packages/extension/src/agent/RemotePageController.ts
+++ b/packages/extension/src/agent/RemotePageController.ts
@@ -117,6 +117,10 @@ export class RemotePageController {
 		return res
 	}
 
+	async hoverElement(...args: any[]): Promise<DomActionReturn> {
+		return this.remoteCallDomAction('hover_element', args)
+	}
+
 	async inputText(...args: any[]): Promise<DomActionReturn> {
 		return this.remoteCallDomAction('input_text', args)
 	}

--- a/packages/extension/src/components/cards.tsx
+++ b/packages/extension/src/components/cards.tsx
@@ -116,6 +116,7 @@ function ReflectionSection({
 function ActionIcon({ name, className }: { name: string; className?: string }) {
 	const icons: Record<string, React.ReactNode> = {
 		click_element_by_index: <Mouse className={className} />,
+		hover_element_by_index: <Mouse className={className} />,
 		input: <Keyboard className={className} />,
 		scroll: <MoveVertical className={className} />,
 		go_to_url: <Globe className={className} />,

--- a/packages/page-controller/src/PageController.ts
+++ b/packages/page-controller/src/PageController.ts
@@ -9,6 +9,7 @@
 import {
 	clickElement,
 	getElementByIndex,
+	hoverElement,
 	inputTextElement,
 	scrollHorizontally,
 	scrollVertically,
@@ -264,6 +265,28 @@ export class PageController extends EventTarget {
 			return {
 				success: false,
 				message: `❌ Failed to click element: ${error}`,
+			}
+		}
+	}
+
+	/**
+	 * Hover element by index
+	 */
+	async hoverElement(index: number): Promise<ActionResult> {
+		try {
+			this.assertIndexed()
+			const element = getElementByIndex(this.selectorMap, index)
+			const elemText = this.elementTextMap.get(index)
+			await hoverElement(element)
+
+			return {
+				success: true,
+				message: `✅ Hovered element (${elemText ?? index}).`,
+			}
+		} catch (error) {
+			return {
+				success: false,
+				message: `❌ Failed to hover element: ${error}`,
 			}
 		}
 	}

--- a/packages/page-controller/src/actions.ts
+++ b/packages/page-controller/src/actions.ts
@@ -126,6 +126,52 @@ export async function clickElement(element: HTMLElement) {
 }
 
 /**
+ * Simulate a hover without clicking.
+ * Fires the standard pointerover/enter + mouseover/enter sequence so
+ * hover-driven UI like tooltips, menus, and previews can appear.
+ *
+ * @private Internal method, subject to change at any time.
+ */
+export async function hoverElement(element: HTMLElement) {
+	blurLastClickedElement()
+
+	lastClickedElement = element
+
+	await scrollIntoViewIfNeeded(element)
+	const frame = element.ownerDocument.defaultView?.frameElement
+	if (frame) await scrollIntoViewIfNeeded(frame)
+
+	const rect = element.getBoundingClientRect()
+	const x = rect.left + rect.width / 2
+	const y = rect.top + rect.height / 2
+
+	await movePointerToElement(element, x, y)
+
+	const doc = element.ownerDocument
+	await enablePassThrough()
+	const hitTarget = doc.elementFromPoint(x, y)
+	await disablePassThrough()
+	const target =
+		hitTarget instanceof HTMLElement && element.contains(hitTarget) ? hitTarget : element
+
+	const pointerOpts = {
+		bubbles: true,
+		cancelable: true,
+		clientX: x,
+		clientY: y,
+		pointerType: 'mouse',
+	}
+	const mouseOpts = { bubbles: true, cancelable: true, clientX: x, clientY: y, button: 0 }
+
+	target.dispatchEvent(new PointerEvent('pointerover', pointerOpts))
+	target.dispatchEvent(new PointerEvent('pointerenter', { ...pointerOpts, bubbles: false }))
+	target.dispatchEvent(new MouseEvent('mouseover', mouseOpts))
+	target.dispatchEvent(new MouseEvent('mouseenter', { ...mouseOpts, bubbles: false }))
+
+	await waitFor(0.2)
+}
+
+/**
  * @private Internal method, subject to change at any time.
  */
 export async function inputTextElement(element: HTMLElement, text: string) {

--- a/packages/ui/src/i18n/locales.ts
+++ b/packages/ui/src/i18n/locales.ts
@@ -19,6 +19,7 @@ const enUS = {
 		},
 		tools: {
 			clicking: 'Clicking element [{{index}}]...',
+			hovering: 'Hovering element [{{index}}]...',
 			inputting: 'Inputting text to element [{{index}}]...',
 			selecting: 'Selecting option "{{text}}"...',
 			scrolling: 'Scrolling page...',
@@ -67,6 +68,7 @@ const zhCN = {
 		},
 		tools: {
 			clicking: '正在点击元素 [{{index}}]...',
+			hovering: '正在悬停元素 [{{index}}]...',
 			inputting: '正在输入文本到元素 [{{index}}]...',
 			selecting: '正在选择选项 "{{text}}"...',
 			scrolling: '正在滚动页面...',

--- a/packages/ui/src/panel/Panel.ts
+++ b/packages/ui/src/panel/Panel.ts
@@ -46,6 +46,7 @@ export class Panel {
 	#headerUpdateTimer: ReturnType<typeof setInterval> | null = null
 	#pendingHeaderText: string | null = null
 	#isAnimating = false
+	#isStopping = false
 
 	// Event handlers (bound for removal)
 	#onStatusChange = () => this.#handleStatusChange()
@@ -99,6 +100,7 @@ export class Panel {
 	/** Handle agent status change */
 	#handleStatusChange(): void {
 		const status = this.#agent.status
+		this.#isStopping = false
 
 		// Map agent status to UI indicator type
 		const indicatorType =
@@ -218,6 +220,7 @@ export class Panel {
 		this.#updateStatusIndicator('thinking')
 		this.#renderHistory()
 		this.#collapse()
+		this.#isStopping = false
 		// Reset user input state
 		this.#isWaitingForUserAnswer = false
 		this.#userAnswerResolver = null
@@ -279,11 +282,16 @@ export class Panel {
 	 * Action button handler: stop when running, close (dispose) when idle
 	 */
 	#handleActionButton(): void {
-		if (this.#agent.status === 'running') {
+		if (this.#agent.status === 'running' && !this.#isStopping) {
+			this.#isStopping = true
+			this.#actionButton.textContent = 'X'
+			this.#actionButton.title = this.#i18n.t('ui.panel.close')
+			this.#pendingHeaderText = this.#i18n.t('ui.panel.close')
 			this.#agent.stop()
-		} else {
-			this.#agent.dispose()
+			return
 		}
+
+		this.#agent.dispose()
 	}
 
 	/**

--- a/packages/ui/src/panel/Panel.ts
+++ b/packages/ui/src/panel/Panel.ts
@@ -256,6 +256,8 @@ export class Panel {
 		switch (toolName) {
 			case 'click_element_by_index':
 				return this.#i18n.t('ui.tools.clicking', { index: a.index })
+			case 'hover_element_by_index':
+				return this.#i18n.t('ui.tools.hovering', { index: a.index })
 			case 'input_text':
 				return this.#i18n.t('ui.tools.inputting', { index: a.index })
 			case 'select_dropdown_option':

--- a/packages/website/src/pages/docs/introduction/limitations/page.tsx
+++ b/packages/website/src/pages/docs/introduction/limitations/page.tsx
@@ -94,7 +94,7 @@ export default function LimitationsPage() {
 							</h3>
 							<ul className="space-y-1.5 text-sm">
 								{[
-									isZh ? '点击、文本输入、选择' : 'Click, text input, select',
+									isZh ? '点击、悬停、文本输入、选择' : 'Click, hover, text input, select',
 									isZh ? '页面滚动（垂直 / 水平）' : 'Scroll (vertical / horizontal)',
 									isZh ? '表单提交、焦点切换' : 'Form submit, focus',
 									isZh ? '同源 iframe（仅单层）' : 'Same-origin iframe (single level only)',
@@ -113,7 +113,7 @@ export default function LimitationsPage() {
 							</h3>
 							<ul className="space-y-1.5 text-sm">
 								{[
-									isZh ? '悬停、拖拽、右键菜单' : 'Hover, drag & drop, right-click',
+									isZh ? '拖拽、右键菜单' : 'Drag & drop, right-click',
 									isZh ? '键盘快捷键' : 'Keyboard shortcuts',
 									isZh ? '坐标定位操作' : 'Position-based control',
 									isZh ? '嵌套 iframe、跨域 iframe' : 'Nested iframes, cross-origin iframes',


### PR DESCRIPTION
## Summary
- treat the first click on the running action button as a stop request and immediately morph it into a close action
- allow a second click to dispose the panel even before the agent finishes transitioning out of `running`
- reset the temporary stopping state on subsequent status changes and panel resets

## Testing
- npm run build --workspace=@page-agent/ui

Closes #183
