### PR TITLE
fix(website): normalize trailing slash in sidebar location comparison

### DIFF
--- a/packages/website/src/pages/docs/Layout.tsx
+++ b/packages/website/src/pages/docs/Layout.tsx
@@ -22,7 +22,8 @@ interface NavSection {
 
 export default function DocsLayout({ children }: DocsLayoutProps) {
 	const { isZh } = useLanguage()
-	const [location] = useLocation()
+	const [rawLocation] = useLocation()
+	const location = rawLocation.replace(/\/+$/, '')
 
 	const navigationSections: NavSection[] = [
 		{


### PR DESCRIPTION
## What

修复：当url结尾带有斜杠时，左侧的目录没有高亮。

Closes #505 

## Type

- [ ] Breaking change
- [x] Bug fix
- [ ] Feature / Improvement
- [ ] Refactor / Chores
- [ ] Documentation / Website / Demo / Testing

## Testing

- [x] Tested in modern browsers
- [x] No console errors
- [ ] Types/doc added

## Requirements / 要求

- [ ] I have read and follow the [Code of Conduct](../docs/CODE_OF_CONDUCT.md) and [Contributing Guide](../CONTRIBUTING.md) . / 我已阅读并遵守行为准则。
- [ ] This PR is NOT generated by a bot or AI agent acting autonomously. I have authored or meaningfully reviewed every change. / 此 PR 不是由 bot 或 AI 自主生成的，我已亲自编写或充分审查了每一处变更。
