### PR TITLE
fix(ci): format README and align markdown tooling with Prettier

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,21 +2,6 @@
     "files.exclude": {
         "packages/*/node_modules": true
     },
-    "markdownlint.config": {
-        // Relaxed rules
-        "default": true,
-        "whitespace": false,
-        "line_length": false,
-        "ul-indent": false,
-        "no-inline-html": false,
-        "no-bare-urls": false,
-        "fenced-code-language": false,
-        "first-line-h1": false,
-        "block-spacing": false,
-        "blanks-around-lists": false,
-        "ol-prefix": false,
-        "no-duplicate-heading": false
-    },
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "js/ts.tsdk.path": "node_modules/typescript/lib",
     "typescript.tsdk": "node_modules/typescript/lib",

--- a/README.md
+++ b/README.md
@@ -55,7 +55,10 @@ The GUI Agent Living in Your Webpage. One script gives any web page its own AI a
 Fastest way to try PageAgent with our free Demo LLM:
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/page-agent@1.11.0/dist/iife/page-agent.demo.js" crossorigin="anonymous"></script>
+<script
+    src="https://cdn.jsdelivr.net/npm/page-agent@1.11.0/dist/iife/page-agent.demo.js"
+    crossorigin="anonymous"
+></script>
 ```
 
 > **⚠️ For technical evaluation only.** This demo CDN uses our free [testing LLM API](https://alibaba.github.io/page-agent/docs/features/models#free-testing-api). By using it, you agree to its [terms](https://github.com/alibaba/page-agent/blob/main/docs/terms-and-privacy.md).

--- a/docs/README-zh.md
+++ b/docs/README-zh.md
@@ -54,7 +54,10 @@
 通过我们免费的 Demo LLM 快速体验 PageAgent：
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/page-agent@1.11.0/dist/iife/page-agent.demo.js" crossorigin="anonymous"></script>
+<script
+    src="https://cdn.jsdelivr.net/npm/page-agent@1.11.0/dist/iife/page-agent.demo.js"
+    crossorigin="anonymous"
+></script>
 ```
 
 > **⚠️ 仅用于技术评估。** 该 Demo CDN 使用了免费的[测试 LLM API](https://alibaba.github.io/page-agent/docs/features/models#free-testing-api)，使用即表示您同意其[条款](https://github.com/alibaba/page-agent/blob/main/docs/terms-and-privacy.md)。

--- a/package.json
+++ b/package.json
@@ -82,6 +82,9 @@
         ],
         "*.css": [
             "npx prettier --write --ignore-unknown"
+        ],
+        "*.md": [
+            "npx prettier --write --ignore-unknown"
         ]
     },
     "commitlint": {


### PR DESCRIPTION
## What

Fixes the main-branch CI failure caused by Prettier formatting in README files, removes unused VS Code markdownlint config, and adds `*.md` to lint-staged so markdown is formatted on commit.

## Type

- [ ] Breaking change
- [x] Bug fix
- [ ] Feature / Improvement
- [ ] Refactor / Chores
- [ ] Documentation / Website / Demo / Testing

## Testing

- [ ] Tested in modern browsers
- [ ] No console errors
- [ ] Types/doc added

Automated validation run locally:
- `npx prettier --check .` — pass
- `npm run lint` — pass

## Requirements / 要求

- [x] I have read and follow the [Code of Conduct](../docs/CODE_OF_CONDUCT.md) and [Contributing Guide](../CONTRIBUTING.md) . / 我已阅读并遵守行为准则。
- [x] This PR is NOT generated by a bot or AI agent acting autonomously. I have authored or meaningfully reviewed every change. / 此 PR 不是由 bot 或 AI 自主生成的，我已亲自编写或充分审查了每一处变更。