### PR TITLE
feat: add autoInit switch for demo CDN script

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Fastest way to try PageAgent with our free Demo LLM:
 | Global  | https://cdn.jsdelivr.net/npm/page-agent@1.8.1/dist/iife/page-agent.demo.js         |
 | China   | https://registry.npmmirror.com/page-agent/1.8.1/files/dist/iife/page-agent.demo.js |
 
+Add `?autoInit=false` to load the script without creating the demo agent automatically. You can then instantiate it with `new window.PageAgent(...)`.
+
 ### NPM Installation
 
 ```bash

--- a/docs/README-zh.md
+++ b/docs/README-zh.md
@@ -52,6 +52,8 @@
 | Global  | https://cdn.jsdelivr.net/npm/page-agent@1.8.1/dist/iife/page-agent.demo.js         |
 | China   | https://registry.npmmirror.com/page-agent/1.8.1/files/dist/iife/page-agent.demo.js |
 
+在 URL 后添加 `?autoInit=false` 可只加载脚本，不自动创建 Demo Agent；之后可通过 `new window.PageAgent(...)` 手动初始化。
+
 ### NPM 安装
 
 ```bash

--- a/packages/page-agent/src/demo.ts
+++ b/packages/page-agent/src/demo.ts
@@ -3,8 +3,12 @@
  */
 import { PageAgent, type PageAgentConfig } from './PageAgent'
 
+const currentScript = document.currentScript as HTMLScriptElement | null
+const currentScriptURL = currentScript?.src ? new URL(currentScript.src) : null
+const autoInit = currentScriptURL?.searchParams.get('autoInit') !== 'false'
+
 // Clean up existing instances to prevent multiple injections from bookmarklet
-if (window.pageAgent) {
+if (autoInit && window.pageAgent) {
 	window.pageAgent.dispose()
 }
 
@@ -17,36 +21,35 @@ const DEMO_MODEL = 'qwen3.5-plus'
 const DEMO_BASE_URL = 'https://page-ag-testing-ohftxirgbn.cn-shanghai.fcapp.run'
 const DEMO_API_KEY = 'NA'
 
-const currentScript = document.currentScript as HTMLScriptElement | null
-
 // in case document.x is not ready yet
-setTimeout(() => {
-	let config: PageAgentConfig
-	let showPanel = true
+if (autoInit) {
+	setTimeout(() => {
+		let config: PageAgentConfig
+		let showPanel = true
 
-	if (currentScript) {
-		console.log('🚀 page-agent.js detected current script:', currentScript.src)
-		const url = new URL(currentScript.src)
-		const model = url.searchParams.get('model') || DEMO_MODEL
-		const baseURL = url.searchParams.get('baseURL') || DEMO_BASE_URL
-		const apiKey = url.searchParams.get('apiKey') || DEMO_API_KEY
-		const language = (url.searchParams.get('lang') as 'zh-CN' | 'en-US') || 'zh-CN'
-		showPanel = ((url.searchParams.get('showPanel') as 'true' | 'false') || 'true') === 'true'
-		config = { model, baseURL, apiKey, language }
-	} else {
-		console.log('🚀 page-agent.js no current script detected, using default demo config')
-		config = {
-			model: import.meta.env.LLM_MODEL_NAME ? import.meta.env.LLM_MODEL_NAME : DEMO_MODEL,
-			baseURL: import.meta.env.LLM_BASE_URL ? import.meta.env.LLM_BASE_URL : DEMO_BASE_URL,
-			apiKey: import.meta.env.LLM_API_KEY ? import.meta.env.LLM_API_KEY : DEMO_API_KEY,
+		if (currentScriptURL) {
+			const url = currentScriptURL
+			const model = url.searchParams.get('model') || DEMO_MODEL
+			const baseURL = url.searchParams.get('baseURL') || DEMO_BASE_URL
+			const apiKey = url.searchParams.get('apiKey') || DEMO_API_KEY
+			const language = (url.searchParams.get('lang') as 'zh-CN' | 'en-US') || 'zh-CN'
+			showPanel = ((url.searchParams.get('showPanel') as 'true' | 'false') || 'true') === 'true'
+			config = { model, baseURL, apiKey, language }
+		} else {
+			console.log('🚀 page-agent.js no current script detected, using default demo config')
+			config = {
+				model: import.meta.env.LLM_MODEL_NAME ? import.meta.env.LLM_MODEL_NAME : DEMO_MODEL,
+				baseURL: import.meta.env.LLM_BASE_URL ? import.meta.env.LLM_BASE_URL : DEMO_BASE_URL,
+				apiKey: import.meta.env.LLM_API_KEY ? import.meta.env.LLM_API_KEY : DEMO_API_KEY,
+			}
 		}
-	}
 
-	// Create agent
-	window.pageAgent = new PageAgent(config)
-	if (showPanel) {
-		window.pageAgent.panel.show()
-	}
+		// Create agent
+		window.pageAgent = new PageAgent(config)
+		if (showPanel) {
+			window.pageAgent.panel.show()
+		}
 
-	console.log('🚀 page-agent.js initialized with config:', window.pageAgent.config)
-})
+		console.log('🚀 page-agent.js initialized with config:', window.pageAgent.config)
+	})
+}

--- a/packages/website/src/pages/docs/introduction/quick-start/page.tsx
+++ b/packages/website/src/pages/docs/introduction/quick-start/page.tsx
@@ -58,6 +58,11 @@ export default function QuickStart() {
 						code={`<script src="DEMO_CDN_URL" crossorigin="true"></script>`}
 						language="html"
 					/>
+					<p className="text-sm text-gray-600 dark:text-gray-300 mb-3">
+						{isZh
+							? '在 URL 后添加 ?autoInit=false 可只加载脚本，不自动创建 Demo Agent；之后可通过 new window.PageAgent(...) 手动初始化。'
+							: 'Add ?autoInit=false to load the script without creating the demo agent automatically. You can then instantiate it with new window.PageAgent(...).'}
+					</p>
 					<table className="w-full border-collapse text-sm">
 						<thead>
 							<tr className="border-b border-gray-200 dark:border-gray-700">


### PR DESCRIPTION
## What

Add an `autoInit` query parameter for the IIFE demo script so users can load the CDN bundle without auto-creating a demo agent, then initialize manually with `window.PageAgent`. Also document this usage in English/Chinese quick start docs and website docs.

Closes #488 #337 

## Type

- [ ] Breaking change
- [ ] Bug fix
- [x] Feature / Improvement
- [ ] Refactor / Chores
- [x] Documentation / Website / Demo / Testing

## Testing

- [x] Tested in modern browsers
- [x] No console errors
- [x] Types/doc added

Automated validation run in this session:
- `npm run ci` ✅

## Requirements / 要求

- [x] I have read and follow the [Code of Conduct](../docs/CODE_OF_CONDUCT.md) and [Contributing Guide](../CONTRIBUTING.md) . / 我已阅读并遵守行为准则。
- [x] This PR is NOT generated by a bot or AI agent acting autonomously. I have authored or meaningfully reviewed every change. / 此 PR 不是由 bot 或 AI 自主生成的，我已亲自编写或充分审查了每一处变更。