### PR TITLE
chore: remove debug console.log statements from production code

### DIFF
--- a/packages/extension/src/agent/useAgent.ts
+++ b/packages/extension/src/agent/useAgent.ts
@@ -108,7 +108,6 @@ export function useAgent(): UseAgentResult {
 
 	const execute = useCallback(async (task: string) => {
 		const agent = agentRef.current
-		console.log('🚀 [useAgent] start executing task:', task)
 		if (!agent) throw new Error('Agent not initialized')
 
 		setCurrentTask(task)

--- a/packages/website/src/pages/home/HeroSection.tsx
+++ b/packages/website/src/pages/home/HeroSection.tsx
@@ -77,9 +77,7 @@ export default function HeroSection() {
 				instructions: {
 					system: 'You are a helpful assistant on PageAgent website.',
 					getPageInstructions: (url: string) => {
-						const hint = url.includes('page-agent') ? 'This is PageAgent demo page.' : undefined
-						console.log('[instructions] getPageInstructions:', url, '->', hint)
-						return hint
+						return url.includes('page-agent') ? 'This is PageAgent demo page.' : undefined
 					},
 				},
 
@@ -98,8 +96,7 @@ export default function HeroSection() {
 			})
 		}
 
-		const result = await win.pageAgent.execute(task)
-		console.log(result)
+		await win.pageAgent.execute(task)
 	}
 
 	return (


### PR DESCRIPTION
## Problem

Three `console.log` calls left in production code paths were found while reviewing the codebase:

| File | Line | Log content |
|------|------|-------------|
| `packages/extension/src/agent/useAgent.ts` | 111 | `'🚀 [useAgent] start executing task:', task` — logs every task string |
| `packages/website/src/pages/home/HeroSection.tsx` | 81 | `'[instructions] getPageInstructions:', url, '->', hint` — logs on every page navigation |
| `packages/website/src/pages/home/HeroSection.tsx` | 102 | `result` — logs the full agent execute result |

These are clearly development-time debug statements. In production they:
- Leak internal task/URL details to anyone with DevTools open
- Add noise that makes real `console.error` warnings harder to spot

Note: the `console.log('PageAgent script loaded!')` inside the bookmarklet injection string was intentionally left — it provides useful feedback when the bookmarklet activates on a third-party site.

## Fix

Removed all three debug logs. In `HeroSection.tsx`, the `getPageInstructions` callback was also simplified to return the hint directly since the local `hint` variable was only used in the removed log.

## Test Plan

- [ ] Open the extension, execute a task — no `[useAgent]` log in console
- [ ] Open the website demo, navigate between pages — no `[instructions]` log in console  
- [ ] Run the demo — no raw result object logged to console