### PR TITLE
fix(a11y): add keyboard support to interactive non-button elements

### DIFF
--- a/packages/extension/src/components/HistoryList.tsx
+++ b/packages/extension/src/components/HistoryList.tsx
@@ -126,6 +126,12 @@ export function HistoryList({
 						role="button"
 						tabIndex={0}
 						onClick={() => onSelect(session.id)}
+						onKeyDown={(e) => {
+							if (e.key === 'Enter' || e.key === ' ') {
+								e.preventDefault()
+								onSelect(session.id)
+							}
+						}}
 						className="w-full text-left px-3 py-2.5 border-b hover:bg-muted/50 transition-colors cursor-pointer flex items-start gap-2 group"
 					>
 						{/* Status icon */}

--- a/packages/extension/src/components/cards.tsx
+++ b/packages/extension/src/components/cards.tsx
@@ -68,11 +68,20 @@ function ReflectionItem({ icon, value }: { icon: string; value: string }) {
 		<Fragment>
 			<span className="text-xs flex justify-center">{icon}</span>
 			<span
+				role="button"
+				tabIndex={0}
+				aria-expanded={expanded}
 				className={cn(
 					'text-[11px] text-muted-foreground cursor-pointer hover:text-muted-foreground/70',
 					!expanded && 'line-clamp-1'
 				)}
 				onClick={() => setExpanded(!expanded)}
+				onKeyDown={(e) => {
+					if (e.key === 'Enter' || e.key === ' ') {
+						e.preventDefault()
+						setExpanded(!expanded)
+					}
+				}}
 			>
 				{value}
 			</span>


### PR DESCRIPTION
## Problem

Two interactive elements were only accessible via mouse, failing [WCAG 2.1 SC 2.1.1 (Keyboard)](https://www.w3.org/WAI/WCAG21/Understanding/keyboard.html):

### 1. `ReflectionItem` in `cards.tsx`
A `<span>` used as a toggle to expand/collapse reflection text. It had an `onClick` handler but:
- No `role="button"` — screen readers didn't identify it as interactive
- No `tabIndex` — keyboard users couldn't focus it
- No `onKeyDown` — pressing Enter or Space did nothing

### 2. Session list item in `HistoryList.tsx`
A `<div role="button" tabIndex={0}>` was already focusable, but had no `onKeyDown` handler, so keyboard users who pressed Enter or Space to activate it got no response.

## Fix

**`cards.tsx` — `ReflectionItem`:**
- Added `role="button"`, `tabIndex={0}`, `aria-expanded={expanded}`
- Added `onKeyDown` to toggle on Enter / Space

**`HistoryList.tsx`:**
- Added `onKeyDown` to match the existing `onClick` behaviour

## Test Plan

- [ ] Focus the reflection text items with Tab and press Enter/Space — they should expand/collapse
- [ ] Focus a session history row with Tab and press Enter/Space — it should open the session