### PR TITLE
fix(extension): resolve React re-render disposal race condition and pass AbortSignal to hooks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6119,6 +6119,25 @@
                 "url": "https://ko-fi.com/dangreen"
             }
         },
+        "node_modules/git-raw-commits/node_modules/conventional-commits-parser": {
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
+            "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@simple-libs/stream-utils": "^1.2.0",
+                "meow": "^13.0.0"
+            },
+            "bin": {
+                "conventional-commits-parser": "dist/cli/index.js"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/git-raw-commits/node_modules/meow": {
             "version": "13.2.0",
             "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",

--- a/packages/core/src/PageAgentCore.ts
+++ b/packages/core/src/PageAgentCore.ts
@@ -246,10 +246,10 @@ export class PageAgentCore extends EventTarget {
 
 		// graceful exit
 		try {
-			await onBeforeTask?.(this)
+			await onBeforeTask?.(this, { signal })
 
 			while (true) {
-				await onBeforeStep?.(this, step)
+				await onBeforeStep?.(this, step, { signal })
 
 				// handle internal agent errors
 				try {
@@ -342,7 +342,7 @@ export class PageAgentCore extends EventTarget {
 					// @note hook may throw error.
 					// which will override the `break` above and be handled as an external error.
 					// as expected.
-					await onAfterStep?.(this, this.history)
+					await onAfterStep?.(this, this.history, { signal })
 				}
 
 				step++
@@ -358,7 +358,7 @@ export class PageAgentCore extends EventTarget {
 				}
 			} // while
 
-			await onAfterTask?.(this, taskResult)
+			await onAfterTask?.(this, taskResult, { signal })
 
 			return taskResult
 		} catch (error) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -78,31 +78,47 @@ export interface AgentConfig extends LLMConfig {
 	 * @experimental
 	 * @param agent - The PageAgentCore instance
 	 * @param stepCount - Current step number (0-indexed)
+	 * @param options - Options containing abort signal
 	 */
-	onBeforeStep?: (agent: PageAgentCore, stepCount: number) => Promise<void> | void
+	onBeforeStep?: (
+		agent: PageAgentCore,
+		stepCount: number,
+		options: { signal: AbortSignal }
+	) => Promise<void> | void
 
 	/**
 	 * Called after each step execution.
 	 * @experimental
 	 * @param agent - The PageAgentCore instance
 	 * @param history - Current history of events
+	 * @param options - Options containing abort signal
 	 */
-	onAfterStep?: (agent: PageAgentCore, history: HistoricalEvent[]) => Promise<void> | void
+	onAfterStep?: (
+		agent: PageAgentCore,
+		history: HistoricalEvent[],
+		options: { signal: AbortSignal }
+	) => Promise<void> | void
 
 	/**
 	 * Called before task execution starts.
 	 * @experimental
 	 * @param agent - The PageAgentCore instance
+	 * @param options - Options containing abort signal
 	 */
-	onBeforeTask?: (agent: PageAgentCore) => Promise<void> | void
+	onBeforeTask?: (agent: PageAgentCore, options: { signal: AbortSignal }) => Promise<void> | void
 
 	/**
 	 * Called after task execution completes (success or failure).
 	 * @experimental
 	 * @param agent - The PageAgentCore instance
 	 * @param result - The execution result
+	 * @param options - Options containing abort signal
 	 */
-	onAfterTask?: (agent: PageAgentCore, result: ExecutionResult) => Promise<void> | void
+	onAfterTask?: (
+		agent: PageAgentCore,
+		result: ExecutionResult,
+		options: { signal: AbortSignal }
+	) => Promise<void> | void
 
 	/**
 	 * Called when the agent is disposed.

--- a/packages/extension/src/agent/useAgent.ts
+++ b/packages/extension/src/agent/useAgent.ts
@@ -48,6 +48,50 @@ export function useAgent(): UseAgentResult {
 	const [currentTask, setCurrentTask] = useState('')
 	const [config, setConfig] = useState<ExtConfig | null>(null)
 
+	const cleanupRef = useRef<(() => void) | null>(null)
+
+	const setupAgent = useCallback((newConfig: ExtConfig) => {
+		if (cleanupRef.current) {
+			cleanupRef.current()
+			cleanupRef.current = null
+		}
+
+		const { systemInstruction, ...agentConfig } = newConfig
+		const agent = new MultiPageAgent({
+			...agentConfig,
+			instructions: systemInstruction ? { system: systemInstruction } : undefined,
+		})
+		agentRef.current = agent
+
+		const handleStatusChange = () => {
+			const newStatus = agent.status as AgentStatus
+			setStatus(newStatus)
+			if (newStatus !== 'running') {
+				setActivity(null)
+			}
+		}
+
+		const handleHistoryChange = () => {
+			setHistory([...agent.history])
+		}
+
+		const handleActivity = (e: Event) => {
+			const newActivity = (e as CustomEvent).detail as AgentActivity
+			setActivity(newActivity)
+		}
+
+		agent.addEventListener('statuschange', handleStatusChange)
+		agent.addEventListener('historychange', handleHistoryChange)
+		agent.addEventListener('activity', handleActivity)
+
+		cleanupRef.current = () => {
+			agent.removeEventListener('statuschange', handleStatusChange)
+			agent.removeEventListener('historychange', handleHistoryChange)
+			agent.removeEventListener('activity', handleActivity)
+			agent.dispose()
+		}
+	}, [])
+
 	useEffect(() => {
 		chrome.storage.local.get(['llmConfig', 'language', 'advancedConfig']).then((result) => {
 			let llmConfig = (result.llmConfig as LLMConfig) ?? DEMO_CONFIG
@@ -63,48 +107,18 @@ export function useAgent(): UseAgentResult {
 				chrome.storage.local.set({ llmConfig: DEMO_CONFIG })
 			}
 
-			setConfig({ ...llmConfig, ...advancedConfig, language })
+			const initialConfig = { ...llmConfig, ...advancedConfig, language }
+			setConfig(initialConfig)
+			setupAgent(initialConfig)
 		})
-	}, [])
-
-	useEffect(() => {
-		if (!config) return
-
-		const { systemInstruction, ...agentConfig } = config
-		const agent = new MultiPageAgent({
-			...agentConfig,
-			instructions: systemInstruction ? { system: systemInstruction } : undefined,
-		})
-		agentRef.current = agent
-
-		const handleStatusChange = (e: Event) => {
-			const newStatus = agent.status as AgentStatus
-			setStatus(newStatus)
-			if (newStatus !== 'running') {
-				setActivity(null)
-			}
-		}
-
-		const handleHistoryChange = (e: Event) => {
-			setHistory([...agent.history])
-		}
-
-		const handleActivity = (e: Event) => {
-			const newActivity = (e as CustomEvent).detail as AgentActivity
-			setActivity(newActivity)
-		}
-
-		agent.addEventListener('statuschange', handleStatusChange)
-		agent.addEventListener('historychange', handleHistoryChange)
-		agent.addEventListener('activity', handleActivity)
 
 		return () => {
-			agent.removeEventListener('statuschange', handleStatusChange)
-			agent.removeEventListener('historychange', handleHistoryChange)
-			agent.removeEventListener('activity', handleActivity)
-			agent.dispose()
+			if (cleanupRef.current) {
+				cleanupRef.current()
+				cleanupRef.current = null
+			}
 		}
-	}, [config])
+	}, [setupAgent])
 
 	const execute = useCallback(async (task: string) => {
 		const agent = agentRef.current
@@ -143,9 +157,11 @@ export function useAgent(): UseAgentResult {
 				disableNamedToolChoice,
 			}
 			await chrome.storage.local.set({ advancedConfig })
-			setConfig({ ...llmConfig, ...advancedConfig, language })
+			const newConfig = { ...llmConfig, ...advancedConfig, language }
+			setConfig(newConfig)
+			setupAgent(newConfig)
 		},
-		[]
+		[setupAgent]
 	)
 
 	return {


### PR DESCRIPTION
This PR resolves two issues in `alibaba/page-agent`:

1. **Fix instant "Task aborted" error when executing tasks via MCP (Issue #570)**:
   - **Root Cause**: When executing browser tasks via the Page Agent MCP server, the MCP client sends updated configuration (e.g. `LLM_API_KEY`) to the Hub. This updates the local storage, which triggers `setConfig()` in `useAgent.ts`. Because the `config` object changes, React immediately schedules a re-render. During re-render, the cleanup function of the config `useEffect` runs, calling `agent.dispose()` which aborts the task that was just initiated in the same tick.
   - **Fix**: Refactored `useAgent.ts` to manage the creation and disposal of the `MultiPageAgent` manually via a `setupAgent` callback, instead of reactively via `useEffect([config])`. We only recreate the agent when new configuration is set, avoiding any Reactive cleanup/dispose race condition while a task is running.

2. **Pass AbortSignal to all task execution hooks (Issue #555)**:
   - **Root Cause**: Hooks like `onBeforeTask`, `onBeforeStep`, `onAfterStep`, and `onAfterTask` did not receive the `AbortSignal` of the active task, preventing them from honoring task cancellation or aborting async operations gracefully.
   - **Fix**: Updated `PageAgentCore`'s hook definitions in `types.ts` and their invocations in `PageAgentCore.ts` to pass `{ signal: AbortSignal }` as the last parameter to all 4 execution lifecycle hooks.
