### PR TITLE
fix(background): prevent service worker from going AWOL after extension update

### DIFF
--- a/packages/extension/src/entrypoints/background.ts
+++ b/packages/extension/src/entrypoints/background.ts
@@ -9,12 +9,12 @@ export default defineBackground(() => {
 	// Recreate the keepalive alarm on install/update — Chrome clears alarms on extension update,
 	// which is exactly when the SW goes AWOL (issue #452).
 	chrome.runtime.onInstalled.addListener(() => {
-		chrome.alarms.create(KEEP_ALIVE_ALARM, { periodInMinutes: 1 })
+		chrome.alarms.create(KEEP_ALIVE_ALARM, { periodInMinutes: 0.5 })
 	})
 
 	// Ensure the alarm exists even if the SW restarted without an install event
 	chrome.alarms.get(KEEP_ALIVE_ALARM).then((alarm) => {
-		if (!alarm) chrome.alarms.create(KEEP_ALIVE_ALARM, { periodInMinutes: 1 })
+		if (!alarm) chrome.alarms.create(KEEP_ALIVE_ALARM, { periodInMinutes: 0.5 })
 	})
 
 	// Alarm handler: waking up is enough — Chrome won't let the SW sleep mid-alarm

--- a/packages/extension/src/entrypoints/background.ts
+++ b/packages/extension/src/entrypoints/background.ts
@@ -1,8 +1,26 @@
 import { handlePageControlMessage } from '@/agent/RemotePageController.background'
 import { handleTabControlMessage, setupTabEventsPort } from '@/agent/TabsController.background'
 
+const KEEP_ALIVE_ALARM = 'keepAlive'
+
 export default defineBackground(() => {
 	console.log('[Background] Service Worker started')
+
+	// Recreate the keepalive alarm on install/update — Chrome clears alarms on extension update,
+	// which is exactly when the SW goes AWOL (issue #452).
+	chrome.runtime.onInstalled.addListener(() => {
+		chrome.alarms.create(KEEP_ALIVE_ALARM, { periodInMinutes: 1 })
+	})
+
+	// Ensure the alarm exists even if the SW restarted without an install event
+	chrome.alarms.get(KEEP_ALIVE_ALARM).then((alarm) => {
+		if (!alarm) chrome.alarms.create(KEEP_ALIVE_ALARM, { periodInMinutes: 1 })
+	})
+
+	// Alarm handler: waking up is enough — Chrome won't let the SW sleep mid-alarm
+	chrome.alarms.onAlarm.addListener((alarm) => {
+		if (alarm.name === KEEP_ALIVE_ALARM) console.debug('[Background] keepAlive tick')
+	})
 
 	// tab change events
 

--- a/packages/extension/wxt.config.js
+++ b/packages/extension/wxt.config.js
@@ -45,7 +45,7 @@ export default defineConfig({
 		name: '__MSG_extName__',
 		description: '__MSG_extDescription__',
 		homepage_url: 'https://alibaba.github.io/page-agent/',
-		permissions: ['tabs', 'tabGroups', 'sidePanel', 'storage'],
+		permissions: ['tabs', 'tabGroups', 'sidePanel', 'storage', 'alarms'],
 		host_permissions: ['<all_urls>'],
 		icons: {
 			64: 'assets/page-agent-64.png',


### PR DESCRIPTION
## Problem

Fixes #452.

Chrome MV3 service workers are terminated by the browser after ~30 seconds of inactivity. This is normally harmless — Chrome restarts the SW on the next event. However, **Chrome clears all registered alarms when an extension is updated**, which breaks the common `chrome.alarms` keepalive pattern and leaves the SW with no scheduled wakeup. The result is the SW goes dormant and stops responding to messages until the user manually restarts it (by clicking the extension icon or navigating to a new page).

## Solution

Use `chrome.alarms` to register a 1-minute periodic wakeup alarm:

- **`chrome.runtime.onInstalled`** — recreates the alarm immediately after install or update, covering the primary trigger for #452
- **`chrome.alarms.get` fallback** — recreates the alarm on any SW cold-start where no install event fires (e.g. browser restart after a crash)
- **`chrome.alarms.onAlarm` listener** — waking up is sufficient; Chrome won't terminate the SW mid-alarm

Added `"alarms"` to the extension manifest permissions.

## Why `periodInMinutes: 1`?

Chrome enforces a minimum of 1 minute (0.5 min in dev) for `chrome.alarms`. One minute is well within the ~30s idle window, so the SW stays responsive.

## Test

1. Install the extension from source
2. Open `chrome://extensions`, find page-agent, click "Service Worker" link to open the SW DevTools
3. Wait >30s — SW should show as active (alarm tick visible in console)
4. Update the extension (bump `version` in `package.json`, rebuild, reload in Chrome)
5. Wait >30s — SW should recover automatically without requiring a manual restart