### PR TITLE
fix(mcp): advertise the package version

### DIFF
--- a/packages/mcp/src/index.js
+++ b/packages/mcp/src/index.js
@@ -2,6 +2,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { exec } from 'node:child_process'
+import { readFileSync } from 'node:fs'
 import { platform } from 'node:os'
 import * as z from 'zod/v4'
 
@@ -9,6 +10,7 @@ import { HubBridge } from './hub-bridge.js'
 
 const env = process.env
 const port = parseInt(env.PORT || '38401')
+const { version } = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8'))
 
 /** @type {Record<string, string>} */
 const llmConfig = {}
@@ -30,7 +32,7 @@ exec(`${cmd} "${url}"`, (err) => {
 
 // --- MCP server (stdio) ---
 
-const mcpServer = new McpServer({ name: 'page-agent', version: '1.5.8' })
+const mcpServer = new McpServer({ name: 'page-agent', version })
 
 mcpServer.registerTool(
 	'execute_task',


### PR DESCRIPTION
## Summary
- read the MCP package version from `packages/mcp/package.json`
- pass that package version to `new McpServer(...)` instead of the stale hardcoded `1.5.8`

## Why
`@page-agent/mcp` is currently published as `1.8.0`, but the MCP server metadata still advertises `1.5.8`. Reading the package version keeps the MCP client-visible server metadata aligned with the package release source of truth.

## Validation
- `node --check packages/mcp/src/index.js`
- `node --input-type=module` smoke check that `packages/mcp/package.json` resolves to `1.8.0`
- `git diff --check -- packages/mcp/src/index.js`
