### PR TITLE
fix(core): make wait honor abort during setup

### DIFF
--- a/packages/core/src/PageAgentCore.test.ts
+++ b/packages/core/src/PageAgentCore.test.ts
@@ -30,7 +30,7 @@ function agentResponse(args: unknown): Response {
 	)
 }
 
-function createPageController(): PageController {
+function createPageController(overrides: Partial<PageController> = {}): PageController {
 	const browserState: BrowserState = {
 		url: 'https://example.test/',
 		title: 'Test page',
@@ -46,6 +46,7 @@ function createPageController(): PageController {
 		getLastUpdateTime: vi.fn(() => Date.now()),
 		getBrowserState: vi.fn(async () => browserState),
 		dispose: vi.fn(),
+		...overrides,
 	} as unknown as PageController
 }
 
@@ -311,6 +312,43 @@ describe.concurrent('PageAgentCore lifecycle', () => {
 	})
 
 	describe('cancellation edge cases', () => {
+		it('aborts wait while reading the last page update time', async () => {
+			let resolveLastUpdate!: (value: number) => void
+			let notifyLastUpdateStarted!: () => void
+			const lastUpdateStarted = new Promise<void>((resolve) => {
+				notifyLastUpdateStarted = resolve
+			})
+			const lastUpdate = new Promise<number>((resolve) => {
+				resolveLastUpdate = resolve
+			})
+			const pageController = createPageController({
+				getLastUpdateTime: vi.fn(() => {
+					notifyLastUpdateStarted()
+					return lastUpdate
+				}),
+			})
+			const fetchMock = createFetchMock().mockResolvedValueOnce(waitResponse())
+			const agent = createAgent(fetchMock, { pageController })
+
+			const task = agent.execute('wait for page')
+			await onceActivity(agent, (detail) => isExecutingTool(detail, 'wait'))
+			await lastUpdateStarted
+
+			let stopSettled = false
+			const stopped = agent.stop().then(() => {
+				stopSettled = true
+			})
+
+			await new Promise((resolve) => setTimeout(resolve, 0))
+			const stoppedBeforeLastUpdateResolved = stopSettled
+			resolveLastUpdate(Date.now())
+			await stopped
+
+			expect(stoppedBeforeLastUpdateResolved).toBe(true)
+			await expect(task).resolves.toMatchObject({ success: false, data: 'Task aborted' })
+			expect(agent.status).toBe('stopped')
+		})
+
 		it('rejects a new task while a stop is still settling', async () => {
 			const fetchMock = createFetchMock().mockResolvedValueOnce(waitResponse())
 			const agent = createAgent(fetchMock)

--- a/packages/core/src/tools/index.ts
+++ b/packages/core/src/tools/index.ts
@@ -5,7 +5,7 @@
 import * as z from 'zod/v4'
 
 import type { PageAgentCore } from '../PageAgentCore'
-import { waitFor } from '../utils'
+import { runWithAbortSignal, waitFor } from '../utils'
 
 /**
  * Per-invocation context passed to every tool execution.
@@ -60,7 +60,10 @@ tools.set(
 		}),
 		execute: async function (this: PageAgentCore, input, { signal }) {
 			// try to subtract LLM calling time from the actual wait time
-			const lastTimeUpdate = await this.pageController.getLastUpdateTime()
+			const lastTimeUpdate = await runWithAbortSignal(
+				() => this.pageController.getLastUpdateTime(),
+				signal
+			)
 			const secondsSinceLastUpdate = (Date.now() - lastTimeUpdate) / 1000
 			const actualWaitTime = Math.max(0, input.seconds - secondsSinceLastUpdate)
 			console.log(`actualWaitTime: ${actualWaitTime} seconds`)

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -2,6 +2,71 @@ import chalk from 'chalk'
 
 export * from './autoFixer'
 
+function toError(error: unknown): Error {
+	if (error instanceof Error) return error
+
+	const normalized = new Error(String(error))
+
+	if (
+		typeof error === 'object' &&
+		error !== null &&
+		'name' in error &&
+		typeof error.name === 'string'
+	) {
+		normalized.name = error.name
+	}
+
+	return normalized
+}
+
+function getAbortError(signal: AbortSignal): Error {
+	const reason = signal.reason
+	if (reason instanceof Error) return reason
+
+	const error = toError(reason || 'This operation was aborted.')
+	error.name = error.name === 'Error' ? 'AbortError' : error.name
+	return error
+}
+
+/**
+ * Run async work while honoring `signal`. Aborting rejects immediately even if
+ * the underlying work does not accept an AbortSignal.
+ */
+export async function runWithAbortSignal<T>(
+	task: () => T | Promise<T>,
+	signal: AbortSignal
+): Promise<T> {
+	signal.throwIfAborted()
+
+	return new Promise<T>((resolve, reject) => {
+		const onAbort = () => {
+			reject(getAbortError(signal))
+		}
+
+		signal.addEventListener('abort', onAbort, { once: true })
+
+		let promise: Promise<T>
+		try {
+			promise = Promise.resolve(task())
+		} catch (error) {
+			signal.removeEventListener('abort', onAbort)
+			reject(toError(error))
+			return
+		}
+
+		promise.then(
+			(value) => {
+				signal.removeEventListener('abort', onAbort)
+				resolve(value)
+			},
+			(error) => {
+				signal.removeEventListener('abort', onAbort)
+				reject(toError(error))
+			}
+		)
+	})
+}
+
 /**
  * Wait for `seconds`. If a `signal` is provided, the wait is cancellable:
  * aborting rejects with the signal's reason (an `AbortError`).
@@ -19,8 +84,7 @@ export async function waitFor(seconds: number, signal?: AbortSignal): Promise<vo
 		}, seconds * 1000)
 		const onAbort = () => {
 			clearTimeout(timer)
-			// reason is a DOMException AbortError.
-			reject(signal.reason as DOMException)
+			reject(getAbortError(signal))
 		}
 		signal.addEventListener('abort', onAbort, { once: true })
 	})


### PR DESCRIPTION
## What

Make the `wait` tool abort promptly while reading page update timing before its timer starts.

Closes #553

## Type

- [ ] Breaking change
- [x] Bug fix
- [ ] Feature / Improvement
- [ ] Refactor / Chores
- [ ] Documentation / Website / Demo / Testing

## Testing

- [ ] Tested in modern browsers
- [ ] No console errors
- [ ] Types/doc added

Automated validation:

- `npm run ci` passed.

## Requirements / 要求

- [ ] I have read and follow the [Code of Conduct](../docs/CODE_OF_CONDUCT.md) and [Contributing Guide](../CONTRIBUTING.md) . / 我已阅读并遵守行为准则。
- [ ] This PR is NOT generated by a bot or AI agent acting autonomously. I have authored or meaningfully reviewed every change. / 此 PR 不是由 bot 或 AI 自主生成的，我已亲自编写或充分审查了每一处变更。