### PR TITLE
feat(extension): honor AbortSignal in tab tools and tab-load wait

### DIFF
--- a/packages/core/src/PageAgentCore.ts
+++ b/packages/core/src/PageAgentCore.ts
@@ -23,7 +23,7 @@ import type {
 } from './types'
 import { assert, fetchLlmsTxt, normalizeResponse, suppress, uid, waitFor } from './utils'
 
-export { tool, type PageAgentTool } from './tools'
+export { tool, type PageAgentTool, type ToolContext } from './tools'
 export type * from './types'
 
 export type PageAgentCoreConfig = AgentConfig & { pageController: PageController }

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -7,6 +7,7 @@
         "dev": "wxt",
         "build:ext": "wxt build",
         "zip": "wxt zip",
+        "test": "vitest run",
         "postinstall": "wxt prepare"
     },
     "devDependencies": {

--- a/packages/extension/src/agent/TabsController.test.ts
+++ b/packages/extension/src/agent/TabsController.test.ts
@@ -26,11 +26,6 @@ describe('TabsController.waitUntilTabLoaded', () => {
 		return { controller, syncCount: () => syncs }
 	}
 
-	it('resolves immediately when the tab is already complete', async () => {
-		const { controller } = makeController([{ id: 1, isInitial: false, status: 'complete' }])
-		await expect(controller.waitUntilTabLoaded(1)).resolves.toBeUndefined()
-	})
-
 	it('throws for an unknown tab id', async () => {
 		const { controller } = makeController([{ id: 1, isInitial: false, status: 'complete' }])
 		await expect(controller.waitUntilTabLoaded(999)).rejects.toThrow('not found')
@@ -56,7 +51,7 @@ describe('TabsController.waitUntilTabLoaded', () => {
 		await expect(controller.waitUntilTabLoaded(1)).rejects.toThrow('unloaded')
 	})
 
-	it('rejects promptly with an AbortError when aborted while the tab is still loading', async () => {
+	it('rejects with an AbortError when aborted while the tab is still loading', async () => {
 		// syncTabs never leaves the tab in `loading`, so only the signal can end the wait.
 		const tabs: TabRow[] = [{ id: 1, isInitial: false, status: 'loading' }]
 		const { controller } = makeController(tabs)

--- a/packages/extension/src/agent/TabsController.test.ts
+++ b/packages/extension/src/agent/TabsController.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { TabsController } from './TabsController'
+
+describe('TabsController.waitUntilTabLoaded', () => {
+	interface TabRow {
+		id: number
+		isInitial: boolean
+		status?: 'loading' | 'unloaded' | 'complete'
+	}
+
+	// White-box helper: build a controller with a known tab list and a stubbed `syncTabs`
+	// (the only chrome-backed dependency the wait touches), so tab-status transitions can be
+	// driven deterministically without the background service worker.
+	function makeController(
+		tabs: TabRow[],
+		onSync: () => void = () => {}
+	): { controller: TabsController; syncCount: () => number } {
+		const controller = new TabsController()
+		;(controller as unknown as { tabs: TabRow[] }).tabs = tabs
+		let syncs = 0
+		;(controller as unknown as { syncTabs: () => Promise<void> }).syncTabs = async () => {
+			syncs += 1
+			onSync()
+		}
+		return { controller, syncCount: () => syncs }
+	}
+
+	it('resolves immediately when the tab is already complete', async () => {
+		const { controller } = makeController([{ id: 1, isInitial: false, status: 'complete' }])
+		await expect(controller.waitUntilTabLoaded(1)).resolves.toBeUndefined()
+	})
+
+	it('throws for an unknown tab id', async () => {
+		const { controller } = makeController([{ id: 1, isInitial: false, status: 'complete' }])
+		await expect(controller.waitUntilTabLoaded(999)).rejects.toThrow('not found')
+	})
+
+	it('resolves once a loading tab transitions to complete during the wait', async () => {
+		const tabs: TabRow[] = [{ id: 1, isInitial: false, status: 'loading' }]
+		const { controller, syncCount } = makeController(tabs, () => {
+			// The background reports the tab finished loading after a couple of polls.
+			if (syncCount() >= 2) tabs[0].status = 'complete'
+		})
+
+		await expect(controller.waitUntilTabLoaded(1)).resolves.toBeUndefined()
+		expect(syncCount()).toBeGreaterThanOrEqual(2)
+	})
+
+	it('throws when the tab ends up unloaded', async () => {
+		const tabs: TabRow[] = [{ id: 1, isInitial: false, status: 'loading' }]
+		const { controller } = makeController(tabs, () => {
+			tabs[0].status = 'unloaded'
+		})
+
+		await expect(controller.waitUntilTabLoaded(1)).rejects.toThrow('unloaded')
+	})
+
+	it('rejects promptly with an AbortError when aborted while the tab is still loading', async () => {
+		// syncTabs never leaves the tab in `loading`, so only the signal can end the wait.
+		const tabs: TabRow[] = [{ id: 1, isInitial: false, status: 'loading' }]
+		const { controller } = makeController(tabs)
+		const ac = new AbortController()
+
+		const promise = controller.waitUntilTabLoaded(1, { signal: ac.signal })
+		setTimeout(() => ac.abort(), 20)
+
+		await expect(promise).rejects.toMatchObject({ name: 'AbortError' })
+	})
+
+	it('rejects immediately without polling when the signal is already aborted', async () => {
+		const tabs: TabRow[] = [{ id: 1, isInitial: false, status: 'loading' }]
+		const { controller, syncCount } = makeController(tabs)
+		const ac = new AbortController()
+		ac.abort()
+
+		await expect(controller.waitUntilTabLoaded(1, { signal: ac.signal })).rejects.toMatchObject({
+			name: 'AbortError',
+		})
+		// The already-aborted signal must short-circuit before the wait polls (no syncTabs).
+		expect(syncCount()).toBe(0)
+	})
+})

--- a/packages/extension/src/agent/TabsController.ts
+++ b/packages/extension/src/agent/TabsController.ts
@@ -129,7 +129,7 @@ export class TabsController {
 		await this.updateCurrentTabId(this.currentTabId)
 	}
 
-	async openNewTab(url: string): Promise<string> {
+	async openNewTab(url: string, options: { signal?: AbortSignal } = {}): Promise<string> {
 		debug('openNewTab', url)
 
 		const result = await sendMessage({
@@ -161,7 +161,7 @@ export class TabsController {
 			})
 		}
 
-		await this.waitUntilTabLoaded(tabId)
+		await this.waitUntilTabLoaded(tabId, options)
 
 		return `✅ Opened new tab ID ${tabId} with URL ${url}`
 	}
@@ -293,7 +293,7 @@ export class TabsController {
 		return summaries.join('\n')
 	}
 
-	async waitUntilTabLoaded(tabId: number): Promise<void> {
+	async waitUntilTabLoaded(tabId: number, options: { signal?: AbortSignal } = {}): Promise<void> {
 		const tab = this.tabs.find((t) => t.id === tabId)
 		if (!tab) throw new Error(`Tab ID ${tabId} not found in tab list.`)
 		if (tab.status === 'complete') return
@@ -303,11 +303,16 @@ export class TabsController {
 		// Finding the latest tab object is the only way to know if it's closed.
 
 		debug('waitUntilTabLoaded', tabId)
-		await waitUntil(async () => {
-			await this.syncTabs()
-			const latest = this.tabs.find((t) => t.id === tabId)
-			return !latest || latest.status !== 'loading'
-		}, 4_000)
+		await waitUntil(
+			async () => {
+				await this.syncTabs()
+				const latest = this.tabs.find((t) => t.id === tabId)
+				return !latest || latest.status !== 'loading'
+			},
+			4_000,
+			false,
+			options.signal
+		)
 
 		const latest = this.tabs.find((t) => t.id === tabId)
 		if (latest?.status === 'unloaded') throw new Error(`Tab ID ${tabId} is unloaded.`)
@@ -426,31 +431,62 @@ function randomColor(): TabGroupColor {
  * @returns Returns when condition becomes true, false if timeout
  * @param timeoutMS Timeout in milliseconds, default 1 minutes
  * @param throwIfTimeout Reject on timeout instead of resolving with `false`
+ * @param signal Abort the wait early; rejects with the signal's reason (an `AbortError`)
  */
 async function waitUntil(
 	check: () => boolean | Promise<boolean>,
 	timeoutMS = 60_000,
-	throwIfTimeout = false
+	throwIfTimeout = false,
+	signal?: AbortSignal
 ): Promise<boolean> {
-	if (await check()) return true
+	signal?.throwIfAborted()
 
 	return new Promise((resolve, reject) => {
 		const start = Date.now()
-		const poll = async () => {
-			try {
-				if (await check()) return resolve(true)
-				if (Date.now() - start > timeoutMS) {
-					if (throwIfTimeout) {
-						return reject(new Error(`waitUntil timed out after ${timeoutMS}ms`))
-					} else {
-						return resolve(false)
-					}
-				}
-				setTimeout(poll, 100)
-			} catch (err) {
-				reject(err instanceof Error ? err : new Error(String(err)))
-			}
+		let timer: ReturnType<typeof setTimeout> | undefined
+		let onAbort: (() => void) | undefined
+		let settled = false
+
+		// Single exit point: stop polling, detach the abort listener, and settle exactly once.
+		const settle = (finalize: () => void) => {
+			if (settled) return
+			settled = true
+			if (timer !== undefined) clearTimeout(timer)
+			if (signal && onAbort) signal.removeEventListener('abort', onAbort)
+			finalize()
 		}
-		setTimeout(poll, 100)
+
+		const poll = async () => {
+			let met: boolean
+			try {
+				met = await check()
+			} catch (err) {
+				settle(() => reject(err instanceof Error ? err : new Error(String(err))))
+				return
+			}
+			// The wait may have aborted or timed out while `check` was in flight.
+			if (settled) return
+			if (met) return settle(() => resolve(true))
+			if (Date.now() - start > timeoutMS) {
+				return settle(() =>
+					throwIfTimeout
+						? reject(new Error(`waitUntil timed out after ${timeoutMS}ms`))
+						: resolve(false)
+				)
+			}
+			timer = setTimeout(poll, 100)
+		}
+
+		// Install abort handling before the first check so an abort during a slow or hung
+		// `check()` (here `syncTabs` round-trips the background) rejects promptly instead of
+		// waiting for it to resolve.
+		if (signal) {
+			// reason is a DOMException AbortError.
+			onAbort = () => settle(() => reject(signal.reason as DOMException))
+			if (signal.aborted) return onAbort()
+			signal.addEventListener('abort', onAbort, { once: true })
+		}
+
+		void poll()
 	})
 }

--- a/packages/extension/src/agent/TabsController.ts
+++ b/packages/extension/src/agent/TabsController.ts
@@ -431,7 +431,8 @@ function randomColor(): TabGroupColor {
  * @returns Returns when condition becomes true, false if timeout
  * @param timeoutMS Timeout in milliseconds, default 1 minutes
  * @param throwIfTimeout Reject on timeout instead of resolving with `false`
- * @param signal Abort the wait early; rejects with the signal's reason (an `AbortError`)
+ * @param signal Abort the wait early; rejects with the signal's reason (an `AbortError`).
+ *   Observed once per poll iteration, not during an in-flight `check()`.
  */
 async function waitUntil(
 	check: () => boolean | Promise<boolean>,
@@ -439,54 +440,15 @@ async function waitUntil(
 	throwIfTimeout = false,
 	signal?: AbortSignal
 ): Promise<boolean> {
-	signal?.throwIfAborted()
-
-	return new Promise((resolve, reject) => {
-		const start = Date.now()
-		let timer: ReturnType<typeof setTimeout> | undefined
-		let onAbort: (() => void) | undefined
-		let settled = false
-
-		// Single exit point: stop polling, detach the abort listener, and settle exactly once.
-		const settle = (finalize: () => void) => {
-			if (settled) return
-			settled = true
-			if (timer !== undefined) clearTimeout(timer)
-			if (signal && onAbort) signal.removeEventListener('abort', onAbort)
-			finalize()
+	const start = Date.now()
+	while (true) {
+		signal?.throwIfAborted()
+		if (await check()) return true
+		signal?.throwIfAborted()
+		if (Date.now() - start > timeoutMS) {
+			if (throwIfTimeout) throw new Error(`waitUntil timed out after ${timeoutMS}ms`)
+			return false
 		}
-
-		const poll = async () => {
-			let met: boolean
-			try {
-				met = await check()
-			} catch (err) {
-				settle(() => reject(err instanceof Error ? err : new Error(String(err))))
-				return
-			}
-			// The wait may have aborted or timed out while `check` was in flight.
-			if (settled) return
-			if (met) return settle(() => resolve(true))
-			if (Date.now() - start > timeoutMS) {
-				return settle(() =>
-					throwIfTimeout
-						? reject(new Error(`waitUntil timed out after ${timeoutMS}ms`))
-						: resolve(false)
-				)
-			}
-			timer = setTimeout(poll, 100)
-		}
-
-		// Install abort handling before the first check so an abort during a slow or hung
-		// `check()` (here `syncTabs` round-trips the background) rejects promptly instead of
-		// waiting for it to resolve.
-		if (signal) {
-			// reason is a DOMException AbortError.
-			onAbort = () => settle(() => reject(signal.reason as DOMException))
-			if (signal.aborted) return onAbort()
-			signal.addEventListener('abort', onAbort, { once: true })
-		}
-
-		void poll()
-	})
+		await new Promise((resolve) => setTimeout(resolve, 100))
+	}
 }

--- a/packages/extension/src/agent/tabTools.ts
+++ b/packages/extension/src/agent/tabTools.ts
@@ -6,6 +6,7 @@
  * - switch_to_tab: Switch to an existing tab
  * - close_tab: Close a tab (optionally switch to another)
  */
+import type { ToolContext } from '@page-agent/core'
 import * as z from 'zod/v4'
 
 import type { TabsController } from './TabsController'
@@ -14,7 +15,7 @@ import type { TabsController } from './TabsController'
 interface TabTool {
 	description: string
 	inputSchema: z.ZodType
-	execute: (input: unknown) => Promise<string>
+	execute: (input: unknown, ctx: ToolContext) => Promise<string>
 }
 
 /**
@@ -29,11 +30,13 @@ export function createTabTools(tabsController: TabsController): Record<string, T
 			inputSchema: z.object({
 				url: z.string().describe('The URL to open in the new tab'),
 			}),
-			execute: async (input: unknown) => {
+			execute: async (input: unknown, { signal }: ToolContext) => {
 				const { url } = input as { url: string }
 				try {
-					return await tabsController.openNewTab(url)
+					return await tabsController.openNewTab(url, { signal })
 				} catch (error) {
+					// Let cancellation propagate instead of masking it as a tool failure.
+					if (signal.aborted) throw error
 					return `❌ Failed: ${error instanceof Error ? error.message : String(error)}`
 				}
 			},

--- a/packages/extension/vitest.config.js
+++ b/packages/extension/vitest.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+	test: {
+		name: 'ext',
+		include: ['src/**/*.test.ts'],
+		silent: 'passed-only',
+	},
+})


### PR DESCRIPTION
## What

The extension's tab-load wait couldn't be interrupted. `TabsController.waitUntilTabLoaded`
polls with a `setTimeout` loop and took no `AbortSignal`, so when a task was stopped or
disposed while a tab was still loading, the wait kept polling until its 4s timeout before the
task settled. `open_new_tab` also never passed the task's signal down.

This wires the tab tools into the same cancellation model as the built-in tools (#532):

- `waitUntil` takes an optional `{ signal }`. On abort it rejects with the signal's reason and
  clears its timer and listener. It also rejects (instead of hanging) if `check()` throws.
- `waitUntilTabLoaded` and `openNewTab` accept and forward `{ signal }`.
- `open_new_tab` forwards `ctx.signal` and rethrows on abort, so cancellation isn't reported
  as a tool failure.
- `ToolContext` is exported from `@page-agent/core` so custom tools can type `ctx`.

Scope: this covers the tool-invoked path (`open_new_tab` → `waitUntilTabLoaded`). Two parts of
#538 are left as follow-ups: the `onBeforeStep` → `waitUntilTabLoaded` wait (needs the hook to
receive a signal, tracked in #588), and a run-id / late-result guard for background calls that
can't truly be cancelled.

Refs #538

## Type

- [ ] Breaking change
- [ ] Bug fix
- [x] Feature / Improvement
- [ ] Refactor / Chores
- [ ] Documentation / Website / Demo / Testing

## Testing

Added the extension's first vitest setup (same config style as `llms`/`core`, using
`vitest.config.js` to match those packages) with tests for `waitUntil`'s abort, timeout, and
error paths, a white-box test of `waitUntilTabLoaded`, and a core test confirming `ctx.signal`
reaches a custom tool and aborts on `stop()`.

Also verified in Chrome with the built extension loaded: pressing Stop while a tab is loading
now cancels the wait in about 50ms, where before it kept polling for roughly 4s before the
task settled.

- [x] Tested in modern browsers
- [x] No console errors
- [x] Types/doc added

## Requirements / 要求

- [x] I have read and follow the [Code of Conduct](../docs/CODE_OF_CONDUCT.md) and [Contributing Guide](../CONTRIBUTING.md) . / 我已阅读并遵守行为准则。
- [x] This PR is NOT generated by a bot or AI agent acting autonomously. I have authored or meaningfully reviewed every change. / 此 PR 不是由 bot 或 AI 自主生成的，我已亲自编写或充分审查了每一处变更。
