### PR TITLE
docs: CDN quick start in README and website

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,15 +59,14 @@ Fastest way to try PageAgent with our free Demo LLM:
     src="https://cdn.jsdelivr.net/npm/page-agent@1.12.1/dist/iife/page-agent.demo.js"
     crossorigin="anonymous"
 ></script>
+
+<!-- China CDN mirror if you can't access jsDelivr -->
+<!-- https://registry.npmmirror.com/page-agent/1.12.1/files/dist/iife/page-agent.demo.js -->
 ```
 
 > **⚠️ For technical evaluation only.** This demo CDN uses our free [testing LLM API](https://alibaba.github.io/page-agent/docs/features/models#free-testing-api). By using it, you agree to its [terms](https://github.com/alibaba/page-agent/blob/main/docs/terms-and-privacy.md).
-> Add `?autoInit=false` to load the script without creating the demo agent automatically. You can then instantiate it with `new window.PageAgent(...)`.
-
-| Mirrors | URL                                                                                 |
-| ------- | ----------------------------------------------------------------------------------- |
-| Global  | https://cdn.jsdelivr.net/npm/page-agent@1.12.1/dist/iife/page-agent.demo.js         |
-| China   | https://registry.npmmirror.com/page-agent/1.12.1/files/dist/iife/page-agent.demo.js |
+>
+> Add `?autoInit=false` to load the script without creating the demo agent automatically. You can then instantiate it with `new window.PageAgent(...)` and your own LLMs.
 
 ### NPM Installation
 

--- a/docs/README-zh.md
+++ b/docs/README-zh.md
@@ -55,18 +55,14 @@
 
 ```html
 <script
