### PR TITLE
fix(extension): use lastFocusedWindow when querying active tab (fixes #457)

### DIFF
--- a/packages/extension/src/agent/TabsController.background.ts
+++ b/packages/extension/src/agent/TabsController.background.ts
@@ -18,7 +18,7 @@ export function handleTabControlMessage(
 		case 'get_active_tab': {
 			debug('get_active_tab')
 			chrome.tabs
-				.query({ active: true })
+				.query({ active: true, lastFocusedWindow: true })
 				.then((tabs) => {
 					debug('get_active_tab: success', tabs)
 					sendResponse({ success: true, tab: tabs[0] })


### PR DESCRIPTION
Fixes #457

## Problem

`chrome.tabs.query({ active: true })` in the service worker returns the active tab across **all open Chrome windows**, not just the focused one. When the user has multiple Chrome windows open, the agent picks the active tab from whichever window the query happens to return first — which may not be the window the user is currently working in.

## Solution

Add `lastFocusedWindow: true` to the query so the agent always selects the active tab from the most recently focused browser window:

```typescript
// Before
chrome.tabs.query({ active: true })

// After
chrome.tabs.query({ active: true, lastFocusedWindow: true })
```

`lastFocusedWindow: true` is the correct filter for background/service-worker contexts: it explicitly targets the last window the user interacted with, regardless of which window is active at query time.

## Testing

- Open two Chrome windows with different tabs active in each.
- Start a Page Agent task while focused on the first window.
- Verify the agent operates on the tab in the first (focused) window, not the second.