### PR TITLE
feat(llms): add Kimi K3 support

### DIFF
--- a/packages/llms/src/models.live.test.ts
+++ b/packages/llms/src/models.live.test.ts
@@ -85,7 +85,7 @@ const MODEL_GROUPS: Record<string, string[]> = {
 	MiniMax: ['MiniMax-M3', 'MiniMax-M2.7', 'MiniMax-M2.5'],
 	xAI: ['grok-4.5', 'grok-4.3', 'grok-build-0.1'],
 	Tencent: ['hy3'],
-	MoonshotAI: ['kimi-k2.7-code', 'kimi-k2.6', 'kimi-k2.5'],
+	MoonshotAI: ['kimi-k3', 'kimi-k2.7-code', 'kimi-k2.6', 'kimi-k2.5'],
 	'Z.AI': ['glm-5.2', 'glm-5.1', 'glm-5', 'glm-4.7'],
 }
 

--- a/packages/llms/src/utils.ts
+++ b/packages/llms/src/utils.ts
@@ -151,7 +151,12 @@ export function modelPatch(body: Record<string, any>, baseURL?: string) {
 	}
 
 	if (modelName.startsWith('kimi')) {
-		if (!modelName.includes('code')) {
+		if (modelName.startsWith('kimi-k3')) {
+			// Kimi K3 always thinks and rejects named tool choice while thinking.
+			debug('Patch Kimi K3: use required tool choice, remove parallel tool calls')
+			delete body.parallel_tool_calls
+			if (body.tool_choice?.function?.name) body.tool_choice = 'required'
+		} else if (!modelName.includes('code')) {
 			// kimi-k2.7-code cannot disable thinking
 			debug('Patch Kimi: disable thinking')
 			body.thinking = { type: 'disabled' }

--- a/packages/website/src/pages/docs/features/models/page.tsx
+++ b/packages/website/src/pages/docs/features/models/page.tsx
@@ -68,7 +68,7 @@ const MODEL_GROUPS: Record<string, string[]> = {
 	],
 	xAI: ['grok-4.5', 'grok-4.3', 'grok-build-0.1'],
 	Tencent: ['hy3'],
-	MoonshotAI: ['kimi-k2.7-code', 'kimi-k2.6', 'kimi-k2.5'],
+	MoonshotAI: ['kimi-k3', 'kimi-k2.7-code', 'kimi-k2.6', 'kimi-k2.5'],
 	'Z.AI': ['glm-5.2', 'glm-5.1', 'glm-5', 'glm-4.7'],
 }
 


### PR DESCRIPTION
## What

Add Kimi K3 to the tested model matrix and website model list. Adapt its always-on reasoning request shape for reliable tool calls.

Closes #(issue)

## Type

- [ ] Breaking change
- [ ] Bug fix
- [x] Feature / Improvement
- [ ] Refactor / Chores
- [x] Documentation / Website / Demo / Testing

## Testing

- [x] `npm run ci` passes
- [ ] Tested in modern browsers
- [ ] Types/doc added

Automated validation: `npm run test:live -w @page-agent/llms` passed with 51 tests; 10 Aliyun and DeepSeek tests were skipped because their API keys were absent.

## Requirements / 要求

- [x] I have read and follow the [Code of Conduct](../docs/CODE_OF_CONDUCT.md) and [Contributing Guide](../CONTRIBUTING.md) . / 我已阅读并遵守行为准则。
- [x] This PR is NOT generated by a bot or AI agent acting autonomously. I have authored or meaningfully reviewed every change. / 此 PR 不是由 bot 或 AI 自主生成的，我已亲自编写或充分审查了每一处变更。
