### PR TITLE
chore(page-controller): remove accidental debug console.log calls

### DIFF
--- a/packages/page-controller/src/dom/dom_tree/index.js
+++ b/packages/page-controller/src/dom/dom_tree/index.js
@@ -552,8 +552,6 @@ export default (
 			scrollData: scrollData,
 		})
 
-		console.log('scrollData!!!', scrollData)
-
 		return scrollData
 	}
 

--- a/packages/page-controller/src/mask/SimulatorMask.ts
+++ b/packages/page-controller/src/mask/SimulatorMask.ts
@@ -209,7 +209,6 @@ export class SimulatorMask extends EventTarget {
 
 	dispose() {
 		this.#disposed = true
-		console.log('dispose SimulatorMask')
 		this.motion?.dispose()
 		this.wrapper.remove()
 		this.dispatchEvent(new Event('dispose'))


### PR DESCRIPTION
## Summary

Two debug `console.log` statements were left in production code and fire on every agent action, polluting the browser console for all users.

- **`isScrollableElement()` in `dom_tree/index.js`** — logged `scrollData!!!` for every scrollable element found during DOM tree construction. The DOM is rebuilt before each AI action, so this fires multiple times per action. It also triggers unnecessary `JSON.stringify`-equivalent serialisation of the scroll metrics object on the hot path.
- **`SimulatorMask.dispose()`** — logged `'dispose SimulatorMask'` every time the highlight overlay was torn down after an action.

Neither log has a structured prefix, a debug flag, or follows the `[Module]` pattern used by intentional logs elsewhere in the codebase.

## Changes

- `packages/page-controller/src/dom/dom_tree/index.js` — remove `console.log('scrollData!!!', scrollData)` from `isScrollableElement()`
- `packages/page-controller/src/mask/SimulatorMask.ts` — remove `console.log('dispose SimulatorMask')` from `dispose()`

## Test plan

- [x] `npm run build --workspace=@page-agent/page-controller` passes
- [x] `git diff --check` clean
- [x] `npx eslint` clean on both changed files
- [x] No functional change — both removed lines are pure console side-effects with no callers depending on their output