### PR TITLE
feat: upload_file tool — let MCP callers provide files for upload into page file inputs

### DIFF
--- a/packages/extension/src/agent/MultiPageAgent.ts
+++ b/packages/extension/src/agent/MultiPageAgent.ts
@@ -4,6 +4,7 @@ import { RemotePageController } from './RemotePageController'
 import { TabsController } from './TabsController'
 import SYSTEM_PROMPT from './system_prompt.md?raw'
 import { createTabTools } from './tabTools'
+import { createUploadTools } from './uploadTools'
 
 /** Detect user language from browser settings */
 function detectLanguage(): 'en-US' | 'zh-CN' {
@@ -26,7 +27,10 @@ export class MultiPageAgent extends PageAgentCore {
 		// multi page controller
 		const tabsController = new TabsController()
 		const pageController = new RemotePageController(tabsController)
-		const customTools = createTabTools(tabsController)
+		const customTools = {
+			...createTabTools(tabsController),
+			...createUploadTools(pageController),
+		}
 
 		// system prompt - auto-detect language if not specified
 		const language = config.language ?? detectLanguage()

--- a/packages/extension/src/agent/RemotePageController.content.ts
+++ b/packages/extension/src/agent/RemotePageController.content.ts
@@ -79,6 +79,7 @@ export function initPageController() {
 			case 'click_element':
 			case 'input_text':
 			case 'select_option':
+			case 'upload_file':
 			case 'scroll':
 			case 'scroll_horizontally':
 			case 'execute_javascript':
@@ -122,6 +123,8 @@ function getMethodName(action: string): string {
 			return 'inputText' as const
 		case 'select_option':
 			return 'selectOption' as const
+		case 'upload_file':
+			return 'uploadFile' as const
 		case 'scroll':
 			return 'scroll' as const
 		case 'scroll_horizontally':

--- a/packages/extension/src/agent/RemotePageController.ts
+++ b/packages/extension/src/agent/RemotePageController.ts
@@ -125,6 +125,10 @@ export class RemotePageController {
 		return this.remoteCallDomAction('select_option', args)
 	}
 
+	async uploadFile(...args: any[]): Promise<DomActionReturn> {
+		return this.remoteCallDomAction('upload_file', args)
+	}
+
 	async scroll(...args: any[]): Promise<DomActionReturn> {
 		return this.remoteCallDomAction('scroll', args)
 	}

--- a/packages/extension/src/agent/uploadTools.ts
+++ b/packages/extension/src/agent/uploadTools.ts
@@ -1,0 +1,116 @@
+/**
+ * File upload tool for the browser extension.
+ *
+ * Files are provided by an external caller (the MCP server) per task:
+ * the hub registers their metadata here, the caller serves the bytes over
+ * its local HTTP bridge, and the tool fetches + injects them into a file
+ * input on the page via the content script.
+ */
+import * as z from 'zod/v4'
+
+import type { RemotePageController } from './RemotePageController'
+
+/** Metadata of a file the external caller offers for upload. */
+export interface RemoteUploadFile {
+	/** Opaque id assigned by the caller; also the download route key */
+	id: string
+	name: string
+	/** MIME type; empty string treated as application/octet-stream */
+	mime: string
+	size: number
+}
+
+/**
+ * Base64 of the raw bytes must survive a chrome.runtime message.
+ * Chrome caps messages at ~64 MB; leave generous headroom.
+ */
+const MAX_FILE_SIZE = 32 * 1024 * 1024
+
+let availableFiles: RemoteUploadFile[] = []
+let bridgePort: number | null = null
+
+/** Register the files offered for the current task. Call with [] to clear. */
+export function setAvailableUploadFiles(files: RemoteUploadFile[], port: number | null): void {
+	availableFiles = files
+	bridgePort = port
+}
+
+/**
+ * Task-prompt block describing the offered files, so the model knows the
+ * valid file_id values. Empty string when no files are registered.
+ */
+export function describeAvailableUploadFiles(): string {
+	if (availableFiles.length === 0) return ''
+	const lines = availableFiles.map(
+		(f) => `- ${f.name} (file_id: ${f.id}, ${(f.size / 1024).toFixed(1)} KB)`
+	)
+	return `\n\nFiles provided by the caller, available to the upload_file tool:\n${lines.join('\n')}`
+}
+
+function toBase64(buffer: ArrayBuffer): string {
+	const bytes = new Uint8Array(buffer)
+	let binary = ''
+	const chunk = 0x8000
+	for (let i = 0; i < bytes.length; i += chunk) {
+		binary += String.fromCharCode(...bytes.subarray(i, i + chunk))
+	}
+	return btoa(binary)
+}
+
+/** Tool definition compatible with PageAgentCore customTools */
+interface UploadTool {
+	description: string
+	inputSchema: z.ZodType
+	execute: (input: unknown) => Promise<string>
+}
+
+/**
+ * Create the upload_file tool bound to a RemotePageController.
+ * Injected into PageAgentCore via customTools config.
+ */
+export function createUploadTools(
+	pageController: RemotePageController
+): Record<string, UploadTool> {
+	return {
+		upload_file: {
+			description:
+				'Upload a file provided by the caller into a file input on the page. ' +
+				'Use the index of the file input itself, or of the visible upload button/label/dropzone ' +
+				'(the hidden input is resolved automatically). Only file_id values listed in the task are valid. ' +
+				'If the page opens a file-picker dialog when clicking upload, use this tool INSTEAD of clicking.',
+			inputSchema: z.object({
+				index: z.int().min(0).describe('Index of the file input or upload button/dropzone'),
+				file_id: z.string().describe('file_id of a provided file, as listed in the task'),
+			}),
+			execute: async (input: unknown) => {
+				const { index, file_id } = input as { index: number; file_id: string }
+				try {
+					const file = availableFiles.find((f) => f.id === file_id)
+					if (!file) {
+						const ids = availableFiles.map((f) => f.id).join(', ') || '(none)'
+						return `❌ Unknown file_id "${file_id}". Available: ${ids}`
+					}
+					if (bridgePort === null) {
+						return '❌ No file bridge available. Files can only be uploaded when provided by the caller.'
+					}
+					if (file.size > MAX_FILE_SIZE) {
+						return `❌ File too large (${file.size} bytes). Max supported size is ${MAX_FILE_SIZE} bytes.`
+					}
+
+					const res = await fetch(`http://localhost:${bridgePort}/files/${file.id}`)
+					if (!res.ok) {
+						return `❌ Failed to fetch file from caller: HTTP ${res.status}`
+					}
+					const dataBase64 = toBase64(await res.arrayBuffer())
+
+					const result = await pageController.uploadFile(index, [
+						{ name: file.name, type: file.mime || 'application/octet-stream', dataBase64 },
+					])
+					return result.message
+				} catch (error) {
+					return `❌ Failed: ${error instanceof Error ? error.message : String(error)}`
+				}
+			},
+		},
+	}
+}

--- a/packages/extension/src/agent/useAgent.ts
+++ b/packages/extension/src/agent/useAgent.ts
@@ -40,6 +40,15 @@ export interface UseAgentResult {
 	configure: (config: ExtConfig) => Promise<void>
 }
 
+/** Compare configs by value, treating missing keys and `undefined` as equal */
+function isSameConfig(a: ExtConfig, b: ExtConfig): boolean {
+	const keys = new Set([...Object.keys(a), ...Object.keys(b)]) as Set<keyof ExtConfig>
+	for (const key of keys) {
+		if (a[key] !== b[key]) return false
+	}
+	return true
+}
+
 export function useAgent(): UseAgentResult {
 	const agentRef = useRef<MultiPageAgent | null>(null)
 	const [status, setStatus] = useState<AgentStatus>('idle')
@@ -47,6 +56,10 @@ export function useAgent(): UseAgentResult {
 	const [activity, setActivity] = useState<AgentActivity | null>(null)
 	const [currentTask, setCurrentTask] = useState('')
 	const [config, setConfig] = useState<ExtConfig | null>(null)
+	const configRef = useRef<ExtConfig | null>(null)
+	configRef.current = config
+	/** Callers awaiting the agent rebuild triggered by their setConfig */
+	const configReadyResolversRef = useRef<(() => void)[]>([])
 
 	useEffect(() => {
 		chrome.storage.local.get(['llmConfig', 'language', 'advancedConfig']).then((result) => {
@@ -98,6 +111,10 @@ export function useAgent(): UseAgentResult {
 		agent.addEventListener('historychange', handleHistoryChange)
 		agent.addEventListener('activity', handleActivity)
 
+		const resolvers = configReadyResolversRef.current
+		configReadyResolversRef.current = []
+		for (const resolve of resolvers) resolve()
+
 		return () => {
 			agent.removeEventListener('statuschange', handleStatusChange)
 			agent.removeEventListener('historychange', handleHistoryChange)
@@ -143,7 +160,20 @@ export function useAgent(): UseAgentResult {
 				disableNamedToolChoice,
 			}
 			await chrome.storage.local.set({ advancedConfig })
-			setConfig({ ...llmConfig, ...advancedConfig, language })
+
+			const next: ExtConfig = { ...llmConfig, ...advancedConfig, language }
+			// Unchanged config must not rebuild the agent: the [config] effect's
+			// cleanup would dispose an agent that a caller (e.g. the hub, which
+			// configures right before execute) is about to run, aborting its task.
+			if (configRef.current && isSameConfig(configRef.current, next)) return
+
+			// Resolve only after the [config] effect has installed the new agent,
+			// so callers never execute on the agent that is being disposed.
+			const ready = new Promise<void>((resolve) => {
+				configReadyResolversRef.current.push(resolve)
+			})
+			setConfig(next)
+			await ready
 		},
 		[]
 	)

--- a/packages/extension/src/entrypoints/hub/hub-ws.ts
+++ b/packages/extension/src/entrypoints/hub/hub-ws.ts
@@ -16,6 +16,8 @@
 import type { ExecutionResult } from '@page-agent/core'
 import { useEffect, useRef, useState } from 'react'
 
+import type { RemoteUploadFile } from '@/agent/uploadTools'
+import { describeAvailableUploadFiles, setAvailableUploadFiles } from '@/agent/uploadTools'
 import type { ExtConfig } from '@/agent/useAgent'
 
 // --- Protocol types ---
@@ -24,6 +26,8 @@ interface ExecuteMessage {
 	type: 'execute'
 	task: string
 	config?: Record<string, unknown>
+	/** Files the caller offers for upload; served at GET /files/{id} on its HTTP bridge */
+	files?: RemoteUploadFile[]
 }
 
 interface StopMessage {
@@ -56,7 +60,8 @@ export type HubWsState = 'connecting' | 'connected' | 'disconnected'
 export interface HubWsHandlers {
 	onExecute: (
 		task: string,
-		config?: Record<string, unknown>
+		config?: Record<string, unknown>,
+		files?: RemoteUploadFile[]
 	) => Promise<{ success: boolean; data: string }>
 	onStop: () => void
 }
@@ -180,7 +185,7 @@ export class HubWs {
 
 		this.#busy = true
 		try {
-			const result = await this.#handlers.onExecute(msg.task, msg.config)
+			const result = await this.#handlers.onExecute(msg.task, msg.config, msg.files)
 			this.#send({ type: 'result', success: result.success, data: result.data })
 		} catch (err) {
 			this.#send({ type: 'error', message: err instanceof Error ? err.message : String(err) })
@@ -217,13 +222,18 @@ export function useHubWs(
 		const hubWs = new HubWs(
 			Number(wsPort),
 			{
-				onExecute: async (task, incomingConfig) => {
+				onExecute: async (task, incomingConfig, files) => {
 					const { execute, configure, config } = latestRef.current
 					if (incomingConfig) {
 						await configure({ ...config, ...incomingConfig } as ExtConfig)
 					}
-					const result = await execute(task)
-					return { success: result.success, data: result.data }
+					try {
+						setAvailableUploadFiles(files ?? [], wsPort ? Number(wsPort) : null)
+						const result = await execute(task + describeAvailableUploadFiles())
+						return { success: result.success, data: result.data }
+					} finally {
+						setAvailableUploadFiles([], null)
+					}
 				},
 				onStop: () => latestRef.current.stop(),
 			},

--- a/packages/mcp/src/hub-bridge.js
+++ b/packages/mcp/src/hub-bridge.js
@@ -1,6 +1,9 @@
 #!/usr/bin/env node
-import { readFileSync } from 'node:fs'
+import { randomUUID } from 'node:crypto'
+import { createReadStream, readFileSync } from 'node:fs'
+import { stat } from 'node:fs/promises'
 import http from 'node:http'
+import { basename, extname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { WebSocketServer } from 'ws'
 
@@ -12,6 +15,27 @@ const launcherTemplate = readFileSync(
 	fileURLToPath(new URL('./launcher.html', import.meta.url)),
 	'utf-8'
 )
+
+/** Minimal ext → MIME map for common upload types */
+const MIME_TYPES = {
+	'.pdf': 'application/pdf',
+	'.png': 'image/png',
+	'.jpg': 'image/jpeg',
+	'.jpeg': 'image/jpeg',
+	'.gif': 'image/gif',
+	'.webp': 'image/webp',
+	'.svg': 'image/svg+xml',
+	'.txt': 'text/plain',
+	'.csv': 'text/csv',
+	'.json': 'application/json',
+	'.zip': 'application/zip',
+	'.mp4': 'video/mp4',
+	'.mp3': 'audio/mpeg',
+	'.doc': 'application/msword',
+	'.docx': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+	'.xls': 'application/vnd.ms-excel',
+	'.xlsx': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+}
 
 /**
  * HTTP + WebSocket bridge to the hub.html extension tab.
@@ -34,10 +58,22 @@ export class HubBridge {
 	/** @type {{ resolve: (r: {success: boolean, data: string}) => void, reject: (e: Error) => void } | null} */
 	#pendingTask = null
 
+	/**
+	 * Files offered to the current task, keyed by unguessable random id.
+	 * Only registered paths are ever served — the HTTP bridge cannot be used
+	 * to read arbitrary local files.
+	 * @type {Map<string, { path: string, name: string, mime: string, size: number }>}
+	 */
+	#taskFiles = new Map()
+
 	/** @param {number} port */
 	constructor(port) {
 		this.port = port
-		this.#httpServer = http.createServer((_req, res) => {
+		this.#httpServer = http.createServer((req, res) => {
+			if (req.url?.startsWith('/files/')) {
+				this.#serveFile(req.url.slice('/files/'.length), res)
+				return
+			}
 			const html = launcherTemplate
 				.replaceAll('__EXT_ID__', EXT_ID)
 				.replaceAll('__STORE_URL__', STORE_URL)
@@ -77,17 +113,68 @@ export class HubBridge {
 	}
 
 	/**
+	 * Validate file paths and register them for the next task.
+	 * @param {string[]} paths absolute paths on this machine
+	 * @returns {Promise<{ id: string, name: string, mime: string, size: number }[]>}
+	 */
+	async registerFiles(paths) {
+		this.#taskFiles.clear()
+		const metas = []
+		for (const path of paths) {
+			const info = await stat(path).catch(() => null)
+			if (!info || !info.isFile()) {
+				this.#taskFiles.clear()
+				throw new Error(`File not found or not a regular file: ${path}`)
+			}
+			const id = randomUUID()
+			const meta = {
+				path,
+				name: basename(path),
+				mime: MIME_TYPES[extname(path).toLowerCase()] ?? 'application/octet-stream',
+				size: info.size,
+			}
+			this.#taskFiles.set(id, meta)
+			metas.push({ id, name: meta.name, mime: meta.mime, size: meta.size })
+		}
+		return metas
+	}
+
+	/**
+	 * @param {string} id
+	 * @param {http.ServerResponse} res
+	 */
+	#serveFile(id, res) {
+		const meta = this.#taskFiles.get(id)
+		if (!meta) {
+			res.writeHead(404)
+			res.end('Not found')
+			return
+		}
+		res.writeHead(200, {
+			'Content-Type': meta.mime,
+			'Content-Length': meta.size,
+			'Access-Control-Allow-Origin': '*',
+		})
+		createReadStream(meta.path)
+			.on('error', () => res.destroy())
+			.pipe(res)
+	}
+
+	/**
 	 * @param {string} task
 	 * @param {Record<string, unknown>} [config]
+	 * @param {string[]} [filePaths] absolute paths of files to offer for upload
 	 * @returns {Promise<{success: boolean, data: string}>}
 	 */
-	async executeTask(task, config) {
+	async executeTask(task, config, filePaths) {
 		if (!this.connected) throw new Error('Hub is not connected. Is the extension running?')
 		if (this.#pendingTask) throw new Error('Agent is already running a task.')
 
+		const files = filePaths?.length ? await this.registerFiles(filePaths) : undefined
+
 		return new Promise((resolve, reject) => {
 			this.#pendingTask = { resolve, reject }
-			this.#hub.send(JSON.stringify({ type: 'execute', task, config }))
+			this.#hub.send(JSON.stringify({ type: 'execute', task, config, files }))
 		})
 	}
 
@@ -121,9 +208,11 @@ export class HubBridge {
 			if (msg.type === 'result') {
 				this.#pendingTask?.resolve({ success: msg.success ?? false, data: msg.data ?? '' })
 				this.#pendingTask = null
+				this.#taskFiles.clear()
 			} else if (msg.type === 'error') {
 				this.#pendingTask?.reject(new Error(msg.message ?? 'Unknown error from hub'))
 				this.#pendingTask = null
+				this.#taskFiles.clear()
 			}
 		})
 

--- a/packages/mcp/src/index.js
+++ b/packages/mcp/src/index.js
@@ -44,12 +44,18 @@ mcpServer.registerTool(
 				.describe(
 					'Task description. Give specific instructions for the task. Steps preferable. And the information you want to get after the task is done.'
 				),
+			files: z
+				.array(z.string())
+				.optional()
+				.describe(
+					'Absolute paths (on the machine running this MCP server) of files the agent may upload into file inputs on the page.'
+				),
 		},
 	},
-	async ({ task }) => {
+	async ({ task, files }) => {
 		try {
 			const config = Object.keys(llmConfig).length > 0 ? llmConfig : undefined
-			const result = await hub.executeTask(task, config)
+			const result = await hub.executeTask(task, config, files)
 			return {
 				content: [
 					{

--- a/packages/page-controller/src/PageController.ts
+++ b/packages/page-controller/src/PageController.ts
@@ -13,6 +13,7 @@ import {
 	scrollHorizontally,
 	scrollVertically,
 	selectOptionElement,
+	uploadFileToElement,
 } from './actions'
 import * as dom from './dom'
 import type { FlatDomTree, InteractiveElementDomNode } from './dom/dom_tree/type'
@@ -45,6 +46,25 @@ export interface BrowserState {
 interface ActionResult {
 	success: boolean
 	message: string
+}
+
+/**
+ * File payload for uploadFile. `dataBase64` keeps the payload JSON-serializable
+ * so it can cross extension messaging boundaries (File objects cannot).
+ */
+export interface UploadFileData {
+	name: string
+	type: string
+	dataBase64: string
+}
+
+function decodeUploadFile(fileData: UploadFileData): File {
+	const binary = atob(fileData.dataBase64)
+	const bytes = new Uint8Array(binary.length)
+	for (let i = 0; i < binary.length; i++) {
+		bytes[i] = binary.charCodeAt(i)
+	}
+	return new File([bytes], fileData.name, { type: fileData.type })
 }
 
 /**
@@ -286,6 +306,36 @@ export class PageController extends EventTarget {
 			return {
 				success: false,
 				message: `❌ Failed to input text: ${error}`,
+			}
+		}
+	}
+
+	/**
+	 * Upload files into a file input by index.
+	 * The index may point at the file input itself or at the visible upload
+	 * button/label/dropzone — the real (often hidden) input is resolved from it.
+	 */
+	async uploadFile(index: number, files: UploadFileData[] | File[]): Promise<ActionResult> {
+		try {
+			this.assertIndexed()
+			const element = getElementByIndex(this.selectorMap, index)
+			const elemText = this.elementTextMap.get(index)
+
+			const fileObjects = files.map((f) => (f instanceof File ? f : decodeUploadFile(f)))
+			if (fileObjects.length === 0) {
+				throw new Error('No files provided')
+			}
+			await uploadFileToElement(element, fileObjects)
+
+			const names = fileObjects.map((f) => f.name).join(', ')
+			return {
+				success: true,
+				message: `✅ Set file(s) (${names}) on file input for element (${elemText ?? index}).`,
+			}
+		} catch (error) {
+			return {
+				success: false,
+				message: `❌ Failed to upload file: ${error}`,
 			}
 		}
 	}

--- a/packages/page-controller/src/actions.ts
+++ b/packages/page-controller/src/actions.ts
@@ -552,3 +552,56 @@ export async function scrollHorizontally(scroll_amount: number, element?: HTMLEl
 		return `✅ ${warningMsg} Scrolled container (${el!.tagName}) horizontally by ${scrolled}px.`
 	}
 }
+
+/**
+ * Resolve the actual `<input type="file">` for an upload target.
+ * Upload UIs usually expose a styled button/label/dropzone while the real
+ * input is visually hidden (and therefore often absent from the selector map),
+ * so we search outward from the indexed element.
+ * @private Internal method, subject to change at any time.
+ */
+export function resolveFileInput(element: HTMLElement): HTMLInputElement {
+	const isFileInput = (el: Element | null): el is HTMLInputElement =>
+		!!el && isInputElement(el) && el.type === 'file'
+
+	if (isFileInput(element)) return element
+
+	const descendant = element.querySelector('input[type="file"]')
+	if (isFileInput(descendant)) return descendant
+
+	if (element instanceof HTMLLabelElement && element.control && isFileInput(element.control)) {
+		return element.control
+	}
+
+	const inForm = element.closest('form')?.querySelector('input[type="file"]')
+	if (isFileInput(inForm ?? null)) return inForm as HTMLInputElement
+
+	// Last resort: a single file input anywhere in the document is unambiguous
+	const all = element.ownerDocument.querySelectorAll('input[type="file"]')
+	if (all.length === 1 && isFileInput(all[0])) return all[0]
+
+	throw new Error(
+		'No file input found for this element. Point the index at the upload button/dropzone or the file input itself.'
+	)
+}
+
+/**
+ * Set files on a file input and fire the events frameworks listen for.
+ * @private Internal method, subject to change at any time.
+ */
+export async function uploadFileToElement(element: HTMLElement, files: File[]) {
+	const input = resolveFileInput(element)
+
+	if (files.length > 1 && !input.multiple) {
+		throw new Error('This file input does not accept multiple files')
+	}
+
+	const dataTransfer = new DataTransfer()
+	for (const file of files) dataTransfer.items.add(file)
+	input.files = dataTransfer.files
+
+	input.dispatchEvent(new Event('input', { bubbles: true }))
+	input.dispatchEvent(new Event('change', { bubbles: true }))
+
+	await waitFor(0.2)
+}


### PR DESCRIPTION
## What

Implements the `upload_file` `@todo`: MCP callers can now provide local files that the agent uploads into `<input type="file">` elements on the page.

**How it works**
- The MCP caller offers files per task (absolute paths on the MCP host). Each file is validated and registered under an unguessable random id, and served **only for the task's duration** at `GET /files/{id}` on the existing localhost HTTP bridge — no new ports, no persistent exposure.
- The hub registers the offered files and appends their ids to the task text; the new `upload_file` customTool in the extension fetches the bytes, base64-encodes them across the messaging boundary, and `PageController` injects them into the file input via `DataTransfer` + synthetic `input`/`change` events.
- The element index may point at the visible upload button/label/dropzone — the real (often hidden) input is resolved from it, which matches how most real-world upload widgets are built (Workday/Ashby/LinkedIn-style wrappers).

## Also included

`f0219ab` fixes a race that breaks every hub task that arrives with a `config` payload: `onExecute` awaits `configure()` before `execute()`, but `setConfig` re-renders `useAgent` and the `[config]` effect cleanup disposes the current agent — aborting the task it is about to run ("Task aborted" with zero LLM requests). The fix was found while developing this feature and the feature's MCP path exercises it, so it's included here; happy to split it into its own PR if you prefer.

## Testing

- Live end-to-end on Windows/Chrome: MCP `execute_task` with `files: [...]` against a page with a `FileReader`-backed file input — exact filename, size, and byte content read back by the page.
- Verified the file bridge rejects unknown ids and that registrations are dropped when the task ends.
