### PR TITLE
feat(llms): add Claude Opus 4.8 support

### DIFF
--- a/packages/llms/src/utils.test.ts
+++ b/packages/llms/src/utils.test.ts
@@ -67,6 +67,18 @@ describe('modelPatch', () => {
 		expect(body).not.toHaveProperty('temperature')
 	})
 
+	it('claude-opus-4-8: drops temperature', () => {
+		const body = baseBody('claude-opus-4-8')
+		modelPatch(body)
+		expect(body).not.toHaveProperty('temperature')
+	})
+
+	it('claude-opus-48 (alt id form): drops temperature', () => {
+		const body = baseBody('claude-opus-48-20251210')
+		modelPatch(body)
+		expect(body).not.toHaveProperty('temperature')
+	})
+
 	it('grok: removes tool_choice and disables reasoning/thinking', () => {
 		const body = baseBody('grok-4')
 		modelPatch(body)

--- a/packages/llms/src/utils.ts
+++ b/packages/llms/src/utils.ts
@@ -56,8 +56,13 @@ export function modelPatch(body: Record<string, any>) {
 
 		// TODO: Claude naming pattern has changed
 		// needs proper handling
-		if (modelName.startsWith('claude-opus-4-7') || modelName.startsWith('claude-opus-47')) {
-			debug('Applying Claude-4.7 patch: remove temperature')
+		if (
+			modelName.startsWith('claude-opus-4-7') ||
+			modelName.startsWith('claude-opus-47') ||
+			modelName.startsWith('claude-opus-4-8') ||
+			modelName.startsWith('claude-opus-48')
+		) {
+			debug('Applying Claude-4.7/4.8 patch: remove temperature')
 			delete body.temperature
 		}
 	}

--- a/packages/website/src/pages/docs/features/models/page.tsx
+++ b/packages/website/src/pages/docs/features/models/page.tsx
@@ -42,6 +42,7 @@ const MODEL_GROUPS: Record<string, string[]> = {
 	DeepSeek: ['deepseek-v4-pro', 'deepseek-v4-flash', 'deepseek-3.2'],
 	Google: ['gemini-3.1-flash-lite', 'gemini-3-pro', 'gemini-3-flash', 'gemini-2.5'],
 	Anthropic: [
+		'claude-opus-4.8',
 		'claude-opus-4.7',
 		'claude-opus-4.6',
 		'claude-opus-4.5',


### PR DESCRIPTION
## What

Add support for **Claude Opus 4.8**.

- `modelPatch` now strips `temperature` for `claude-opus-4-8` (and the dot-stripped `claude-opus-48` variant), matching the existing 4.7 handling.
- Added unit tests covering both id forms.
- Listed `claude-opus-4.8` on the website models page.

## Why

Opus 4.8 rejects the `temperature` parameter just like 4.7, so the same patch needs to apply.

## Testing

- `npm test -w @page-agent/llms` — 58 tests pass.