-    src="https://cdn.jsdelivr.net/npm/page-agent@1.12.1/dist/iife/page-agent.demo.js"
+    src="https://registry.npmmirror.com/page-agent/1.12.1/files/dist/iife/page-agent.demo.js"
     crossorigin="anonymous"
 ></script>
 ```
 
 > **⚠️ 仅用于技术评估。** 该 Demo CDN 使用了免费的[测试 LLM API](https://alibaba.github.io/page-agent/docs/features/models#free-testing-api)，使用即表示您同意其[条款](https://github.com/alibaba/page-agent/blob/main/docs/terms-and-privacy.md)。
-> 在 URL 后添加 `?autoInit=false` 可只加载脚本，不自动创建 Demo Agent；之后可通过 `new window.PageAgent(...)` 手动初始化。
-
-| Mirrors | URL                                                                                 |
-| ------- | ----------------------------------------------------------------------------------- |
-| Global  | https://cdn.jsdelivr.net/npm/page-agent@1.12.1/dist/iife/page-agent.demo.js         |
-| China   | https://registry.npmmirror.com/page-agent/1.12.1/files/dist/iife/page-agent.demo.js |
+>
+> 在 URL 后添加 `?autoInit=false` 可只加载脚本，不自动创建 Demo Agent，之后可通过 `new window.PageAgent(...)` 手动初始化，并使用自定义 LLM。
 
 ### NPM 安装
 

--- a/packages/website/src/pages/docs/introduction/quick-start/page.tsx
+++ b/packages/website/src/pages/docs/introduction/quick-start/page.tsx
@@ -10,7 +10,8 @@ export default function QuickStart() {
 	const [cdnSource, setCdnSource] = useState<'international' | 'china'>(
 		isZh ? 'china' : 'international'
 	)
-	const cdnUrl = cdnSource === 'china' ? CDN_DEMO_CN_URL : CDN_DEMO_URL
+	const cdnBase = cdnSource === 'china' ? CDN_DEMO_CN_URL : CDN_DEMO_URL
+	const cdnUrl = `${cdnBase}?lang=${isZh ? 'zh-CN' : 'en-US'}`
 
 	return (
 		<div>
@@ -80,8 +81,8 @@ export default function QuickStart() {
 					/>
 					<p className="text-sm text-gray-600 dark:text-gray-300">
 						{isZh
-							? '在 URL 后添加 ?autoInit=false 可只加载脚本，不自动创建 Demo Agent，之后可通过 new window.PageAgent(...) 手动初始化，并使用自定义 LLM。'
-							: 'Add ?autoInit=false to load the script without creating the demo agent automatically. You can then instantiate it with new window.PageAgent(...) and your own LLMs.'}
+							? '添加 autoInit=false 参数可只加载脚本，不自动创建 Demo Agent，之后可通过 new window.PageAgent(...) 手动初始化，并使用自定义 LLM。'
+							: 'Add the autoInit=false parameter to load the script without creating the demo agent automatically. You can then instantiate it with new window.PageAgent(...) and your own LLMs.'}
 					</p>
 				</div>
 

--- a/packages/website/src/pages/docs/introduction/quick-start/page.tsx
+++ b/packages/website/src/pages/docs/introduction/quick-start/page.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react'
+
 import CodeEditor from '@/components/CodeEditor'
 import { Heading } from '@/components/Heading'
 import { CDN_DEMO_CN_URL, CDN_DEMO_URL } from '@/constants'
@@ -5,6 +7,10 @@ import { useLanguage } from '@/i18n/context'
 
 export default function QuickStart() {
 	const { isZh } = useLanguage()
+	const [cdnSource, setCdnSource] = useState<'international' | 'china'>(
+		isZh ? 'china' : 'international'
+	)
+	const cdnUrl = cdnSource === 'china' ? CDN_DEMO_CN_URL : CDN_DEMO_URL
 
 	return (
 		<div>
@@ -54,35 +60,29 @@ export default function QuickStart() {
 							)}
 						</span>
 					</div>
+					<div className="flex items-center gap-2 text-sm">
+						<label htmlFor="cdn-source" className="text-gray-700 dark:text-gray-300">
+							{isZh ? '镜像：' : 'Mirror:'}
+						</label>
+						<select
+							id="cdn-source"
+							value={cdnSource}
+							onChange={(e) => setCdnSource(e.target.value as 'international' | 'china')}
+							className="px-2 py-1.5 text-xs border border-gray-300 dark:border-gray-500 rounded bg-white dark:bg-gray-600 text-gray-700 dark:text-gray-200"
+						>
+							<option value="international">jsdelivr CDN {isZh ? '（全球）' : '(Global)'}</option>
+							<option value="china">npmmirror CDN {isZh ? '（中国）' : '(China)'}</option>
+						</select>
+					</div>
 					<CodeEditor
-						code={`<script src="DEMO_CDN_URL" crossorigin="true"></script>`}
+						code={`<script src="${cdnUrl}" crossorigin="anonymous"></script>`}
 						language="html"
 					/>
-					<p className="text-sm text-gray-600 dark:text-gray-300 mb-3">
+					<p className="text-sm text-gray-600 dark:text-gray-300">
 						{isZh
-							? '在 URL 后添加 ?autoInit=false 可只加载脚本，不自动创建 Demo Agent；之后可通过 new window.PageAgent(...) 手动初始化。'
-							: 'Add ?autoInit=false to load the script without creating the demo agent automatically. You can then instantiate it with new window.PageAgent(...).'}
+							? '在 URL 后添加 ?autoInit=false 可只加载脚本，不自动创建 Demo Agent，之后可通过 new window.PageAgent(...) 手动初始化，并使用自定义 LLM。'
+							: 'Add ?autoInit=false to load the script without creating the demo agent automatically. You can then instantiate it with new window.PageAgent(...) and your own LLMs.'}
 					</p>
-					<table className="w-full border-collapse text-sm">
-						<thead>
-							<tr className="border-b border-gray-200 dark:border-gray-700">
-								<th className="text-left py-2 px-3 font-semibold w-28">
-									{isZh ? '镜像' : 'Mirrors'}
-								</th>
-								<th className="text-left py-2 px-3 font-semibold">URL</th>
-							</tr>
-						</thead>
-						<tbody>
-							<tr className="border-b border-gray-100 dark:border-gray-800">
-								<td className="py-2 px-3">{isZh ? '全球' : 'Global'}</td>
-								<td className="py-2 px-3 font-mono text-xs break-all">{CDN_DEMO_URL}</td>
-							</tr>
-							<tr>
-								<td className="py-2 px-3">{isZh ? '中国' : 'China'}</td>
-								<td className="py-2 px-3 font-mono text-xs break-all">{CDN_DEMO_CN_URL}</td>
-							</tr>
-						</tbody>
-					</table>
 				</div>
 
 				{/* NPM - Recommended */}


### PR DESCRIPTION
## What

Simplify CDN quick start in EN/ZH READMEs, and replace the website docs mirrors table with a jsDelivr / npmmirror dropdown that also follows the page language (`?lang=`), same pattern as the homepage bookmarklet.

## Type

- [ ] Breaking change
- [ ] Bug fix
- [ ] Feature / Improvement
- [ ] Refactor / Chores
- [x] Documentation / Website / Demo / Testing

## Testing

- [x] `npm run ci` passes
- [ ] Tested in modern browsers
- [ ] Types/doc added

Automated validation: `npm run ci` (lint, format, typecheck, test, build incl. website) — passed.

## Requirements / 要求

- [x] I have read and follow the [Code of Conduct](../docs/CODE_OF_CONDUCT.md) and [Contributing Guide](../CONTRIBUTING.md) . / 我已阅读并遵守行为准则。
- [x] This PR is NOT generated by a bot or AI agent acting autonomously. I have authored or meaningfully reviewed every change. / 此 PR 不是由 bot 或 AI 自主生成的，我已亲自编写或充分审查了每一处变更。