### PR TITLE
feat(llms): add transformRequestBody hook and improve prompt assembly

### DIFF
--- a/packages/core/src/PageAgentCore.ts
+++ b/packages/core/src/PageAgentCore.ts
@@ -446,17 +446,18 @@ export class PageAgentCore extends EventTarget {
 	 * Get system prompt, dynamically replace language settings based on configured language
 	 */
 	#getSystemPrompt(): string {
-		if (this.config.customSystemPrompt) {
-			return this.config.customSystemPrompt
-		}
-
 		const targetLanguage = this.config.language === 'zh-CN' ? '中文' : 'English'
-		const systemPrompt = SYSTEM_PROMPT.replace(
-			/Default working language: \*\*.*?\*\*/,
-			`Default working language: **${targetLanguage}**`
-		)
+		const systemInstructions = this.config.instructions?.system?.trim()
+		const systemPrompt =
+			this.config.customSystemPrompt ??
+			SYSTEM_PROMPT.replace(
+				/Default working language: \*\*.*?\*\*/,
+				`Default working language: **${targetLanguage}**`
+			)
 
-		return systemPrompt
+		return systemInstructions
+			? `${systemPrompt}\n\n<system_instructions>\n${systemInstructions}\n</system_instructions>`
+			: systemPrompt
 	}
 
 	/**
@@ -465,7 +466,6 @@ export class PageAgentCore extends EventTarget {
 	async #getInstructions(): Promise<string> {
 		const { instructions, experimentalLlmsTxt } = this.config
 
-		const systemInstructions = instructions?.system?.trim()
 		let pageInstructions: string | undefined
 
 		const url = this.#states.browserState?.url || ''
@@ -482,13 +482,9 @@ export class PageAgentCore extends EventTarget {
 
 		const llmsTxt = experimentalLlmsTxt && url ? await fetchLlmsTxt(url) : undefined
 
-		if (!systemInstructions && !pageInstructions && !llmsTxt) return ''
+		if (!pageInstructions && !llmsTxt) return ''
 
 		let result = '<instructions>\n'
-
-		if (systemInstructions) {
-			result += `<system_instructions>\n${systemInstructions}\n</system_instructions>\n`
-		}
 
 		if (pageInstructions) {
 			result += `<page_instructions>\n${pageInstructions}\n</page_instructions>\n`

--- a/packages/extension/src/agent/useAgent.ts
+++ b/packages/extension/src/agent/useAgent.ts
@@ -128,6 +128,7 @@ export function useAgent(): UseAgentResult {
 			experimentalLlmsTxt,
 			experimentalIncludeAllTabs,
 			disableNamedToolChoice,
+			transformRequestBody,
 			...llmConfig
 		}: ExtConfig) => {
 			await chrome.storage.local.set({ llmConfig })
@@ -144,7 +145,7 @@ export function useAgent(): UseAgentResult {
 				disableNamedToolChoice,
 			}
 			await chrome.storage.local.set({ advancedConfig })
-			setConfig({ ...llmConfig, ...advancedConfig, language })
+			setConfig({ ...llmConfig, transformRequestBody, ...advancedConfig, language })
 		},
 		[]
 	)

--- a/packages/extension/src/components/cards.tsx
+++ b/packages/extension/src/components/cards.tsx
@@ -143,6 +143,26 @@ function CopyButton({ text, label }: { text: string; label: string }) {
 }
 
 // Extract message content by role from raw request
+function stringifyMessageContent(content: unknown): string | null {
+	if (content == null) return null
+	if (typeof content === 'string') return content
+
+	if (Array.isArray(content)) {
+		const textParts = content
+			.map((part) => {
+				if (!part || typeof part !== 'object') return null
+				if ((part as { type?: unknown }).type !== 'text') return null
+				const text = (part as { text?: unknown }).text
+				return typeof text === 'string' ? text : null
+			})
+			.filter((text): text is string => Boolean(text))
+
+		return textParts.length > 0 ? textParts.join('\n\n') : JSON.stringify(content, null, 2)
+	}
+
+	return JSON.stringify(content, null, 2)
+}
+
 function extractPrompt(rawRequest: unknown, role: 'system' | 'user'): string | null {
 	const messages = (rawRequest as { messages?: { role: string; content?: unknown }[] })?.messages
 	if (!messages) return null
@@ -150,8 +170,7 @@ function extractPrompt(rawRequest: unknown, role: 'system' | 'user'): string | n
 		role === 'system'
 			? messages.find((m) => m.role === role)
 			: messages.findLast((m) => m.role === role)
-	if (!msg?.content) return null
-	return typeof msg.content === 'string' ? msg.content : JSON.stringify(msg.content, null, 2)
+	return stringifyMessageContent(msg?.content)
 }
 
 // Raw request/response section (collapsible tabs, for debugging)

--- a/packages/llms/src/OpenAIClient.ts
+++ b/packages/llms/src/OpenAIClient.ts
@@ -27,6 +27,9 @@ export class OpenAIClient implements LLMClient {
 	): Promise<InvokeResult> {
 		// 1. Convert tools to OpenAI format
 		const openaiTools = Object.entries(tools).map(([name, t]) => zodToOpenAITool(name, t))
+		const requestMessages = this.config.experimentalSystemPromptCache
+			? messages.map((message) => this.#withSystemPromptCache(message))
+			: messages
 
 		// Build request body
 
@@ -38,7 +41,7 @@ export class OpenAIClient implements LLMClient {
 		const requestBody: Record<string, unknown> = {
 			model: this.config.model,
 			temperature: this.config.temperature,
-			messages,
+			messages: requestMessages,
 			tools: openaiTools,
 			parallel_tool_calls: false,
 			tool_choice: toolChoice,
@@ -226,6 +229,23 @@ export class OpenAIClient implements LLMClient {
 			},
 			rawResponse: data,
 			rawRequest: requestBody,
+		}
+	}
+
+	#withSystemPromptCache(message: Message): Message {
+		if (message.role !== 'system' || typeof message.content !== 'string') {
+			return message
+		}
+
+		return {
+			...message,
+			content: [
+				{
+					type: 'text',
+					text: message.content,
+					cache_control: { type: 'ephemeral' },
+				},
+			],
 		}
 	}
 }

--- a/packages/llms/src/OpenAIClient.ts
+++ b/packages/llms/src/OpenAIClient.ts
@@ -45,10 +45,19 @@ export class OpenAIClient implements LLMClient {
 		}
 
 		modelPatch(requestBody)
-		const transformedBody = this.config.transformRequestBody?.(requestBody, {
-			model: this.config.model,
-			baseURL: this.config.baseURL,
-		})
+		let transformedBody: Record<string, unknown> | void
+		try {
+			transformedBody = this.config.transformRequestBody?.(requestBody, {
+				model: this.config.model,
+				baseURL: this.config.baseURL,
+			})
+		} catch (error) {
+			throw new InvokeError(
+				InvokeErrorType.CONFIG_ERROR,
+				`transformRequestBody failed: ${(error as Error).message}`,
+				error
+			)
+		}
 		const finalRequestBody = transformedBody ?? requestBody
 
 		// 2. Call API

--- a/packages/llms/src/OpenAIClient.ts
+++ b/packages/llms/src/OpenAIClient.ts
@@ -27,9 +27,6 @@ export class OpenAIClient implements LLMClient {
 	): Promise<InvokeResult> {
 		// 1. Convert tools to OpenAI format
 		const openaiTools = Object.entries(tools).map(([name, t]) => zodToOpenAITool(name, t))
-		const requestMessages = this.config.experimentalSystemPromptCache
-			? messages.map((message) => this.#withSystemPromptCache(message))
-			: messages
 
 		// Build request body
 
@@ -41,13 +38,18 @@ export class OpenAIClient implements LLMClient {
 		const requestBody: Record<string, unknown> = {
 			model: this.config.model,
 			temperature: this.config.temperature,
-			messages: requestMessages,
+			messages,
 			tools: openaiTools,
 			parallel_tool_calls: false,
 			tool_choice: toolChoice,
 		}
 
 		modelPatch(requestBody)
+		const transformedBody = this.config.transformRequestBody?.(requestBody, {
+			model: this.config.model,
+			baseURL: this.config.baseURL,
+		})
+		const finalRequestBody = transformedBody ?? requestBody
 
 		// 2. Call API
 		let response: Response
@@ -58,7 +60,7 @@ export class OpenAIClient implements LLMClient {
 					'Content-Type': 'application/json',
 					...(this.config.apiKey && { Authorization: `Bearer ${this.config.apiKey}` }),
 				},
-				body: JSON.stringify(requestBody),
+				body: JSON.stringify(finalRequestBody),
 				signal: abortSignal,
 			})
 		} catch (error: unknown) {
@@ -228,24 +230,7 @@ export class OpenAIClient implements LLMClient {
 				reasoningTokens: data.usage?.completion_tokens_details?.reasoning_tokens,
 			},
 			rawResponse: data,
-			rawRequest: requestBody,
-		}
-	}
-
-	#withSystemPromptCache(message: Message): Message {
-		if (message.role !== 'system' || typeof message.content !== 'string') {
-			return message
-		}
-
-		return {
-			...message,
-			content: [
-				{
-					type: 'text',
-					text: message.content,
-					cache_control: { type: 'ephemeral' },
-				},
-			],
+			rawRequest: finalRequestBody,
 		}
 	}
 }

--- a/packages/llms/src/errors.ts
+++ b/packages/llms/src/errors.ts
@@ -14,6 +14,7 @@ export const InvokeErrorType = {
 	UNKNOWN: 'unknown',
 
 	// Non-retryable
+	CONFIG_ERROR: 'config_error', // Invalid local configuration or hook
 	AUTH_ERROR: 'auth_error', // Authentication failed
 	CONTEXT_LENGTH: 'context_length', // Prompt too long
 	CONTENT_FILTER: 'content_filter', // Content filtered

--- a/packages/llms/src/index.ts
+++ b/packages/llms/src/index.ts
@@ -21,6 +21,7 @@ export function parseLLMConfig(config: LLMConfig): Required<LLMConfig> {
 		apiKey: config.apiKey || '',
 		temperature: config.temperature ?? DEFAULT_TEMPERATURE,
 		maxRetries: config.maxRetries ?? LLM_MAX_RETRIES,
+		experimentalSystemPromptCache: config.experimentalSystemPromptCache ?? false,
 		disableNamedToolChoice: config.disableNamedToolChoice ?? false,
 		customFetch: (config.customFetch ?? fetch).bind(globalThis), // fetch will be illegal unless bound
 	}

--- a/packages/llms/src/index.ts
+++ b/packages/llms/src/index.ts
@@ -1,10 +1,26 @@
 import { OpenAIClient } from './OpenAIClient'
 import { DEFAULT_TEMPERATURE, LLM_MAX_RETRIES } from './constants'
 import { InvokeError, InvokeErrorType } from './errors'
-import type { InvokeOptions, InvokeResult, LLMClient, LLMConfig, Message, Tool } from './types'
+import type {
+	InvokeOptions,
+	InvokeResult,
+	LLMClient,
+	LLMConfig,
+	Message,
+	Tool,
+	TransformRequestContext,
+} from './types'
 
 export { InvokeError, InvokeErrorType }
-export type { InvokeOptions, InvokeResult, LLMClient, LLMConfig, Message, Tool }
+export type {
+	InvokeOptions,
+	InvokeResult,
+	LLMClient,
+	LLMConfig,
+	Message,
+	Tool,
+	TransformRequestContext,
+}
 
 export function parseLLMConfig(config: LLMConfig): Required<LLMConfig> {
 	// Runtime validation as defensive programming (types already guarantee these)
@@ -21,7 +37,7 @@ export function parseLLMConfig(config: LLMConfig): Required<LLMConfig> {
 		apiKey: config.apiKey || '',
 		temperature: config.temperature ?? DEFAULT_TEMPERATURE,
 		maxRetries: config.maxRetries ?? LLM_MAX_RETRIES,
-		experimentalSystemPromptCache: config.experimentalSystemPromptCache ?? false,
+		transformRequestBody: config.transformRequestBody ?? ((requestBody) => requestBody),
 		disableNamedToolChoice: config.disableNamedToolChoice ?? false,
 		customFetch: (config.customFetch ?? fetch).bind(globalThis), // fetch will be illegal unless bound
 	}

--- a/packages/llms/src/types.ts
+++ b/packages/llms/src/types.ts
@@ -6,9 +6,21 @@ import type * as z from 'zod/v4'
 /**
  * Message format - OpenAI standard (industry standard)
  */
