### PR TITLE
fix(hub-ws): skip no-op reconfigure to prevent agent recreate loop

### DIFF
--- a/packages/extension/src/entrypoints/hub/hub-ws.ts
+++ b/packages/extension/src/entrypoints/hub/hub-ws.ts
@@ -219,7 +219,11 @@ export function useHubWs(
 			{
 				onExecute: async (task, incomingConfig) => {
 					const { execute, configure, config } = latestRef.current
-					if (incomingConfig) {
+					//  issue#69 Only reconfigure when incoming values actually differ from current config.
+					// Otherwise every execute() call from MCP (which always sends env vars) would
+					// trigger setConfig -> useEffect cleanup -> agent.dispose() -> recreate,
+					// racing with the in-flight execute and causing an infinite retry loop.
+					if (incomingConfig && hasConfigDiff(config, incomingConfig)) {
 						await configure({ ...config, ...incomingConfig } as ExtConfig)
 					}
 					const result = await execute(task)
@@ -240,4 +244,17 @@ export function useHubWs(
 	}, [wsPort])
 
 	return { wsState }
+}
+
+/**
+ * Shallow diff between the current config and an incoming partial config.
+ * Returns true if any key in `incoming` has a value different from `current`.
+ * Used to skip no-op reconfigure calls that would otherwise recreate the agent.
+ */
+function hasConfigDiff(current: ExtConfig | null, incoming: Record<string, unknown>): boolean {
+	if (!current) return true
+	for (const key of Object.keys(incoming)) {
+		if ((current as unknown as Record<string, unknown>)[key] !== incoming[key]) return true
+	}
+	return false
 }


### PR DESCRIPTION
When MCP passes env vars (LLM_BASE_URL / LLM_API_KEY / LLM_MODEL_NAME) on every execute_task call, onExecute unconditionally invoked configure(...) with the same values. Each call created a new config object, retriggering the useEffect that disposes and recreates the agent, racing with the in-flight execute() and causing an infinite retry loop from the MCP client side.

onExecute now only calls configure when incomingConfig actually differs from the current config (shallow diff over incoming keys). Non-MCP paths (settings UI) are unaffected.

Closes #639

## What

Brief description of changes.

Closes #(issue)

## Type

- [ ] Breaking change
- [x] Bug fix
- [ ] Feature / Improvement
- [ ] Refactor / Chores
- [ ] Documentation / Website / Demo / Testing

## Testing

- [x] `npm run ci` passes
- [x] Tested in modern browsers
- [x] Types/doc added

## Requirements / 要求

- [x] I have read and follow the [Code of Conduct](../docs/CODE_OF_CONDUCT.md) and [Contributing Guide](../CONTRIBUTING.md) . / 我已阅读并遵守行为准则。
- [x] This PR is NOT generated by a bot or AI agent acting autonomously. I have authored or meaningfully reviewed every change. / 此 PR 不是由 bot 或 AI 自主生成的，我已亲自编写或充分审查了每一处变更。
