### PR TITLE
Report actual wait duration

### DIFF
--- a/packages/core/src/tools/index.ts
+++ b/packages/core/src/tools/index.ts
@@ -58,12 +58,8 @@ tools.set(
 			console.log(`actualWaitTime: ${actualWaitTime} seconds`)
 			await waitFor(actualWaitTime)
 
-			const waitedSeconds = Number(actualWaitTime.toFixed(2))
-			if (waitedSeconds === input.seconds) {
-				return `✅ Waited for ${input.seconds} seconds.`
-			}
-
-			return `✅ Waited for ${waitedSeconds} seconds. ${secondsSinceLastUpdate.toFixed(2)} seconds had already passed since the last page update.`
+			const waitedSeconds = (secondsSinceLastUpdate + actualWaitTime).toFixed(2)
+			return `✅ Waited for ${waitedSeconds} seconds.`
 		},
 	})
 )

--- a/packages/core/src/tools/index.ts
+++ b/packages/core/src/tools/index.ts
@@ -53,11 +53,17 @@ tools.set(
 		execute: async function (this: PageAgentCore, input) {
 			// try to subtract LLM calling time from the actual wait time
 			const lastTimeUpdate = await this.pageController.getLastUpdateTime()
-			const actualWaitTime = Math.max(0, input.seconds - (Date.now() - lastTimeUpdate) / 1000)
+			const secondsSinceLastUpdate = (Date.now() - lastTimeUpdate) / 1000
+			const actualWaitTime = Math.max(0, input.seconds - secondsSinceLastUpdate)
 			console.log(`actualWaitTime: ${actualWaitTime} seconds`)
 			await waitFor(actualWaitTime)
 
-			return `✅ Waited for ${input.seconds} seconds.`
+			const waitedSeconds = Number(actualWaitTime.toFixed(2))
+			if (waitedSeconds === input.seconds) {
+				return `✅ Waited for ${input.seconds} seconds.`
+			}
+
+			return `✅ Waited for ${waitedSeconds} seconds. ${secondsSinceLastUpdate.toFixed(2)} seconds had already passed since the last page update.`
 		},
 	})
 )


### PR DESCRIPTION
## Summary
- keep the existing wait-time compensation for LLM latency
- report the actual waited duration back to the agent
- include the already-elapsed time since the last page update when the requested wait was shortened

## Validation
- `git diff --check`
- `npx eslint packages/core/src/tools/index.ts`
- `npm run build --workspace=@page-agent/llms`
- `npm run build --workspace=@page-agent/core`