### PR TITLE
docs: update mcp-server

### DIFF
--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -19,16 +19,16 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
     "mcpServers": {
         "page-agent": {
             "command": "npx",
-            "args": ["-y", "@page-agent/mcp"],
-            "env": {
-                "LLM_BASE_URL": "https://dashscope.aliyuncs.com/compatible-mode/v1",
-                "LLM_API_KEY": "sk-xxx",
-                "LLM_MODEL_NAME": "qwen3.5-plus"
-            }
+            "args": ["-y", "@page-agent/mcp"]
         }
     }
 }
 ```
+
+Configure LLM credentials in Page Agent Ext. Avoid passing `LLM_*` from MCP client
+configuration because it can trigger the Hub to rebuild the extension agent while a task is
+starting, causing `Task aborted`.
+Configure the URL, API key, and model in the browser extension.
 
 ### Cursor / Copilot
 


### PR DESCRIPTION
## What

Updates the @page-agent/mcp setup example to omit `LLM_*` env variables and directs users to configure the URL, API key, and model in the browser extension.

Closes #(issue)

## Type

- [ ] Breaking change
- [ ] Bug fix
- [ ] Feature / Improvement
- [ ] Refactor / Chores
- [x] Documentation / Website / Demo / Testing

## Testing

- [x] `npm run ci` passes
- [ ] Tested in modern browsers
- [ ] Types/doc added

Validation run:
- `npx prettier --check packages/mcp/README.md` passes.
- `npm run lint` passes.
- `npm run typecheck` passes after `npm run postinstall -w @page-agent/ext`.
- `npm test` passes.
- `npm run ci` was attempted with Node v24.16.0 and npm 11.13.0, but the format step failed on existing repository-wide Prettier warnings outside this change.

## Requirements / 要求

- [x] I have read and follow the [Code of Conduct](../docs/CODE_OF_CONDUCT.md) and [Contributing Guide](../CONTRIBUTING.md) . / 我已阅读并遵守行为准则。
- [x] This PR is NOT generated by a bot or AI agent acting autonomously. I have authored or meaningfully reviewed every change. / 此 PR 不是由 bot 或 AI 自主生成的，我已亲自编写或充分审查了每一处变更。
