### PR TITLE
feat(llms): add transformRequestBody hook and improve prompt assembly

### DIFF
--- a/packages/extension/src/agent/useAgent.ts
+++ b/packages/extension/src/agent/useAgent.ts
@@ -128,6 +128,7 @@ export function useAgent(): UseAgentResult {
 			experimentalLlmsTxt,
 			experimentalIncludeAllTabs,
 			disableNamedToolChoice,
+			transformRequestBody,
 			...llmConfig
 		}: ExtConfig) => {
 			await chrome.storage.local.set({ llmConfig })
@@ -144,7 +145,7 @@ export function useAgent(): UseAgentResult {
 				disableNamedToolChoice,
 			}
 			await chrome.storage.local.set({ advancedConfig })
-			setConfig({ ...llmConfig, ...advancedConfig, language })
+			setConfig({ ...llmConfig, transformRequestBody, ...advancedConfig, language })
 		},
 		[]
 	)

--- a/packages/extension/src/agent/useAgent.ts
+++ b/packages/extension/src/agent/useAgent.ts
@@ -128,7 +128,6 @@ export function useAgent(): UseAgentResult {
 			experimentalLlmsTxt,
 			experimentalIncludeAllTabs,
 			disableNamedToolChoice,
-			transformRequestBody,
 			...llmConfig
 		}: ExtConfig) => {
 			await chrome.storage.local.set({ llmConfig })
@@ -145,7 +144,7 @@ export function useAgent(): UseAgentResult {
 				disableNamedToolChoice,
 			}
 			await chrome.storage.local.set({ advancedConfig })
-			setConfig({ ...llmConfig, transformRequestBody, ...advancedConfig, language })
+			setConfig({ ...llmConfig, ...advancedConfig, language })
 		},
 		[]
 	)

--- a/packages/extension/src/components/cards.tsx
+++ b/packages/extension/src/components/cards.tsx
@@ -143,6 +143,26 @@ function CopyButton({ text, label }: { text: string; label: string }) {
 }
 
 // Extract message content by role from raw request
+function stringifyMessageContent(content: unknown): string | null {
+	if (content == null) return null
+	if (typeof content === 'string') return content
+
+	if (Array.isArray(content)) {
+		const textParts = content
+			.map((part) => {
+				if (!part || typeof part !== 'object') return null
+				if ((part as { type?: unknown }).type !== 'text') return null
+				const text = (part as { text?: unknown }).text
+				return typeof text === 'string' ? text : null
+			})
+			.filter((text): text is string => Boolean(text))
+
+		return textParts.length > 0 ? textParts.join('\n\n') : JSON.stringify(content, null, 2)
+	}
+
+	return JSON.stringify(content, null, 2)
+}
+
 function extractPrompt(rawRequest: unknown, role: 'system' | 'user'): string | null {
 	const messages = (rawRequest as { messages?: { role: string; content?: unknown }[] })?.messages
 	if (!messages) return null
@@ -150,8 +170,7 @@ function extractPrompt(rawRequest: unknown, role: 'system' | 'user'): string | n
 		role === 'system'
 			? messages.find((m) => m.role === role)
 			: messages.findLast((m) => m.role === role)
-	if (!msg?.content) return null
-	return typeof msg.content === 'string' ? msg.content : JSON.stringify(msg.content, null, 2)
+	return stringifyMessageContent(msg?.content)
 }
 
 // Raw request/response section (collapsible tabs, for debugging)

--- a/packages/extension/src/components/cards.tsx
+++ b/packages/extension/src/components/cards.tsx
@@ -143,34 +143,16 @@ function CopyButton({ text, label }: { text: string; label: string }) {
 }
 
 // Extract message content by role from raw request
-function stringifyMessageContent(content: unknown): string | null {
-	if (content == null) return null
-	if (typeof content === 'string') return content
-
-	if (Array.isArray(content)) {
-		const textParts = content
-			.map((part) => {
-				if (!part || typeof part !== 'object') return null
-				if ((part as { type?: unknown }).type !== 'text') return null
-				const text = (part as { text?: unknown }).text
-				return typeof text === 'string' ? text : null
-			})
-			.filter((text): text is string => Boolean(text))
-
-		return textParts.length > 0 ? textParts.join('\n\n') : JSON.stringify(content, null, 2)
-	}
-
-	return JSON.stringify(content, null, 2)
-}
-
 function extractPrompt(rawRequest: unknown, role: 'system' | 'user'): string | null {
 	const messages = (rawRequest as { messages?: { role: string; content?: unknown }[] })?.messages
 	if (!messages) return null
+	if (!Array.isArray(messages)) return null
 	const msg =
 		role === 'system'
 			? messages.find((m) => m.role === role)
 			: messages.findLast((m) => m.role === role)
-	return stringifyMessageContent(msg?.content)
+	if (!msg?.content) return null
+	return typeof msg.content === 'string' ? msg.content : JSON.stringify(msg.content, null, 2)
 }
 
 // Raw request/response section (collapsible tabs, for debugging)

