### PR TITLE
fix(a11y): add aria-pressed to API key visibility toggle

### DIFF
--- a/packages/extension/src/components/ConfigPanel.tsx
+++ b/packages/extension/src/components/ConfigPanel.tsx
@@ -248,6 +248,7 @@ export function ConfigPanel({ config, onSave, onClose }: ConfigPanelProps) {
 						className="h-8 w-8 shrink-0 cursor-pointer"
 						onClick={() => setShowApiKey(!showApiKey)}
 						aria-label={showApiKey ? 'Hide API key' : 'Show API key'}
+						aria-pressed={showApiKey}
 					>
 						{showApiKey ? <EyeOff className="size-3" /> : <Eye className="size-3" />}
 					</Button>


### PR DESCRIPTION
## Problem

`ConfigPanel.tsx` has two visibility toggle buttons — one for the auth token and one for the API key. They are functionally identical, but inconsistently implemented:

| Button | `aria-label` | `aria-pressed` |
|--------|-------------|----------------|
| Show/Hide token | ✅ | ✅ |
| Show/Hide API key | ✅ | ❌ |

Without `aria-pressed`, screen reader users cannot tell whether the API key is currently shown or hidden without first tabbing to the input and reading its type.

## Fix

Added `aria-pressed={showApiKey}` to the API key toggle button to match the existing behaviour of the token toggle.

## Test Plan

- [ ] Focus the "Show/Hide API key" button with a screen reader
- [ ] Verify it announces "pressed" when the key is visible and "not pressed" when hidden