### PR TITLE
chore(ci): remove workflow_dispatch from main workflows

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -3,7 +3,6 @@ name: Deploy Website
 on:
   push:
     branches: [main]
-  workflow_dispatch:
 
 jobs:
   deploy:

--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -7,7 +7,6 @@ permissions:
 on:
   push:
     branches: [main]
-  workflow_dispatch:
 
 jobs:
   test:


### PR DESCRIPTION
## What

Remove `workflow_dispatch` from `main-ci` and `deploy-website` so they only run on push to `main`.

## Type

- [ ] Breaking change
- [ ] Bug fix
- [ ] Feature / Improvement
- [x] Refactor / Chores
- [ ] Documentation / Website / Demo / Testing

## Testing

- [x] `npm run ci` passes
- [ ] Tested in modern browsers
- [ ] Types/doc added

Automated validation in this session: `npm run ci` passed (lint, format, typecheck, tests, build).

## Requirements / 要求

- [x] I have read and follow the [Code of Conduct](../docs/CODE_OF_CONDUCT.md) and [Contributing Guide](../CONTRIBUTING.md) . / 我已阅读并遵守行为准则。
- [x] This PR is NOT generated by a bot or AI agent acting autonomously. I have authored or meaningfully reviewed every change. / 此 PR 不是由 bot 或 AI 自主生成的，我已亲自编写或充分审查了每一处变更。