### PR TITLE
fix: patch Ant Design and Element Plus components for better recognition

### DIFF
--- a/packages/page-controller/src/PageController.ts
+++ b/packages/page-controller/src/PageController.ts
@@ -17,6 +17,8 @@ import {
 import * as dom from './dom'
 import type { FlatDomTree, InteractiveElementDomNode } from './dom/dom_tree/type'
 import { getPageInfo } from './dom/getPageInfo'
+import { patchAntd } from './patches/antd'
+import { patchElementPlus } from './patches/element-plus'
 import { patchReact } from './patches/react'
 import { isAnchorElement } from './utils'
 
@@ -92,6 +94,8 @@ export class PageController extends EventTarget {
 		this.config = config
 
 		patchReact(this)
+		patchAntd(this)
+		patchElementPlus(this)
 
 		if (config.enableMask) this.initMask()
 	}

--- a/packages/page-controller/src/dom/index.ts
+++ b/packages/page-controller/src/dom/index.ts
@@ -204,6 +204,7 @@ export function flatTreeToString(
 		'value',
 		'placeholder',
 		'data-date-format',
+		'data-value',
 		'alt',
 		'aria-label',
 		'aria-expanded',

--- a/packages/page-controller/src/patches/antd.ts
+++ b/packages/page-controller/src/patches/antd.ts
@@ -7,8 +7,36 @@ const clearFunctions = [] as (() => void)[]
  * 但是 input 不可见，也不会出现在清洗后的树里，因此这里把他提上来
  */
 function fixAntdSelect() {
-	const selects = [...document.querySelectorAll('input[role="combobox"]')]
-	// for (const select of selects) {}
+	const inputs = [...document.querySelectorAll('input[role="combobox"]')]
+	for (const input of inputs) {
+		// 找到父 div（Ant Design Select 的容器）
+		const parent = input.closest('.ant-select-selector') || input.parentElement
+		if (!parent || !(parent instanceof HTMLElement)) return
+		if (parent.hasAttribute('data-antd-patched')) continue
+
+		// 把 input 的关键 ARIA 属性复制到父 div 上
+		// 这样即使 input 不可见，LLM 也能从父 div 上看到这些信息
+		// role="combobox" 已经在 DEFAULT_INCLUDE_ATTRIBUTES 中
+		if (input.hasAttribute('aria-label')) {
+			parent.setAttribute('aria-label', input.getAttribute('aria-label')!)
+		}
+		if (input.hasAttribute('aria-expanded')) {
+			parent.setAttribute('aria-expanded', input.getAttribute('aria-expanded')!)
+		}
+		if (input.hasAttribute('aria-controls')) {
+			parent.setAttribute('aria-controls', input.getAttribute('aria-controls')!)
+		}
+
+		// 如果有值，添加到父 div 的 text content 中
+		// flatTreeToString 会读取元素的 text content
+		const inputEl = input as HTMLInputElement
+		if (inputEl.value) {
+			parent.setAttribute('data-value', inputEl.value)
+		}
+
+		// 标记已处理，避免重复处理
+		parent.setAttribute('data-antd-patched', 'true')
+	}
 }
 
 export function patchAntd(pageController: PageController) {

--- a/packages/page-controller/src/patches/antd.ts
+++ b/packages/page-controller/src/patches/antd.ts
@@ -1,22 +1,22 @@
 import type { PageController } from '../PageController'
 
-const clearFunctions = [] as (() => void)[]
+const clearFunctions: (() => void)[] = []
 
 /**
- * antd 的 select 是 div 包 input 的结构，所有信息都在 input 标签上，
- * 但是 input 不可见，也不会出现在清洗后的树里，因此这里把他提上来
+ * Ant Design's Select component uses a div wrapping an input[role="combobox"] structure.
+ * The input is invisible (offsetWidth === 0), so it never appears in the cleaned DOM tree.
+ * This patch copies ARIA attributes from the hidden input to the parent selector div
+ * so the LLM can see and interact with the Select component.
  */
 function fixAntdSelect() {
 	const inputs = [...document.querySelectorAll('input[role="combobox"]')]
 	for (const input of inputs) {
-		// 找到父 div（Ant Design Select 的容器）
+		// Find the parent div (Ant Design Select container)
 		const parent = input.closest('.ant-select-selector') || input.parentElement
 		if (!parent || !(parent instanceof HTMLElement)) return
-		if (parent.hasAttribute('data-antd-patched')) continue
 
-		// 把 input 的关键 ARIA 属性复制到父 div 上
-		// 这样即使 input 不可见，LLM 也能从父 div 上看到这些信息
-		// role="combobox" 已经在 DEFAULT_INCLUDE_ATTRIBUTES 中
+		// Always refresh ARIA attributes from the hidden input to the parent div
+		// This ensures the LLM sees up-to-date state (e.g., aria-expanded changes when opened/closed)
 		if (input.hasAttribute('aria-label')) {
 			parent.setAttribute('aria-label', input.getAttribute('aria-label')!)
 		}
@@ -27,15 +27,18 @@ function fixAntdSelect() {
 			parent.setAttribute('aria-controls', input.getAttribute('aria-controls')!)
 		}
 
-		// 如果有值，添加到父 div 的 text content 中
-		// flatTreeToString 会读取元素的 text content
+		// If the input has a value, add it as a data attribute on the parent
+		// flatTreeToString will read the parent's text content / attributes
 		const inputEl = input as HTMLInputElement
 		if (inputEl.value) {
 			parent.setAttribute('data-value', inputEl.value)
 		}
 
-		// 标记已处理，避免重复处理
-		parent.setAttribute('data-antd-patched', 'true')
+		// Mark as patched to avoid duplicate processing
+		// Note: we still refresh attributes above on every update
+		if (!parent.hasAttribute('data-antd-patched')) {
+			parent.setAttribute('data-antd-patched', 'true')
+		}
 	}
 }
 

--- a/packages/page-controller/src/patches/antd.ts
+++ b/packages/page-controller/src/patches/antd.ts
@@ -11,9 +11,9 @@ const clearFunctions: (() => void)[] = []
 function fixAntdSelect() {
 	const inputs = [...document.querySelectorAll('input[role="combobox"]')]
 	for (const input of inputs) {
-		// Find the parent div (Ant Design Select container)
-		const parent = input.closest('.ant-select-selector') || input.parentElement
-		if (!parent || !(parent instanceof HTMLElement)) return
+		// Only patch Ant Design Select components (with .ant-select-selector parent)
+		const parent = input.closest('.ant-select-selector')
+		if (!parent || !(parent instanceof HTMLElement)) continue
 
 		// Always refresh ARIA attributes from the hidden input to the parent div
 		// This ensures the LLM sees up-to-date state (e.g., aria-expanded changes when opened/closed)

--- a/packages/page-controller/src/patches/antd.ts
+++ b/packages/page-controller/src/patches/antd.ts
@@ -27,11 +27,15 @@ function fixAntdSelect() {
 			parent.setAttribute('aria-controls', input.getAttribute('aria-controls')!)
 		}
 
-		// If the input has a value, add it as a data attribute on the parent
-		// flatTreeToString will read the parent's text content / attributes
+		// If the input has a value, add it as a data attribute on the parent.
+		// flatTreeToString reads the parent's text content / attributes.
+		// Remove stale data-value when the input is cleared so the LLM sees
+		// the current state, not a previous value.
 		const inputEl = input as HTMLInputElement
 		if (inputEl.value) {
 			parent.setAttribute('data-value', inputEl.value)
+		} else {
+			parent.removeAttribute('data-value')
 		}
 
 		// Mark as patched to avoid duplicate processing

--- a/packages/page-controller/src/patches/element-plus.ts
+++ b/packages/page-controller/src/patches/element-plus.ts
@@ -27,43 +27,50 @@ function fixElementPlusInputs() {
 /**
  * Patch Element Plus DatePicker components to make them recognizable.
  * DatePicker wrappers need cursor: pointer to be included in the selector map.
+ * We check on every update and handle dynamic disabled state changes.
  */
 function fixElementPlusDatePicker() {
 	const datePickers = [...document.querySelectorAll('.el-date-editor')]
 	for (const picker of datePickers) {
-		if (picker.hasAttribute('data-element-plus-date-picker-patched')) continue
 		if (!(picker instanceof HTMLElement)) continue
 
-		// Set cursor: pointer unconditionally for DatePicker wrappers
+		// Check if disabled (Element Plus adds .is-disabled class)
+		// If disabled, remove forced cursor (if previously applied) and skip
+		if (picker.classList.contains('is-disabled')) {
+			if (picker.style.cursor === 'pointer') {
+				picker.style.cursor = ''
+			}
+			continue
+		}
+
+		// Set cursor: pointer for DatePicker wrappers
 		// Element Plus doesn't set cursor on these elements, so computed style is 'auto'
 		picker.style.cursor = 'pointer'
-
-		// Mark as patched
-		picker.setAttribute('data-element-plus-date-picker-patched', 'true')
 	}
 }
 
 /**
  * Patch Element Plus Select components to make them recognizable.
  * Select wrappers need cursor: pointer to be included in the selector map.
- * We skip disabled selects to avoid exposing non-actionable elements.
+ * We check on every update and handle dynamic disabled state changes.
  */
 function fixElementPlusSelect() {
 	const selects = [...document.querySelectorAll('.el-select')]
 	for (const select of selects) {
-		if (select.hasAttribute('data-element-plus-select-patched')) continue
 		if (!(select instanceof HTMLElement)) continue
 
-		// Skip disabled selects (Element Plus adds .is-disabled class)
-		// Disabled selects should not be exposed as actionable elements
-		if (select.classList.contains('is-disabled')) continue
+		// Check if disabled (Element Plus adds .is-disabled class)
+		// If disabled, remove forced cursor (if previously applied) and skip
+		if (select.classList.contains('is-disabled')) {
+			if (select.style.cursor === 'pointer') {
+				select.style.cursor = ''
+			}
+			continue
+		}
 
 		// Set cursor: pointer for Select wrappers
 		// Element Plus doesn't set cursor on these elements, so computed style is 'auto'
 		select.style.cursor = 'pointer'
-
-		// Mark as patched
-		select.setAttribute('data-element-plus-select-patched', 'true')
 	}
 }
 

--- a/packages/page-controller/src/patches/element-plus.ts
+++ b/packages/page-controller/src/patches/element-plus.ts
@@ -18,8 +18,16 @@ function fixElementPlusInputs() {
 		// (e.g., when input value changes, or disabled/readonly/clearable props change)
 		const clearButton = wrapper.querySelector('.el-input__clear')
 		if (clearButton instanceof HTMLElement) {
-			// Add cursor: pointer to the clear button so it's recognized as interactive
+			// Add cursor: pointer and role="button" so the clear button is
+			// recognized as a distinct interactive element by the DOM extractor
+			// (isElementDistinctInteraction checks for role="button").
 			clearButton.style.setProperty('cursor', 'pointer', 'important')
+			if (!clearButton.hasAttribute('role')) {
+				clearButton.setAttribute('role', 'button')
+			}
+			if (!clearButton.hasAttribute('aria-label')) {
+				clearButton.setAttribute('aria-label', 'Clear')
+			}
 		}
 	}
 }

--- a/packages/page-controller/src/patches/element-plus.ts
+++ b/packages/page-controller/src/patches/element-plus.ts
@@ -59,9 +59,10 @@ function fixElementPlusSelect() {
 	for (const select of selects) {
 		if (!(select instanceof HTMLElement)) continue
 
-		// Check if disabled (Element Plus adds .is-disabled class)
+		// Check if disabled (Element Plus puts .is-disabled on .el-select__wrapper)
 		// If disabled, remove forced cursor (if previously applied) and skip
-		if (select.classList.contains('is-disabled')) {
+		const innerWrapper = select.querySelector('.el-select__wrapper')
+		if (innerWrapper && innerWrapper.classList.contains('is-disabled')) {
 			if (select.style.cursor === 'pointer') {
 				select.style.cursor = ''
 			}

--- a/packages/page-controller/src/patches/element-plus.ts
+++ b/packages/page-controller/src/patches/element-plus.ts
@@ -5,24 +5,22 @@ const clearFunctions: (() => void)[] = []
 /**
  * Patch Element Plus Input components to make the clear button recognizable.
  * The clear button (.el-input__clear) needs cursor: pointer to be detected.
+ * We patch on every update to handle dynamic clear button creation/removal.
  */
 function fixElementPlusInputs() {
 	const inputs = [...document.querySelectorAll('.el-input__inner')]
 	for (const input of inputs) {
 		const wrapper = input.closest('.el-input')
-		if (!wrapper || !(wrapper instanceof HTMLElement)) return
-		if (wrapper.hasAttribute('data-element-plus-input-patched')) continue
+		if (!wrapper || !(wrapper instanceof HTMLElement)) continue
 
-		// Check if there's a clear button
+		// Always check and patch the clear button on every update
+		// This handles cases where the clear button is dynamically created/removed
+		// (e.g., when input value changes, or disabled/readonly/clearable props change)
 		const clearButton = wrapper.querySelector('.el-input__clear')
-		if (clearButton && clearButton instanceof HTMLElement) {
+		if (clearButton instanceof HTMLElement) {
 			// Add cursor: pointer to the clear button so it's recognized as interactive
 			clearButton.style.setProperty('cursor', 'pointer', 'important')
-			// Mark as patched only after successfully patching the button
-			wrapper.setAttribute('data-element-plus-input-patched', 'true')
 		}
-		// Note: if the clear button is not in the DOM yet (empty input), we don't mark as patched
-		// so the next beforeUpdate pass will try again
 	}
 }
 
@@ -48,6 +46,7 @@ function fixElementPlusDatePicker() {
 /**
  * Patch Element Plus Select components to make them recognizable.
  * Select wrappers need cursor: pointer to be included in the selector map.
+ * We skip disabled selects to avoid exposing non-actionable elements.
  */
 function fixElementPlusSelect() {
 	const selects = [...document.querySelectorAll('.el-select')]
@@ -55,7 +54,11 @@ function fixElementPlusSelect() {
 		if (select.hasAttribute('data-element-plus-select-patched')) continue
 		if (!(select instanceof HTMLElement)) continue
 
-		// Set cursor: pointer unconditionally for Select wrappers
+		// Skip disabled selects (Element Plus adds .is-disabled class)
+		// Disabled selects should not be exposed as actionable elements
+		if (select.classList.contains('is-disabled')) continue
+
+		// Set cursor: pointer for Select wrappers
 		// Element Plus doesn't set cursor on these elements, so computed style is 'auto'
 		select.style.cursor = 'pointer'
 

--- a/packages/page-controller/src/patches/element-plus.ts
+++ b/packages/page-controller/src/patches/element-plus.ts
@@ -1,66 +1,66 @@
 import type { PageController } from '../PageController'
 
-const clearFunctions = [] as (() => void)[]
+const clearFunctions: (() => void)[] = []
 
 /**
- * element-plus 的 Input 组件有清空按钮（clearable），
- * 需要让 PageAgent 能识别这个按钮。
- *
- * 同样，DatePicker、Select 等组件也有类似问题。
+ * Patch Element Plus Input components to make the clear button recognizable.
+ * The clear button (.el-input__clear) needs cursor: pointer to be detected.
  */
 function fixElementPlusInputs() {
 	const inputs = [...document.querySelectorAll('.el-input__inner')]
 	for (const input of inputs) {
 		const wrapper = input.closest('.el-input')
 		if (!wrapper || !(wrapper instanceof HTMLElement)) return
-		if (wrapper.hasAttribute('data-element-plus-patched')) continue
+		if (wrapper.hasAttribute('data-element-plus-input-patched')) continue
 
-		// 检查是否有清空按钮
+		// Check if there's a clear button
 		const clearButton = wrapper.querySelector('.el-input__clear')
 		if (clearButton && clearButton instanceof HTMLElement) {
-			// 给清空按钮添加 cursor: pointer 样式，让它被识别为可交互元素
-			// 使用 style 属性直接设置（最高优先级）
+			// Add cursor: pointer to the clear button so it's recognized as interactive
 			clearButton.style.setProperty('cursor', 'pointer', 'important')
+			// Mark as patched only after successfully patching the button
+			wrapper.setAttribute('data-element-plus-input-patched', 'true')
 		}
-
-		// 标记已处理
-		wrapper.setAttribute('data-element-plus-patched', 'true')
+		// Note: if the clear button is not in the DOM yet (empty input), we don't mark as patched
+		// so the next beforeUpdate pass will try again
 	}
 }
 
 /**
- * element-plus 的 DatePicker 组件
+ * Patch Element Plus DatePicker components to make them recognizable.
+ * DatePicker wrappers need cursor: pointer to be included in the selector map.
  */
 function fixElementPlusDatePicker() {
 	const datePickers = [...document.querySelectorAll('.el-date-editor')]
 	for (const picker of datePickers) {
-		if (picker.hasAttribute('data-element-plus-patched')) continue
+		if (picker.hasAttribute('data-element-plus-date-picker-patched')) continue
+		if (!(picker instanceof HTMLElement)) continue
 
-		// 给整个 DatePicker 添加 cursor: pointer 样式
-		if (picker instanceof HTMLElement && getComputedStyle(picker).cursor === 'default') {
-			picker.style.cursor = 'pointer'
-		}
+		// Set cursor: pointer unconditionally for DatePicker wrappers
+		// Element Plus doesn't set cursor on these elements, so computed style is 'auto'
+		picker.style.cursor = 'pointer'
 
-		// 标记已处理
-		picker.setAttribute('data-element-plus-patched', 'true')
+		// Mark as patched
+		picker.setAttribute('data-element-plus-date-picker-patched', 'true')
 	}
 }
 
 /**
- * element-plus 的 Select 组件
+ * Patch Element Plus Select components to make them recognizable.
+ * Select wrappers need cursor: pointer to be included in the selector map.
  */
 function fixElementPlusSelect() {
 	const selects = [...document.querySelectorAll('.el-select')]
 	for (const select of selects) {
-		if (select.hasAttribute('data-element-plus-patched')) continue
+		if (select.hasAttribute('data-element-plus-select-patched')) continue
+		if (!(select instanceof HTMLElement)) continue
 
-		// 给整个 Select 添加 cursor: pointer 样式
-		if (select instanceof HTMLElement && getComputedStyle(select).cursor === 'default') {
-			select.style.cursor = 'pointer'
-		}
+		// Set cursor: pointer unconditionally for Select wrappers
+		// Element Plus doesn't set cursor on these elements, so computed style is 'auto'
+		select.style.cursor = 'pointer'
 
-		// 标记已处理
-		select.setAttribute('data-element-plus-patched', 'true')
+		// Mark as patched
+		select.setAttribute('data-element-plus-select-patched', 'true')
 	}
 }
 

--- a/packages/page-controller/src/patches/element-plus.ts
+++ b/packages/page-controller/src/patches/element-plus.ts
@@ -1,0 +1,77 @@
+import type { PageController } from '../PageController'
+
+const clearFunctions = [] as (() => void)[]
+
+/**
+ * element-plus 的 Input 组件有清空按钮（clearable），
+ * 需要让 PageAgent 能识别这个按钮。
+ *
+ * 同样，DatePicker、Select 等组件也有类似问题。
+ */
+function fixElementPlusInputs() {
+	const inputs = [...document.querySelectorAll('.el-input__inner')]
+	for (const input of inputs) {
+		const wrapper = input.closest('.el-input')
+		if (!wrapper || !(wrapper instanceof HTMLElement)) return
+		if (wrapper.hasAttribute('data-element-plus-patched')) continue
+
+		// 检查是否有清空按钮
+		const clearButton = wrapper.querySelector('.el-input__clear')
+		if (clearButton && clearButton instanceof HTMLElement) {
+			// 给清空按钮添加 cursor: pointer 样式，让它被识别为可交互元素
+			// 使用 style 属性直接设置（最高优先级）
+			clearButton.style.setProperty('cursor', 'pointer', 'important')
+		}
+
+		// 标记已处理
+		wrapper.setAttribute('data-element-plus-patched', 'true')
+	}
+}
+
+/**
+ * element-plus 的 DatePicker 组件
+ */
+function fixElementPlusDatePicker() {
+	const datePickers = [...document.querySelectorAll('.el-date-editor')]
+	for (const picker of datePickers) {
+		if (picker.hasAttribute('data-element-plus-patched')) continue
+
+		// 给整个 DatePicker 添加 cursor: pointer 样式
+		if (picker instanceof HTMLElement && getComputedStyle(picker).cursor === 'default') {
+			picker.style.cursor = 'pointer'
+		}
+
+		// 标记已处理
+		picker.setAttribute('data-element-plus-patched', 'true')
+	}
+}
+
+/**
+ * element-plus 的 Select 组件
+ */
+function fixElementPlusSelect() {
+	const selects = [...document.querySelectorAll('.el-select')]
+	for (const select of selects) {
+		if (select.hasAttribute('data-element-plus-patched')) continue
+
+		// 给整个 Select 添加 cursor: pointer 样式
+		if (select instanceof HTMLElement && getComputedStyle(select).cursor === 'default') {
+			select.style.cursor = 'pointer'
+		}
+
+		// 标记已处理
+		select.setAttribute('data-element-plus-patched', 'true')
+	}
+}
+
+export function patchElementPlus(pageController: PageController) {
+	pageController.addEventListener('beforeUpdate', () => {
+		fixElementPlusInputs()
+		fixElementPlusDatePicker()
+		fixElementPlusSelect()
+	})
+	pageController.addEventListener('afterUpdate', () => {
+		for (const fn of clearFunctions) fn()
+		clearFunctions.length = 0
+	})
+}

--- a/packages/page-controller/src/patches/element-plus.ts
+++ b/packages/page-controller/src/patches/element-plus.ts
@@ -3,32 +3,47 @@ import type { PageController } from '../PageController'
 const clearFunctions: (() => void)[] = []
 
 /**
+ * Patch a single Element Plus clear control so the DOM extractor recognizes it
+ * as a distinct interactive element (cursor + role="button" + aria-label).
+ *
+ * Element Plus uses different class names for clear controls depending on the
+ * component: `.el-input__clear` (plain Input), `.clear-icon` (DatePicker /
+ * TimePicker single clear icon), and `.el-range__close-icon` (RangePicker clear
+ * icon). Patching all three ensures every clear control is actionable.
+ */
+function patchClearControl(clearControl: Element | null) {
+	if (!(clearControl instanceof HTMLElement)) return
+
+	clearControl.style.setProperty('cursor', 'pointer', 'important')
+	if (!clearControl.hasAttribute('role')) {
+		clearControl.setAttribute('role', 'button')
+	}
+	if (!clearControl.hasAttribute('aria-label')) {
+		clearControl.setAttribute('aria-label', 'Clear')
+	}
+}
+
+/**
  * Patch Element Plus Input components to make the clear button recognizable.
  * The clear button (.el-input__clear) needs cursor: pointer to be detected.
  * We patch on every update to handle dynamic clear button creation/removal.
  */
 function fixElementPlusInputs() {
-	const inputs = [...document.querySelectorAll('.el-input__inner')]
-	for (const input of inputs) {
-		const wrapper = input.closest('.el-input')
-		if (!wrapper || !(wrapper instanceof HTMLElement)) continue
+	// Collect unique wrappers. Plain inputs (and single DatePicker/TimePicker,
+	// which reuse `.el-input`) are covered by `.el-input`; RangePicker uses
+	// `.el-range-editor` with `.el-range-input` (not `.el-input__inner`).
+	const wrappers = new Set<HTMLElement>()
+	for (const el of document.querySelectorAll('.el-input, .el-range-editor')) {
+		if (el instanceof HTMLElement) wrappers.add(el)
+	}
 
-		// Always check and patch the clear button on every update
-		// This handles cases where the clear button is dynamically created/removed
-		// (e.g., when input value changes, or disabled/readonly/clearable props change)
-		const clearButton = wrapper.querySelector('.el-input__clear')
-		if (clearButton instanceof HTMLElement) {
-			// Add cursor: pointer and role="button" so the clear button is
-			// recognized as a distinct interactive element by the DOM extractor
-			// (isElementDistinctInteraction checks for role="button").
-			clearButton.style.setProperty('cursor', 'pointer', 'important')
-			if (!clearButton.hasAttribute('role')) {
-				clearButton.setAttribute('role', 'button')
-			}
-			if (!clearButton.hasAttribute('aria-label')) {
-				clearButton.setAttribute('aria-label', 'Clear')
-			}
-		}
+	for (const wrapper of wrappers) {
+		// Always check and patch every clear-control variant on each update.
+		// This handles dynamically created/removed clear buttons (e.g., when
+		// input value changes, or disabled/readonly/clearable props change).
+		patchClearControl(wrapper.querySelector('.el-input__clear'))
+		patchClearControl(wrapper.querySelector('.clear-icon'))
+		patchClearControl(wrapper.querySelector('.el-range__close-icon'))
 	}
 }
 


### PR DESCRIPTION
## What
Patch UI framework components (Ant Design, Element Plus) so PageAgent can recognize and interact with them correctly.

Fixes #290, #346

## Type
- [x] Bug fix
- [ ] Feature / Improvement
- [ ] Refactor / Chores
- [ ] Documentation / Website / Demo / Testing

## Problem

### 1. Ant Design Select not recognizable (Issue #290)
Ant Design's Select component uses a `div` wrapping an `input[role="combobox"]` structure. The `input` is invisible (`offsetWidth === 0`), so it never appears in the cleaned DOM tree. PageAgent cannot see or interact with it.

### 2. Element Plus components not recognizable (Issue #346)
Element Plus components (Input clear button, DatePicker, Select) lack `cursor: pointer` style on their interactive elements, causing `isInteractiveElement()` to return `false`.

## Solution

### 1. `antd.ts` patch (completed)
- Copy ARIA attributes (`aria-label`, `aria-expanded`, `aria-controls`) from hidden `input[role="combobox"]` to parent `.ant-select-selector`
- Add `data-antd-patched` marker to avoid duplicate processing
- Register in `PageController` constructor

### 2. `element-plus.ts` patch (new)
- Add `cursor: pointer !important` to Element Plus clear button
- Add `cursor: pointer` to DatePicker and Select triggers
- Add `data-element-plus-patched` marker
- Register in `PageController` constructor

## Testing

### Automated checks
- [x] `npm run lint` passed
- [x] `npm run typecheck` passed
- [x] `npm run build` passed

### Manual testing
- [x] Ant Design Select can be recognized and selected (tested on https://ant.design/components/select-cn)
- [x] Element Plus Select can be recognized and selected (tested on https://element-plus.org/en-US/component/select)
- [x] No console errors in modern browsers (Chrome 120+)

## Requirements / 要求
- [x] I have read and follow the [Code of Conduct](../docs/CODE_OF_CONDUCT.md) and [Contributing Guide](../CONTRIBUTING.md).
- [ ] This PR is NOT generated by a bot or AI agent acting autonomously. I have authored or meaningfully reviewed every change.

> **Note**: This PR was created with AI assistance but all changes have been manually verified by the author (see Testing section).