### PR TITLE
fix(extension): don't abort hub tasks when configure precedes execute

### DIFF
--- a/packages/extension/src/agent/useAgent.ts
+++ b/packages/extension/src/agent/useAgent.ts
@@ -40,6 +40,15 @@ export interface UseAgentResult {
 	configure: (config: ExtConfig) => Promise<void>
 }
 
+/** Compare configs by value, treating missing keys and `undefined` as equal */
+function isSameConfig(a: ExtConfig, b: ExtConfig): boolean {
+	const keys = new Set([...Object.keys(a), ...Object.keys(b)]) as Set<keyof ExtConfig>
+	for (const key of keys) {
+		if (a[key] !== b[key]) return false
+	}
+	return true
+}
+
 export function useAgent(): UseAgentResult {
 	const agentRef = useRef<MultiPageAgent | null>(null)
 	const [status, setStatus] = useState<AgentStatus>('idle')
@@ -47,6 +56,10 @@ export function useAgent(): UseAgentResult {
 	const [activity, setActivity] = useState<AgentActivity | null>(null)
 	const [currentTask, setCurrentTask] = useState('')
 	const [config, setConfig] = useState<ExtConfig | null>(null)
+	const configRef = useRef<ExtConfig | null>(null)
+	configRef.current = config
+	/** Callers awaiting the agent rebuild triggered by their setConfig */
+	const configReadyResolversRef = useRef<(() => void)[]>([])
 
 	useEffect(() => {
 		chrome.storage.local.get(['llmConfig', 'language', 'advancedConfig']).then((result) => {
@@ -98,6 +111,10 @@ export function useAgent(): UseAgentResult {
 		agent.addEventListener('historychange', handleHistoryChange)
 		agent.addEventListener('activity', handleActivity)
 
+		const resolvers = configReadyResolversRef.current
+		configReadyResolversRef.current = []
+		for (const resolve of resolvers) resolve()
+
 		return () => {
 			agent.removeEventListener('statuschange', handleStatusChange)
 			agent.removeEventListener('historychange', handleHistoryChange)
@@ -143,7 +160,20 @@ export function useAgent(): UseAgentResult {
 				disableNamedToolChoice,
 			}
 			await chrome.storage.local.set({ advancedConfig })
-			setConfig({ ...llmConfig, ...advancedConfig, language })
+
+			const next: ExtConfig = { ...llmConfig, ...advancedConfig, language }
+			// Unchanged config must not rebuild the agent: the [config] effect's
+			// cleanup would dispose an agent that a caller (e.g. the hub, which
+			// configures right before execute) is about to run, aborting its task.
+			if (configRef.current && isSameConfig(configRef.current, next)) return
+
+			// Resolve only after the [config] effect has installed the new agent,
+			// so callers never execute on the agent that is being disposed.
+			const ready = new Promise<void>((resolve) => {
+				configReadyResolversRef.current.push(resolve)
+			})
+			setConfig(next)
+			await ready
 		},
 		[]
 	)


### PR DESCRIPTION
Fixes #570

## Problem

Every task sent through the MCP server fails instantly with **"Task aborted"** whenever any of `LLM_BASE_URL` / `LLM_API_KEY` / `LLM_MODEL_NAME` is set — even when those values are identical to the extension's saved settings. The extension popup works fine, and the hub makes **zero** network requests before failing.

## Root cause

`packages/mcp` attaches a `config` object to every `execute` message when LLM env vars are set. In the hub, `useHubWs.onExecute` then does:

```ts
if (incomingConfig) {
  await configure({ ...config, ...incomingConfig } as ExtConfig)
}
const result = await execute(task)
```

`configure()` calls `setConfig()` in `useAgent`, which re-renders and re-runs the `useEffect([config])`. That effect's **cleanup disposes the current agent** and installs a new one — but `execute()` resolves `agentRef` *before* React commits the new agent, so the task starts (or is about to start) on the agent being disposed. `dispose()` fires its `AbortController`, and `PageAgentCore` returns the literal `"Task aborted"`.

Observable in the hub tab's console on every MCP run: `init` → `Disposing PageAgent...` → `dispose`.

## Fix (in `useAgent.configure()`)

1. **Value-equal config → skip the rebuild.** If the merged config equals the current one (the common MCP case, since the env config usually mirrors saved settings), don't `setConfig` at all — no re-render, no dispose. Storage writes still happen.
2. **Changed config → await the rebuild.** `configure()` now resolves only after the `[config]` effect has installed the new agent, so callers never `execute()` on an agent whose dispose is already scheduled.

## Verification

- `npm run typecheck`, `npm test` (17/17), `npm run lint`, `npm run build:ext` all pass.
- Runtime-verified the equivalent behavior end-to-end: with config no longer triggering a rebuild before execute, MCP `execute_task` completes successfully through hub → extension → LLM → page (previously 100% instant abort).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
