### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/packages/website/src/pages/docs/features/models/page.tsx
+++ b/packages/website/src/pages/docs/features/models/page.tsx
@@ -49,7 +49,7 @@ const MODEL_GROUPS: Record<string, string[]> = {
 		'claude-haiku-4.5',
 		'claude-sonnet-3.5',
 	],
-	MiniMax: ['MiniMax-M2.7', 'MiniMax-M2.7-highspeed', 'MiniMax-M2.5', 'MiniMax-M2.5-highspeed'],
+	MiniMax: ['MiniMax-M3', 'MiniMax-M2.7', 'MiniMax-M2.7-highspeed'],
 	xAI: ['grok-4.1-fast', 'grok-4', 'grok-code-fast'],
 	MoonshotAI: ['kimi-k2.5'],
 	'Z.AI': ['glm-5', 'glm-4.7'],


### PR DESCRIPTION
## Summary

Upgrade the MiniMax model entries on the docs `Tested Models` page so users discover the latest M3 release first.

## Changes

- Add `MiniMax-M3` to the model list as the new flagship (placed first per the "newest first" comment)
- Retain `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` as available alternatives
- Remove deprecated `MiniMax-M2.5` / `MiniMax-M2.5-highspeed` entries

The temperature/`parallel_tool_calls` patch in `packages/llms/src/utils.ts` already keys on `startsWith('minimax')`, so M3 inherits the existing OpenAI-compatible request fixes without further changes.

## Why

`MiniMax-M3` is the new flagship MiniMax model with 512K context, 128K max output, and image input on both OpenAI- and Anthropic-compatible interfaces. Surfacing it as the recommended option keeps the docs aligned with what MiniMax currently ships.

## Testing

- `npm run typecheck` passes
- `npm run lint` passes for the touched file
- `npm run build:website` builds successfully