### PR TITLE
fix(ci): pin release workflow to npm 11

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,9 +23,9 @@ jobs:
           node-version: 24
           registry-url: 'https://registry.npmjs.org'
 
-      # Ensure npm 11.5.1 or later is installed
+      # Stay on the latest npm 11 release
       - name: Update npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## What

Pin the release workflow to `npm@11` so `npm install -g npm@latest` no longer pulls npm 12, whose install-time security defaults break the release pipeline.

## Type

- [ ] Breaking change
- [x] Bug fix
- [ ] Feature / Improvement
- [ ] Refactor / Chores
- [ ] Documentation / Website / Demo / Testing

## Testing

- [x] `npm run ci` passes
- [ ] Tested in modern browsers
- [ ] Types/doc added

Validation note: `npm run ci` passed locally (lint, format, typecheck, unit tests, build). Live LLM model tests were skipped to match GitHub CI (no provider keys).

## Requirements / 要求

- [x] I have read and follow the [Code of Conduct](../docs/CODE_OF_CONDUCT.md) and [Contributing Guide](../CONTRIBUTING.md) . / 我已阅读并遵守行为准则。
- [x] This PR is NOT generated by a bot or AI agent acting autonomously. I have authored or meaningfully reviewed every change. / 此 PR 不是由 bot 或 AI 自主生成的，我已亲自编写或充分审查了每一处变更。