--- a/packages/llms/src/OpenAIClient.ts
+++ b/packages/llms/src/OpenAIClient.ts
@@ -47,10 +47,7 @@ export class OpenAIClient implements LLMClient {
 		modelPatch(requestBody)
 		let transformedBody: Record<string, unknown> | undefined
 		try {
-			transformedBody = this.config.transformRequestBody?.(requestBody, {
-				model: this.config.model,
-				baseURL: this.config.baseURL,
-			})
+			transformedBody = this.config.transformRequestBody(requestBody)
 		} catch (error) {
 			throw new InvokeError(
 				InvokeErrorType.CONFIG_ERROR,

--- a/packages/llms/src/OpenAIClient.ts
+++ b/packages/llms/src/OpenAIClient.ts
@@ -45,6 +45,20 @@ export class OpenAIClient implements LLMClient {
 		}
 
 		modelPatch(requestBody)
+		let transformedBody: Record<string, unknown> | undefined
+		try {
+			transformedBody = this.config.transformRequestBody?.(requestBody, {
+				model: this.config.model,
+				baseURL: this.config.baseURL,
+			})
+		} catch (error) {
+			throw new InvokeError(
+				InvokeErrorType.CONFIG_ERROR,
+				`transformRequestBody failed: ${(error as Error).message}`,
+				error
+			)
+		}
+		const finalRequestBody = transformedBody ?? requestBody
 
 		// 2. Call API
 		let response: Response
@@ -55,7 +69,7 @@ export class OpenAIClient implements LLMClient {
 					'Content-Type': 'application/json',
 					...(this.config.apiKey && { Authorization: `Bearer ${this.config.apiKey}` }),
 				},
-				body: JSON.stringify(requestBody),
+				body: JSON.stringify(finalRequestBody),
 				signal: abortSignal,
 			})
 		} catch (error: unknown) {
@@ -225,7 +239,7 @@ export class OpenAIClient implements LLMClient {
 				reasoningTokens: data.usage?.completion_tokens_details?.reasoning_tokens,
 			},
 			rawResponse: data,
-			rawRequest: requestBody,
+			rawRequest: finalRequestBody,
 		}
 	}
 }

