### PR TITLE
fix: wait for hub config before executing tasks

### DIFF
--- a/packages/extension/src/agent/useAgent.ts
+++ b/packages/extension/src/agent/useAgent.ts
@@ -47,6 +47,7 @@ export function useAgent(): UseAgentResult {
 	const [activity, setActivity] = useState<AgentActivity | null>(null)
 	const [currentTask, setCurrentTask] = useState('')
 	const [config, setConfig] = useState<ExtConfig | null>(null)
+	const agentReadyResolversRef = useRef<(() => void)[]>([])
 
 	useEffect(() => {
 		chrome.storage.local.get(['llmConfig', 'language', 'advancedConfig']).then((result) => {
@@ -97,11 +98,16 @@ export function useAgent(): UseAgentResult {
 		agent.addEventListener('statuschange', handleStatusChange)
 		agent.addEventListener('historychange', handleHistoryChange)
 		agent.addEventListener('activity', handleActivity)
+		const resolvers = agentReadyResolversRef.current.splice(0)
+		resolvers.forEach((resolve) => resolve())
 
 		return () => {
 			agent.removeEventListener('statuschange', handleStatusChange)
 			agent.removeEventListener('historychange', handleHistoryChange)
 			agent.removeEventListener('activity', handleActivity)
+			if (agentRef.current === agent) {
+				agentRef.current = null
+			}
 			agent.dispose()
 		}
 	}, [config])
@@ -143,7 +149,12 @@ export function useAgent(): UseAgentResult {
 				disableNamedToolChoice,
 			}
 			await chrome.storage.local.set({ advancedConfig })
-			setConfig({ ...llmConfig, ...advancedConfig, language })
+			const nextConfig = { ...llmConfig, ...advancedConfig, language }
+			const agentReady = new Promise<void>((resolve) => {
+				agentReadyResolversRef.current.push(resolve)
+			})
+			setConfig(nextConfig)
+			await agentReady
 		},
 		[]
 	)

--- a/packages/extension/src/entrypoints/hub/hub-ws.ts
+++ b/packages/extension/src/entrypoints/hub/hub-ws.ts
@@ -218,10 +218,11 @@ export function useHubWs(
 			Number(wsPort),
 			{
 				onExecute: async (task, incomingConfig) => {
-					const { execute, configure, config } = latestRef.current
+					const { configure, config } = latestRef.current
 					if (incomingConfig) {
 						await configure({ ...config, ...incomingConfig } as ExtConfig)
 					}
+					const { execute } = latestRef.current
 					const result = await execute(task)
 					return { success: result.success, data: result.data }
 				},


### PR DESCRIPTION
## Summary
- make extension configuration wait until the React agent instance has been recreated
- call the latest execute handler after applying incoming Hub task config
- clear stale agent refs when a config-driven agent instance is disposed

## Why
When the MCP server sends LLM config with an `execute` message, Hub calls `configure()` and then immediately calls `execute()`. `configure()` previously returned after scheduling React state only, so `execute()` could run against the old agent while React cleanup was disposing it. That aborts the task immediately.

## Validation
- `npm run typecheck`
- `npm test`
- `npm run lint`