### PR TITLE
fix(extension): detect stalled background worker

### DIFF
--- a/packages/extension/src/agent/TabsController.ts
+++ b/packages/extension/src/agent/TabsController.ts
@@ -1,18 +1,56 @@
 import { isContentScriptAllowed } from './RemotePageController'
 
 const PREFIX = '[TabsController]'
+const BACKGROUND_RESPONSE_TIMEOUT_MS = 2_000
 
 const debug = console.debug.bind(console, `\x1b[90m${PREFIX}\x1b[0m`)
 
-function sendMessage(message: {
+interface TabControlMessage {
 	type: 'TAB_CONTROL'
 	action: TabAction
 	payload?: any
-}): Promise<any> {
-	return chrome.runtime.sendMessage(message).catch((error) => {
-		console.error(PREFIX, message.action, error)
-		return null
+}
+
+function backgroundUnavailableError(action: string, cause?: unknown): Error {
+	const detail = cause instanceof Error ? ` (${cause.message})` : ''
+	return new Error(
+		`Background service worker is not responding while running ${action}${detail}. ` +
+			'Try fully restarting the browser, or inspect the extension side panel Application tab and update or unregister the service worker if it is stuck.'
+	)
+}
+
+async function sendBackgroundMessage<T>(message: unknown, action: string): Promise<T> {
+	let timeoutId: ReturnType<typeof setTimeout> | undefined
+	const timeout = new Promise<never>((_, reject) => {
+		timeoutId = setTimeout(() => {
+			reject(backgroundUnavailableError(action))
+		}, BACKGROUND_RESPONSE_TIMEOUT_MS)
 	})
+
+	try {
+		return await Promise.race([chrome.runtime.sendMessage(message), timeout])
+	} catch (error) {
+		const normalized =
+			error instanceof Error && error.message.startsWith('Background service worker')
+				? error
+				: backgroundUnavailableError(action, error)
+		console.error(PREFIX, action, normalized)
+		throw normalized
+	} finally {
+		if (timeoutId) clearTimeout(timeoutId)
+	}
+}
+
+function sendMessage(message: TabControlMessage): Promise<any> {
+	return sendBackgroundMessage(message, message.action)
+}
+
+async function checkBackgroundHealth() {
+	const result = await sendBackgroundMessage<{ ok?: boolean }>(
+		{ type: 'EXT_HEALTH_CHECK' },
+		'health_check'
+	)
+	if (!result?.ok) throw backgroundUnavailableError('health_check')
 }
 
 /**
@@ -53,6 +91,8 @@ export class TabsController {
 		this.initialTabId = null
 		this.experimentalIncludeAllTabs = experimentalIncludeAllTabs
 		this.task = task
+
+		await checkBackgroundHealth()
 
 		const activeTabResult = await sendMessage({
 			type: 'TAB_CONTROL',

--- a/packages/extension/src/entrypoints/background.ts
+++ b/packages/extension/src/entrypoints/background.ts
@@ -20,7 +20,10 @@ export default defineBackground(() => {
 	// message proxy
 
 	chrome.runtime.onMessage.addListener((message, sender, sendResponse): true | undefined => {
-		if (message.type === 'TAB_CONTROL') {
+		if (message.type === 'EXT_HEALTH_CHECK') {
+			sendResponse({ ok: true })
+			return
+		} else if (message.type === 'TAB_CONTROL') {
 			return handleTabControlMessage(message, sender, sendResponse)
 		} else if (message.type === 'PAGE_CONTROL') {
 			return handlePageControlMessage(message, sender, sendResponse)


### PR DESCRIPTION
## Summary

- add a lightweight `EXT_HEALTH_CHECK` message handled by the extension background service worker
- make `TabsController` verify the background worker before task startup
- wrap background `sendMessage` calls with a short timeout and raise an actionable recovery error instead of returning `null`

## Why

Issue #452 reports the side panel becoming unresponsive when Chrome MV3 leaves the extension service worker in a stuck/inactive state. The current tab-control path logs `chrome.runtime.sendMessage` failures and returns `null`, which can turn the real service-worker problem into a less helpful null dereference during task startup.

This keeps the service worker stateless/restartable, but gives the side panel a deterministic health probe and a clear failure message that points to the maintainer-provided recovery steps from #452.

This is intentionally scoped to the background/TabsController path and does not touch the sidepanel UI copy, so it complements the existing startup-guidance PR without overlapping its file scope.

## Validation

- `npm ci --ignore-scripts --no-audit --no-fund` (npm 10.9.4 reports the repo's npm ^11.6.3 engine warning)
- `npm run postinstall --workspace=@page-agent/ext`
- `npm run typecheck`
- `npx eslint packages/extension/src/agent/TabsController.ts packages/extension/src/entrypoints/background.ts`
- `git diff --check`
- `npm run build`
