### PR TITLE
fix(extension): clear currentTabId in storage on TabsController.init

### DIFF
--- a/packages/extension/src/agent/TabsController.ts
+++ b/packages/extension/src/agent/TabsController.ts
@@ -42,7 +42,7 @@ export class TabsController {
 			throw new Error('TabsController already disposed')
 		}
 
-		this.currentTabId = null
+		await this.updateCurrentTabId(null)
 		this.disposed = false
 		this.port = undefined
 		this.portRetries = 0


### PR DESCRIPTION
## What

Clear `currentTabId` through `TabsController.updateCurrentTabId(null)` when `TabsController.init()` starts, so the in-memory state and `chrome.storage.local` projection reset together.

This prevents a new run from briefly showing the mask on the previous run's tab while `isAgentRunning` is true and the heartbeat is still fresh.

Closes #550

## Type

- [ ] Breaking change
- [x] Bug fix
- [ ] Feature / Improvement
- [ ] Refactor / Chores
- [ ] Documentation / Website / Demo / Testing

## Testing

- [x] Tested in modern browsers
- [ ] No console errors
- [ ] Types/doc added

## Requirements / 要求

- [x] I have read and follow the [Code of Conduct](../docs/CODE_OF_CONDUCT.md) and [Contributing Guide](../CONTRIBUTING.md) . / 我已阅读并遵守行为准则。
- [x] This PR is NOT generated by a bot or AI agent acting autonomously. I have authored or meaningfully reviewed every change. / 此 PR 不是由 bot 或 AI 自主生成的，我已亲自编写或充分审查了每一处变更。