### PR TITLE
fix: add rel="noopener noreferrer" to hub link in ConfigPanel

### DIFF
--- a/packages/extension/src/components/ConfigPanel.tsx
+++ b/packages/extension/src/components/ConfigPanel.tsx
@@ -181,6 +181,7 @@ export function ConfigPanel({ config, onSave, onClose }: ConfigPanelProps) {
 			<a
 				href="/hub.html"
 				target="_blank"
+				rel="noopener noreferrer"
 				className="flex items-center justify-between p-3 rounded-md border bg-muted/50 text-xs font-medium text-muted-foreground hover:text-foreground hover:border-foreground/20 transition-colors"
 			>
 				Manage Page Agent Hub


### PR DESCRIPTION
## Problem

The "Manage Page Agent Hub" link in `ConfigPanel.tsx` opens in a new tab (`target="_blank"`) but is missing `rel="noopener noreferrer"`.

Without these attributes, the opened page has access to the opener's `window` object via `window.opener`, which can be used to redirect the original tab to a different URL — a known [reverse tabnapping](https://owasp.org/www-community/attacks/Reverse_Tabnabbing) vector.

All other external links in the same file (`Terms of Use`, `Source Code`, `Home Page`, `Privacy`) already include `rel="noopener noreferrer"`. This is the only one missing it.

## Fix

Added `rel="noopener noreferrer"` to the hub link.

## References

- [MDN: `noopener` link type](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel/noopener)
- [OWASP: Reverse Tabnabbing](https://owasp.org/www-community/attacks/Reverse_Tabnabbing)