+export interface MessageCacheControl {
+	type: 'ephemeral'
+}
+
+export interface MessageTextPart {
+	type: 'text'
+	text: string
+	cache_control?: MessageCacheControl
+}
+
+export type MessageContent = string | MessageTextPart[] | null
+
 export interface Message {
 	role: 'system' | 'user' | 'assistant' | 'tool'
-	content?: string | null
+	content?: MessageContent
 	tool_calls?: {
 		id: string
 		type: 'function'
@@ -94,6 +106,13 @@ export interface LLMConfig {
 
 	temperature?: number
 	maxRetries?: number
+
+	/**
+	 * Emit Anthropic-style prompt cache hints on the system message.
+	 * This adds `cache_control: { type: 'ephemeral' }` to a system text content part.
+	 * Non-standard extension: only enable when your OpenAI-compatible provider explicitly supports it.
+	 */
+	experimentalSystemPromptCache?: boolean
 
 	/**
 	 * remove the tool_choice field from the request.

--- a/packages/llms/src/types.ts
+++ b/packages/llms/src/types.ts
@@ -3,17 +3,9 @@
  */
 import type * as z from 'zod/v4'
 
-/**
- * Message format - OpenAI standard (industry standard)
- */
-export interface MessageCacheControl {
-	type: 'ephemeral'
-}
-
 export interface MessageTextPart {
 	type: 'text'
 	text: string
-	cache_control?: MessageCacheControl
 }
 
 export type MessageContent = string | MessageTextPart[] | null
@@ -96,6 +88,11 @@ export interface InvokeResult<TResult = unknown> {
 	rawRequest?: unknown // Raw request for debugging
 }
 
+export interface TransformRequestContext {
+	model: string
+	baseURL: string
+}
+
 /**
  * LLM configuration
  */
@@ -108,11 +105,15 @@ export interface LLMConfig {
 	maxRetries?: number
 
 	/**
-	 * Emit Anthropic-style prompt cache hints on the system message.
-	 * This adds `cache_control: { type: 'ephemeral' }` to a system text content part.
-	 * Non-standard extension: only enable when your OpenAI-compatible provider explicitly supports it.
+	 * Transform the final request body before sending it to the provider.
+	 * Use this to implement provider-specific request tweaks such as caching hints or custom flags.
+	 *
+	 * Return a new object, or mutate the input object and return nothing.
 	 */
-	experimentalSystemPromptCache?: boolean
+	transformRequestBody?: (
+		requestBody: Record<string, unknown>,
+		context: TransformRequestContext
+	) => Record<string, unknown> | void
 
 	/**
 	 * remove the tool_choice field from the request.

--- a/packages/website/src/pages/docs/advanced/page-agent-core/page.tsx
+++ b/packages/website/src/pages/docs/advanced/page-agent-core/page.tsx
@@ -157,12 +157,11 @@ const result = await agent.execute('Fill in the form with test data')`}
 							description: isZh ? 'API 调用失败时的最大重试次数' : 'Maximum retries on API failure',
 						},
 						{
-							name: 'experimentalSystemPromptCache',
-							type: 'boolean',
-							defaultValue: 'false',
+							name: 'transformRequestBody',
+							type: '(requestBody, context) => Record<string, unknown> | void',
 							description: isZh
-								? '为系统消息添加 cache_control: { type: "ephemeral" } 缓存提示。仅在提供商明确支持时启用（如 Claude API 兼容端点）。'
-								: 'Add cache_control: { type: "ephemeral" } to the system message for prompt caching. Only enable when your provider explicitly supports it (e.g. Claude-compatible endpoints).',
+								? '在请求发送前转换最终 request body。可用于处理供应商特定的缓存提示或私有参数。'
+								: 'Transform the final request body before sending it. Useful for provider-specific cache hints or private request parameters.',
 						},
 						{
 							name: 'disableNamedToolChoice',
@@ -180,6 +179,42 @@ const result = await agent.execute('Fill in the form with test data')`}
 								: 'Custom fetch function for customizing headers, credentials, proxy, etc.',
 						},
 					]}
+				/>
+
+				<h3 className="text-lg font-semibold mt-6 mb-3 text-gray-800 dark:text-gray-200">
+					{isZh ? 'transformRequestBody 示例' : 'transformRequestBody Example'}
+				</h3>
+				<p className="text-gray-600 dark:text-gray-400 mb-4">
+					{isZh
+						? '如果某个供应商需要私有字段或缓存提示，可以通过 transformRequestBody 在发送前透传请求体，而不需要把供应商逻辑写进 PageAgent 内部。'
+						: 'If a provider needs private fields or cache hints, use transformRequestBody to tweak the request body before sending it instead of baking provider-specific logic into PageAgent.'}
+				</p>
+				<CodeEditor
+					language="typescript"
+					code={`const agent = new PageAgentCore({
+  pageController: new PageController({ enableMask: true }),
+  baseURL: 'https://your-provider.example/v1',
+  apiKey: 'your-api-key',
+  model: 'qwen3.5-plus',
+  transformRequestBody: (requestBody) => {
+    const messages = requestBody.messages
+    if (!Array.isArray(messages)) return
+
+    const systemMessage = messages.find(
+      (message) => message && typeof message === 'object' && message.role === 'system'
+    ) as { role: string; content?: unknown } | undefined
+
+    if (!systemMessage || typeof systemMessage.content !== 'string') return
+
+    systemMessage.content = [
+      {
+        type: 'text',
+        text: systemMessage.content,
+        cache_control: { type: 'ephemeral' },
+      },
+    ]
+  },
+})`}
 				/>
 
 				{/* Agent Config */}

--- a/packages/website/src/pages/docs/advanced/page-agent-core/page.tsx
+++ b/packages/website/src/pages/docs/advanced/page-agent-core/page.tsx
@@ -157,6 +157,14 @@ const result = await agent.execute('Fill in the form with test data')`}
 							description: isZh ? 'API 调用失败时的最大重试次数' : 'Maximum retries on API failure',
 						},
 						{
+							name: 'experimentalSystemPromptCache',
+							type: 'boolean',
+							defaultValue: 'false',
+							description: isZh
+								? '为系统消息添加 cache_control: { type: "ephemeral" } 缓存提示。仅在提供商明确支持时启用（如 Claude API 兼容端点）。'
+								: 'Add cache_control: { type: "ephemeral" } to the system message for prompt caching. Only enable when your provider explicitly supports it (e.g. Claude-compatible endpoints).',
+						},
+						{
 							name: 'disableNamedToolChoice',
 							type: 'boolean',
 							defaultValue: 'false',


### PR DESCRIPTION
---
## What

This PR refines how provider-specific request optimizations are handled for OpenAI-compatible LLMs.

- Improve prompt assembly in `PageAgentCore` by moving `instructions.system` into the actual system prompt and removing duplicate `system_instructions` from the user-side instruction block.
- Add structured message content support and update the extension debug UI so transformed request bodies can still be displayed correctly.
- Introduce an initial experimental system prompt cache option, then replace it with a more maintainable `transformRequestBody` hook on `LLMConfig`.
- Let callers customize the final request body after `modelPatch(requestBody)` using `{ model, baseURL }`, instead of hardcoding provider-specific logic into the product.
- Add safer handling for request transformation errors and avoid persisting function-valued hooks in extension storage.
- Update docs to reflect the new `transformRequestBody` API and add a `qwen3.5-plus` example.

## Why

Provider-specific optimizations vary a lot and are not based on one shared standard. This PR keeps the prompt improvements, but moves vendor-specific request customization behind a single hook so the core code stays maintainable.


  Closes #474 

  ## Type

  - [ ] Breaking change
  - [ ] Bug fix
  - [x] Feature / Improvement
  - [x] Refactor / Chores
  - [x] Documentation / Website / Demo / Testing

  ## Testing

  - [x] Tested in modern browsers
  - [x] No console errors
  - [x] Types/doc added

  ## Requirements / 要求

  - [x] I have read and follow the [Code of Conduct](../docs/CODE_OF_CONDUCT.md) and [Contributing Guide](../CONTRIBUTING.md) . / 我已阅读并遵守行为准则。
  - [x] This PR is NOT generated by a bot or AI agent acting autonomously. I have authored or meaningfully reviewed every change

  ---