### PR TITLE
chore: add self-hosted runners

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -3,10 +3,11 @@ name: Deploy Website
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: page-agent-trusted
     permissions:
       contents: read
       pages: write

--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -1,14 +1,17 @@
-name: CI
+# Runs only for code already on main, on the self-hosted runner.
+# PR-triggered CI must stay on GitHub-hosted runners (see ci.yml).
+name: Main CI
 permissions:
   contents: read
 
 on:
-  pull_request:
+  push:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: page-agent-trusted
     steps:
       - uses: actions/checkout@v7
         with:


### PR DESCRIPTION
## What

Move main-branch CI and website deploy onto the `page-agent-trusted` self-hosted runner; keep PR CI on GitHub-hosted `ubuntu-latest`.

## Type

- [ ] Breaking change
- [ ] Bug fix
- [ ] Feature / Improvement
- [x] Refactor / Chores
- [ ] Documentation / Website / Demo / Testing

## Testing

- [x] `npm run ci` passes
- [ ] Tested in modern browsers
- [ ] Types/doc added

Automated validation: `npm run ci` passed (lint, format, typecheck, tests, build).

## Requirements / 要求

- [x] I have read and follow the [Code of Conduct](../docs/CODE_OF_CONDUCT.md) and [Contributing Guide](../CONTRIBUTING.md) . / 我已阅读并遵守行为准则。
- [x] This PR is NOT generated by a bot or AI agent acting autonomously. I have authored or meaningfully reviewed every change. / 此 PR 不是由 bot 或 AI 自主生成的，我已亲自编写或充分审查了每一处变更。