### PR TITLE
Add go back tool

### DIFF
--- a/packages/core/src/tools/index.ts
+++ b/packages/core/src/tools/index.ts
@@ -170,6 +170,18 @@ tools.set(
 )
 
 tools.set(
+	'go_back',
+	tool({
+		description: 'Navigate to the previous page in browser history.',
+		inputSchema: z.object({}),
+		execute: async function (this: PageAgentCore) {
+			const result = await this.pageController.goBack()
+			return result.message
+		},
+	})
+)
+
+tools.set(
 	'execute_javascript',
 	tool({
 		description:
@@ -186,5 +198,4 @@ tools.set(
 
 // @todo send_keys
 // @todo upload_file
-// @todo go_back
 // @todo extract_structured_data

--- a/packages/page-controller/src/PageController.ts
+++ b/packages/page-controller/src/PageController.ts
@@ -9,6 +9,7 @@
 import {
 	clickElement,
 	getElementByIndex,
+	goBack,
 	inputTextElement,
 	scrollHorizontally,
 	scrollVertically,
@@ -371,6 +372,25 @@ export class PageController extends EventTarget {
 			return {
 				success: false,
 				message: `❌ Failed to scroll horizontally: ${error}`,
+			}
+		}
+	}
+
+	/**
+	 * Navigate to the previous page in browser history
+	 */
+	async goBack(): Promise<ActionResult> {
+		try {
+			const message = await goBack()
+
+			return {
+				success: true,
+				message,
+			}
+		} catch (error) {
+			return {
+				success: false,
+				message: `❌ Failed to go back: ${error}`,
 			}
 		}
 	}

--- a/packages/page-controller/src/actions.ts
+++ b/packages/page-controller/src/actions.ts
@@ -255,6 +255,17 @@ export async function selectOptionElement(selectElement: HTMLSelectElement, opti
 	await waitFor(0.1) // Wait to ensure change event processing completes
 }
 
+export async function goBack() {
+	if (window.history.length <= 1) {
+		return '⚠️ No previous page in browser history.'
+	}
+
+	const currentUrl = window.location.href
+	window.history.back()
+
+	return `✅ Navigating back from ${currentUrl}.`
+}
+
 interface ScrollableElement extends Element {
 	scrollIntoViewIfNeeded?: (centerIfNeeded?: boolean) => void
 }


### PR DESCRIPTION
## Summary
- add a PageController history navigation action
- expose it as the built-in `go_back` agent tool
- remove the stale `go_back` TODO from the tool list

## Validation
- `git diff --check`
- `npx eslint packages/page-controller/src/actions.ts packages/page-controller/src/PageController.ts packages/core/src/tools/index.ts`
- `npm run build --workspace=@page-agent/page-controller` completed; declaration generation still reports existing scroll helper predicate diagnostics in `actions.ts`
- `npm run build --workspace=@page-agent/core` completed; declaration generation still reports missing internal package declarations unless dependencies are built first