### PR TITLE
test(llms): exercise MiniMax on native endpoints and surface MiniMax-M3

### DIFF
--- a/packages/llms/src/models.live.test.ts
+++ b/packages/llms/src/models.live.test.ts
@@ -18,6 +18,8 @@
  *   TESTING_OPENROUTER_KEY=...
  *   TESTING_DEEPSEEK_KEY=...
  *   TESTING_ALIYUN_KEY=...
+ *   TESTING_MINIMAX_KEY=...
+ *   TESTING_MINIMAX_CN_KEY=...
  */
 import { config as dotenvConfig } from 'dotenv'
 import { dirname, resolve } from 'path'
@@ -152,6 +154,17 @@ const PROVIDERS = {
 		baseURL: 'https://api.deepseek.com',
 		apiKey: process.env.TESTING_DEEPSEEK_KEY,
 	},
+	// MiniMax exposes the same OpenAI-compatible model ids on two regional
+	// hosts: the global host (api.minimax.io) and the China host
+	// (api.minimaxi.com). Each needs its own key.
+	minimax: {
+		baseURL: 'https://api.minimax.io/v1',
+		apiKey: process.env.TESTING_MINIMAX_KEY,
+	},
+	minimaxChina: {
+		baseURL: 'https://api.minimaxi.com/v1',
+		apiKey: process.env.TESTING_MINIMAX_CN_KEY,
+	},
 } as const
 
 const ECHO_TOOL: Tool<{ message: string }, string> = {
@@ -219,6 +232,39 @@ describe.concurrent('DeepSeek — native', () => {
 	const nativeModels = MODEL_GROUPS.DeepSeek.filter((model) => model !== 'deepseek-3.2')
 
 	for (const model of nativeModels) {
+		it.skipIf(!apiKey)(
+			model,
+			async () => {
+				await expectEchoToolCall(baseURL, apiKey!, model)
+			},
+			TEST_TIMEOUT
+		)
+	}
+})
+
+// MiniMax's own OpenAI-compatible API serves the current generation
+// (MiniMax-M3, MiniMax-M2.7). The older MiniMax-M2.5 is only reachable via
+// OpenRouter resellers, not the native endpoints, so it is excluded here.
+const MINIMAX_NATIVE_MODELS = MODEL_GROUPS.MiniMax.filter((model) => model !== 'MiniMax-M2.5')
+
+describe.concurrent('MiniMax — global native', () => {
+	const { baseURL, apiKey } = PROVIDERS.minimax
+
+	for (const model of MINIMAX_NATIVE_MODELS) {
+		it.skipIf(!apiKey)(
+			model,
+			async () => {
+				await expectEchoToolCall(baseURL, apiKey!, model)
+			},
+			TEST_TIMEOUT
+		)
+	}
+})
+
+describe.concurrent('MiniMax — China native', () => {
+	const { baseURL, apiKey } = PROVIDERS.minimaxChina
+
+	for (const model of MINIMAX_NATIVE_MODELS) {
 		it.skipIf(!apiKey)(
 			model,
 			async () => {

--- a/packages/website/src/pages/docs/features/models/page.tsx
+++ b/packages/website/src/pages/docs/features/models/page.tsx
@@ -61,11 +61,7 @@ const MODEL_GROUPS: Record<string, string[]> = {
 		'claude-sonnet-4-5',
 		'claude-haiku-4-5',
 	],
-	MiniMax: [
-		// 'MiniMax-M3', low success rate
-		'MiniMax-M2.7',
-		'MiniMax-M2.5',
-	],
+	MiniMax: ['MiniMax-M3', 'MiniMax-M2.7', 'MiniMax-M2.5'],
 	xAI: ['grok-4.5', 'grok-4.3', 'grok-build-0.1'],
 	Tencent: ['hy3'],
 	MoonshotAI: ['kimi-k3', 'kimi-k2.7-code', 'kimi-k2.6', 'kimi-k2.5'],


### PR DESCRIPTION
Reason: MiniMax-M3 was exercised only through an OpenRouter-derived id and hidden from the docs, and the live-test registry had no direct MiniMax endpoints.

## Changes

- **`packages/llms/src/models.live.test.ts`** — add MiniMax to the live-test provider registry so its models are exercised on the native OpenAI-compatible API instead of only through an OpenRouter-derived id:
    - `minimax` → global host `https://api.minimax.io/v1` (key `TESTING_MINIMAX_KEY`)
    - `minimaxChina` → China host `https://api.minimaxi.com/v1` (key `TESTING_MINIMAX_CN_KEY`)
    - register request-shape checks for `MiniMax-M3` and `MiniMax-M2.7` against both hosts; `MiniMax-M2.5` stays OpenRouter-only, mirroring the existing DeepSeek native-filter pattern.
    - document the two new env keys in the suite header.
- **`packages/website/src/pages/docs/features/models/page.tsx`** — list `MiniMax-M3` in the MiniMax model group (removing the stale "low success rate" demotion) so the public model list matches the model matrix in the live tests.

The `modelPatch` in `packages/llms/src/utils.ts` already keys on `startsWith('minimax')` and disables thinking for M3, so it applies unchanged on the native endpoints; no runtime change is needed.

## Testing

- `npm run typecheck` — passes
- `npx eslint packages/llms/src/models.live.test.ts packages/website/src/pages/docs/features/models/page.tsx` — passes
- `npm test -w @page-agent/llms` — 43 passed
- `npm run test:live -w @page-agent/llms` — collects cleanly; 65 tests skip without provider keys (no live API calls)