--- a/packages/llms/src/errors.ts
+++ b/packages/llms/src/errors.ts
@@ -14,6 +14,7 @@ export const InvokeErrorType = {
 	UNKNOWN: 'unknown',
 
 	// Non-retryable
+	CONFIG_ERROR: 'config_error', // Invalid local configuration or hook
 	AUTH_ERROR: 'auth_error', // Authentication failed
 	CONTEXT_LENGTH: 'context_length', // Prompt too long
 	CONTENT_FILTER: 'content_filter', // Content filtered

--- a/packages/llms/src/index.ts
+++ b/packages/llms/src/index.ts
@@ -1,26 +1,10 @@
 import { OpenAIClient } from './OpenAIClient'
 import { DEFAULT_TEMPERATURE, LLM_MAX_RETRIES } from './constants'
 import { InvokeError, InvokeErrorType } from './errors'
-import type {
-	InvokeOptions,
-	InvokeResult,
-	LLMClient,
-	LLMConfig,
-	Message,
-	Tool,
-	TransformRequestContext,
-} from './types'
+import type { InvokeOptions, InvokeResult, LLMClient, LLMConfig, Message, Tool } from './types'
 
 export { InvokeError, InvokeErrorType }
-export type {
-	InvokeOptions,
-	InvokeResult,
-	LLMClient,
-	LLMConfig,
-	Message,
-	Tool,
-	TransformRequestContext,
-}
+export type { InvokeOptions, InvokeResult, LLMClient, LLMConfig, Message, Tool }
 
 export function parseLLMConfig(config: LLMConfig): Required<LLMConfig> {
 	// Runtime validation as defensive programming (types already guarantee these)

--- a/packages/llms/src/index.ts
+++ b/packages/llms/src/index.ts
@@ -1,10 +1,26 @@
 import { OpenAIClient } from './OpenAIClient'
 import { DEFAULT_TEMPERATURE, LLM_MAX_RETRIES } from './constants'
 import { InvokeError, InvokeErrorType } from './errors'
-import type { InvokeOptions, InvokeResult, LLMClient, LLMConfig, Message, Tool } from './types'
+import type {
+	InvokeOptions,
+	InvokeResult,
+	LLMClient,
+	LLMConfig,
+	Message,
+	Tool,
+	TransformRequestContext,
+} from './types'
 
 export { InvokeError, InvokeErrorType }
-export type { InvokeOptions, InvokeResult, LLMClient, LLMConfig, Message, Tool }
+export type {
+	InvokeOptions,
+	InvokeResult,
+	LLMClient,
+	LLMConfig,
+	Message,
+	Tool,
+	TransformRequestContext,
+}
 
 export function parseLLMConfig(config: LLMConfig): Required<LLMConfig> {
 	// Runtime validation as defensive programming (types already guarantee these)
@@ -21,6 +37,7 @@ export function parseLLMConfig(config: LLMConfig): Required<LLMConfig> {
 		apiKey: config.apiKey || '',
 		temperature: config.temperature ?? DEFAULT_TEMPERATURE,
 		maxRetries: config.maxRetries ?? LLM_MAX_RETRIES,
+		transformRequestBody: config.transformRequestBody ?? ((requestBody) => requestBody),
 		disableNamedToolChoice: config.disableNamedToolChoice ?? false,
 		customFetch: (config.customFetch ?? fetch).bind(globalThis), // fetch will be illegal unless bound
 	}

--- a/packages/llms/src/types.ts
+++ b/packages/llms/src/types.ts
@@ -3,12 +3,16 @@
  */
 import type * as z from 'zod/v4'
 
-/**
- * Message format - OpenAI standard (industry standard)
- */
+export interface MessageTextPart {
+	type: 'text'
+	text: string
+}
+
+export type MessageContent = string | MessageTextPart[] | null
+
 export interface Message {
 	role: 'system' | 'user' | 'assistant' | 'tool'
-	content?: string | null
+	content?: MessageContent
 	tool_calls?: {
 		id: string
 		type: 'function'
@@ -84,6 +88,11 @@ export interface InvokeResult<TResult = unknown> {
 	rawRequest?: unknown // Raw request for debugging
 }
 
+export interface TransformRequestContext {
+	model: string
+	baseURL: string
+}
+
 /**
  * LLM configuration
  */
@@ -94,6 +103,17 @@ export interface LLMConfig {
 
 	temperature?: number
 	maxRetries?: number
+
+	/**
+	 * Transform the final request body before sending it to the provider.
+	 * Use this to implement provider-specific request tweaks such as caching hints or custom flags.
+	 *
+	 * Return a new object, or mutate the input object and return undefined.
+	 */
+	transformRequestBody?: (
+		requestBody: Record<string, unknown>,
+		context: TransformRequestContext
+	) => Record<string, unknown> | undefined
 
 	/**
 	 * remove the tool_choice field from the request.

--- a/packages/llms/src/types.ts
+++ b/packages/llms/src/types.ts
@@ -3,16 +3,12 @@
  */
 import type * as z from 'zod/v4'
 
-export interface MessageTextPart {
-	type: 'text'
-	text: string
-}
-
-export type MessageContent = string | MessageTextPart[] | null
-
+/**
+ * Message format - OpenAI standard (industry standard)
+ */
 export interface Message {
 	role: 'system' | 'user' | 'assistant' | 'tool'
-	content?: MessageContent
+	content?: string | null
 	tool_calls?: {
 		id: string
 		type: 'function'
@@ -88,11 +84,6 @@ export interface InvokeResult<TResult = unknown> {
 	rawRequest?: unknown // Raw request for debugging
 }
 
-export interface TransformRequestContext {
-	model: string
-	baseURL: string
-}
-
 /**
  * LLM configuration
  */
@@ -111,8 +102,7 @@ export interface LLMConfig {
 	 * Return a new object, or mutate the input object and return undefined.
 	 */
 	transformRequestBody?: (
-		requestBody: Record<string, unknown>,
-		context: TransformRequestContext
+		requestBody: Record<string, unknown>
 	) => Record<string, unknown> | undefined
 
 	/**

--- a/packages/website/src/pages/docs/advanced/page-agent-core/page.tsx
+++ b/packages/website/src/pages/docs/advanced/page-agent-core/page.tsx
@@ -157,6 +157,13 @@ const result = await agent.execute('Fill in the form with test data')`}
 							description: isZh ? 'API 调用失败时的最大重试次数' : 'Maximum retries on API failure',
 						},
 						{
+							name: 'transformRequestBody',
+							type: '(requestBody, context) => Record<string, unknown> | undefined',
+							description: isZh
+								? '在请求发送前转换最终 request body。可用于处理供应商特定的缓存提示或私有参数。'
+								: 'Transform the final request body before sending it. Useful for provider-specific cache hints or private request parameters.',
+						},
+						{
 							name: 'disableNamedToolChoice',
 							type: 'boolean',
 							defaultValue: 'false',
@@ -172,6 +179,42 @@ const result = await agent.execute('Fill in the form with test data')`}
 								: 'Custom fetch function for customizing headers, credentials, proxy, etc.',
 						},
 					]}
+				/>
+
+				<h3 className="text-lg font-semibold mt-6 mb-3 text-gray-800 dark:text-gray-200">
+					{isZh ? 'transformRequestBody 示例' : 'transformRequestBody Example'}
+				</h3>
+				<p className="text-gray-600 dark:text-gray-400 mb-4">
+					{isZh
+						? '如果某个供应商需要私有字段或缓存提示，可以通过 transformRequestBody 在发送前透传请求体，而不需要把供应商逻辑写进 PageAgent 内部。'
+						: 'If a provider needs private fields or cache hints, use transformRequestBody to tweak the request body before sending it instead of baking provider-specific logic into PageAgent.'}
+				</p>
+				<CodeEditor
+					language="typescript"
+					code={`const agent = new PageAgentCore({
+  pageController: new PageController({ enableMask: true }),
+  baseURL: 'https://your-provider.example/v1',
+  apiKey: 'your-api-key',
+  model: 'qwen3.5-plus',
+  transformRequestBody: (requestBody) => {
+    const messages = requestBody.messages
+    if (!Array.isArray(messages)) return
+
+    const systemMessage = messages.find(
+      (message) => message && typeof message === 'object' && message.role === 'system'
+    ) as { role: string; content?: unknown } | undefined
+
+    if (!systemMessage || typeof systemMessage.content !== 'string') return
+
+    systemMessage.content = [
+      {
+        type: 'text',
+        text: systemMessage.content,
+        cache_control: { type: 'ephemeral' },
+      },
+    ]
+  },
+})`}
 				/>
 
 				{/* Agent Config */}

--- a/packages/website/src/pages/docs/advanced/page-agent-core/page.tsx
+++ b/packages/website/src/pages/docs/advanced/page-agent-core/page.tsx
@@ -158,7 +158,7 @@ const result = await agent.execute('Fill in the form with test data')`}
 						},
 						{
 							name: 'transformRequestBody',
-							type: '(requestBody, context) => Record<string, unknown> | undefined',
+							type: '(requestBody) => Record<string, unknown> | undefined',
 							description: isZh
 								? '在请求发送前转换最终 request body。可用于处理供应商特定的缓存提示或私有参数。'
 								: 'Transform the final request body before sending it. Useful for provider-specific cache hints or private request parameters.',


### PR DESCRIPTION
---
## What

This PR adds a generic request transformation hook for OpenAI-compatible LLMs, so provider-specific request optimizations can be implemented without hardcoding vendor logic into the product.

- Add `transformRequestBody` to `LLMConfig`, allowing callers to customize the final request body after `modelPatch(requestBody)` using `{ model, baseURL }`.
- Add structured message content support and update the extension debug UI so transformed request bodies can still be displayed correctly when message content is no longer a plain string.
- Add safer handling for request transformation errors by surfacing hook failures as configuration errors instead of treating them like provider or network failures.
- Avoid persisting function-valued hooks in extension storage; keep `transformRequestBody` in memory only.
- Update docs to reflect the new `transformRequestBody` API and add a `qwen3.5-plus` example.

## Why

Provider-specific optimizations vary widely and do not follow one shared standard. This PR moves vendor-specific request customization behind a single hook so the core code stays maintainable while still giving users a clear extension point.



  Closes #474 

  ## Type

  - [ ] Breaking change
  - [ ] Bug fix
  - [x] Feature / Improvement
  - [x] Refactor / Chores
  - [x] Documentation / Website / Demo / Testing

  ## Testing

  - [x] Tested in modern browsers
  - [x] No console errors
  - [x] Types/doc added

  ## Requirements / 要求

  - [x] I have read and follow the [Code of Conduct](../docs/CODE_OF_CONDUCT.md) and [Contributing Guide](../CONTRIBUTING.md) . / 我已阅读并遵守行为准则。
  - [x] This PR is NOT generated by a bot or AI agent acting autonomously. I have authored or meaningfully reviewed every change

  ---