### PR TITLE
fix(page-controller): index new (*-prefixed) elements in getElementTextMap

### DIFF
--- a/packages/page-controller/src/dom/index.test.ts
+++ b/packages/page-controller/src/dom/index.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+
+import { getElementTextMap } from './index'
+
+describe('getElementTextMap', () => {
+	it('maps existing (non-new) element lines to their description', () => {
+		const simplifiedHTML = ['[0]<a aria-label=Home />', '[1]<button >Submit />'].join('\n')
+
+		const map = getElementTextMap(simplifiedHTML)
+
+		expect(map.get(0)).toBe('[0]<a aria-label=Home />')
+		expect(map.get(1)).toBe('[1]<button >Submit />')
+	})
+
+	it('maps new element lines marked with a leading "*"', () => {
+		const simplifiedHTML = ['[0]<a aria-label=Home />', '*[5]<a role=button>Get started />'].join(
+			'\n'
+		)
+
+		const map = getElementTextMap(simplifiedHTML)
+
+		// New elements are prefixed with '*' and must still be indexed.
+		expect(map.get(5)).toBe('*[5]<a role=button>Get started />')
+	})
+
+	it('indents do not prevent matching', () => {
+		const simplifiedHTML = '\t\t*[3]<div >Option />'
+
+		const map = getElementTextMap(simplifiedHTML)
+
+		expect(map.get(3)).toBe('*[3]<div >Option />')
+	})
+})

--- a/packages/page-controller/src/dom/index.ts
+++ b/packages/page-controller/src/dom/index.ts
@@ -514,7 +514,8 @@ export function getElementTextMap(simplifiedHTML: string) {
 		.filter((line) => line.length > 0)
 	const elementTextMap = new Map<number, string>()
 	for (const line of lines) {
-		const regex = /^\[(\d+)\]<[^>]+>([^<]*)/
+		// New elements are prefixed with '*' (e.g. `*[5]<a ...`), so allow an optional leading '*'.
+		const regex = /^\*?\[(\d+)\]<[^>]+>([^<]*)/
 		const match = regex.exec(line)
 		if (match) {
 			const index = parseInt(match[1], 10)


### PR DESCRIPTION
## Problem

`getElementTextMap` (`packages/page-controller/src/dom/index.ts`) builds the index → line map that `PageController` uses to echo a descriptive result for `clickElement` / `inputText`. It matched interactive lines with:

```
/^\[(\d+)\]<[^>]+>([^<]*)/
```

But `flatTreeToString` renders **new** elements with a leading `*`:

```ts
const highlightIndicator = node.isNew ? `*[${node.highlightIndex}]` : `[${node.highlightIndex}]`
```

which the system prompt documents ("Elements tagged with `*[` are the new clickable elements"). The `^\[` anchor never matches a `*[...]` line, so:

- new elements (dropdown options, freshly-rendered modals, etc.) get **no** entry, and
- on the **first** `updateTree()` every element is new, so the map is empty entirely.

`PageController` then falls back to the bare index — `Clicked element (5).` instead of `Clicked element (*[5]<a role=button>Get started />).` — losing traceability for exactly the elements the agent most often acts on, and for the whole first extraction.

## Fix

Allow an optional leading `*` in the regex (`/^\*?\[(\d+)\]<[^>]+>([^<]*)/`). Existing (non-`*`) lines are unchanged, and plain text still can't match because the `[i]<…>` structure is still required.

## Tests

Adds `packages/page-controller/src/dom/index.test.ts` covering the existing-element, new-element (`*`-prefixed), and indented cases. `npm test` passes across all packages; typecheck and eslint are clean.
