### PR TITLE
fix(deps): hoist happy-dom to root devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
                 "dotenv": "^17.4.2",
                 "eslint": "^10.4.0",
                 "globals": "^17.6.0",
+                "happy-dom": "^20.10.2",
                 "husky": "^9.1.7",
                 "lint-staged": "^17.0.5",
                 "prettier": "^3.8.3",
@@ -11456,9 +11457,6 @@
             "license": "MIT",
             "dependencies": {
                 "ai-motion": "^0.4.8"
-            },
-            "devDependencies": {
-                "happy-dom": "^20.10.2"
             }
         },
         "packages/ui": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
         "dotenv": "^17.4.2",
         "eslint": "^10.4.0",
         "globals": "^17.6.0",
+        "happy-dom": "^20.10.2",
         "husky": "^9.1.7",
         "lint-staged": "^17.0.5",
         "prettier": "^3.8.3",

--- a/packages/page-controller/package.json
+++ b/packages/page-controller/package.json
@@ -48,8 +48,5 @@
     },
     "dependencies": {
         "ai-motion": "^0.4.8"
-    },
-    "devDependencies": {
-        "happy-dom": "^20.10.2"
     }
 }


### PR DESCRIPTION
## What

`packages/page-controller/vitest.config.js` sets `environment: 'happy-dom'`, but Vitest runs from the root workspace, so its built-in happy-dom environment must resolve `happy-dom` from root `node_modules`. Moved `happy-dom` from the page-controller package to a root devDependency (next to `vitest`) so it stays hoisted and `npm test -w @page-agent/page-controller` works after `npm ci`.

## Type

- [ ] Breaking change
- [x] Bug fix
- [ ] Feature / Improvement
- [ ] Refactor / Chores
- [ ] Documentation / Website / Demo / Testing

## Testing

- [ ] Tested in modern browsers
- [x] No console errors
- [ ] Types/doc added

## Requirements / 要求

- [x] I have read and follow the [Code of Conduct](../docs/CODE_OF_CONDUCT.md) and [Contributing Guide](../CONTRIBUTING.md) . / 我已阅读并遵守行为准则。
- [x] This PR is NOT generated by a bot or AI agent acting autonomously. I have authored or meaningfully reviewed every change. / 此 PR 不是由 bot 或 AI 自主生成的，我已亲自编写或充分审查了每一处变更。