### PR TITLE
docs: add monorepo contributor setup instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,15 @@ Add `?autoInit=false` to load the script without creating the demo agent automat
 npm install page-agent
 ```
 
+For monorepo contributors, install and build from source:
+
+```bash
+git clone https://github.com/alibaba/page-agent.git
+cd page-agent
+npm install
+npm run build
+```
+
 ```javascript
 import { PageAgent } from 'page-agent'
 


### PR DESCRIPTION
## Summary
- Added monorepo contributor setup instructions to README
- Shows how to clone, install dependencies, and build from source

## Problem
Contributors who wanted to work on the page-agent monorepo had no clear instructions in the README for setting up their local environment.

## Solution
Added "For monorepo contributors" section with:
```bash
git clone https://github.com/alibaba/page-agent.git
cd page-agent
npm install
npm run build
```

This complements the existing "NPM Installation" section for users who just want to use page-agent as a dependency.

## Tests
Documentation only.

## Risk / Compatibility
- Docs only, no runtime changes