### PR TITLE
chore(llms): limit live test concurrency

### DIFF
--- a/packages/llms/vitest.config.js
+++ b/packages/llms/vitest.config.js
@@ -4,6 +4,8 @@ export default defineConfig({
 	test: {
 		name: 'llms',
 		include: ['src/**/*.test.ts'],
+		// Keep live provider suites under OpenRouter's ~20 req/min free-route cap.
+		maxConcurrency: 2,
 		// Suppress console output from passing tests; failed tests still get their logs.
 		silent: 'passed-only',
 	},


### PR DESCRIPTION
## What

Cap Vitest `maxConcurrency` at 2 so live OpenRouter suites stay under the free-route rate limit.

## Type

- [ ] Breaking change
- [ ] Bug fix
- [ ] Feature / Improvement
- [x] Refactor / Chores
- [ ] Documentation / Website / Demo / Testing

## Testing

- [x] `npm run ci` passes
- [ ] Tested in modern browsers
- [ ] Types/doc added

Validation note: `npm run ci` passed locally (live provider tests skipped via empty `TESTING_*_KEY`).

## Requirements / 要求

- [x] I have read and follow the [Code of Conduct](../docs/CODE_OF_CONDUCT.md) and [Contributing Guide](../CONTRIBUTING.md) . / 我已阅读并遵守行为准则。
- [x] This PR is NOT generated by a bot or AI agent acting autonomously. I have authored or meaningfully reviewed every change. / 此 PR 不是由 bot 或 AI 自主生成的，我已亲自编写或充分审查了每一处变更。