### PR TITLE
feat(core): pass AbortSignal to all task execution hooks

### DIFF
--- a/packages/core/src/PageAgentCore.ts
+++ b/packages/core/src/PageAgentCore.ts
@@ -246,10 +246,10 @@ export class PageAgentCore extends EventTarget {
 
 		// graceful exit
 		try {
-			await onBeforeTask?.(this)
+			await onBeforeTask?.(this, { signal })
 
 			while (true) {
-				await onBeforeStep?.(this, step)
+				await onBeforeStep?.(this, step, { signal })
 
 				// handle internal agent errors
 				try {
@@ -342,7 +342,7 @@ export class PageAgentCore extends EventTarget {
 					// @note hook may throw error.
 					// which will override the `break` above and be handled as an external error.
 					// as expected.
-					await onAfterStep?.(this, this.history)
+					await onAfterStep?.(this, this.history, { signal })
 				}
 
 				step++
@@ -358,7 +358,7 @@ export class PageAgentCore extends EventTarget {
 				}
 			} // while
 
-			await onAfterTask?.(this, taskResult)
+			await onAfterTask?.(this, taskResult, { signal })
 
 			return taskResult
 		} catch (error) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -78,31 +78,47 @@ export interface AgentConfig extends LLMConfig {
 	 * @experimental
 	 * @param agent - The PageAgentCore instance
 	 * @param stepCount - Current step number (0-indexed)
+	 * @param options - Options containing abort signal
 	 */
-	onBeforeStep?: (agent: PageAgentCore, stepCount: number) => Promise<void> | void
+	onBeforeStep?: (
+		agent: PageAgentCore,
+		stepCount: number,
+		options: { signal: AbortSignal }
+	) => Promise<void> | void
 
 	/**
 	 * Called after each step execution.
 	 * @experimental
 	 * @param agent - The PageAgentCore instance
 	 * @param history - Current history of events
+	 * @param options - Options containing abort signal
 	 */
-	onAfterStep?: (agent: PageAgentCore, history: HistoricalEvent[]) => Promise<void> | void
+	onAfterStep?: (
+		agent: PageAgentCore,
+		history: HistoricalEvent[],
+		options: { signal: AbortSignal }
+	) => Promise<void> | void
 
 	/**
 	 * Called before task execution starts.
 	 * @experimental
 	 * @param agent - The PageAgentCore instance
+	 * @param options - Options containing abort signal
 	 */
-	onBeforeTask?: (agent: PageAgentCore) => Promise<void> | void
+	onBeforeTask?: (agent: PageAgentCore, options: { signal: AbortSignal }) => Promise<void> | void
 
 	/**
 	 * Called after task execution completes (success or failure).
 	 * @experimental
 	 * @param agent - The PageAgentCore instance
 	 * @param result - The execution result
+	 * @param options - Options containing abort signal
 	 */
-	onAfterTask?: (agent: PageAgentCore, result: ExecutionResult) => Promise<void> | void
+	onAfterTask?: (
+		agent: PageAgentCore,
+		result: ExecutionResult,
+		options: { signal: AbortSignal }
+	) => Promise<void> | void
 
 	/**
 	 * Called when the agent is disposed.


### PR DESCRIPTION
This PR implements passing the `AbortSignal` to all task execution hooks (Issue #555):

### Root Cause
Currently, hooks such as `onBeforeTask`, `onBeforeStep`, `onAfterStep`, and `onAfterTask` do not receive the `AbortSignal` of the active task, which prevents them from honoring task cancellation or aborting async operations gracefully.

### Fix
Updated `PageAgentCore`'s hook definitions in `types.ts` and their invocations in `PageAgentCore.ts` to pass `{ signal: AbortSignal }` as the last parameter to all 4 execution lifecycle hooks.
