### PR TITLE
fix(controller): index disabled dropdown options so the full list is visible

### DIFF
--- a/packages/page-controller/src/dom/dom_tree/dropdown-options.test.ts
+++ b/packages/page-controller/src/dom/dom_tree/dropdown-options.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import domTree from './index.js'
+
+function setupSizes() {
+	Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
+		configurable: true,
+		get() {
+			return 100
+		},
+	})
+	Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+		configurable: true,
+		get() {
+			return 30
+		},
+	})
+}
+
+function buildDropdown(html: string) {
+	return domTree({
+		doHighlightElements: false,
+		viewportExpansion: -1,
+		interactiveBlacklist: [],
+		interactiveWhitelist: [],
+	}) as any
+}
+
+function getIndexedOptions(tree: any) {
+	return Object.values(tree.map)
+		.filter((n: any) => n.tagName === 'li' && typeof n.highlightIndex === 'number')
+		.sort((a: any, b: any) => a.highlightIndex - b.highlightIndex)
+}
+
+describe('dropdown option indexing (#519)', () => {
+	beforeEach(() => {
+		setupSizes()
+		document.body.innerHTML = ''
+	})
+
+	it('indexes enabled dropdown options', () => {
+		document.body.innerHTML = `
+			<div class="el-select-dropdown">
+				<ul class="el-select-dropdown__list">
+					<li class="el-select-dropdown__item" style="cursor:pointer">选项1</li>
+					<li class="el-select-dropdown__item" style="cursor:pointer">选项2</li>
+					<li class="el-select-dropdown__item" style="cursor:pointer">选项3</li>
+				</ul>
+			</div>
+		`
+		const tree = buildDropdown(document.body.innerHTML)
+		const indexed = getIndexedOptions(tree)
+		expect(indexed.length).toBe(3)
+	})
+
+	it('indexes disabled dropdown options so the full list is visible to the LLM', () => {
+		document.body.innerHTML = `
+			<div class="el-select-dropdown">
+				<ul class="el-select-dropdown__list">
+					<li class="el-select-dropdown__item" style="cursor:pointer">闸片产线</li>
+					<li class="el-select-dropdown__item is-disabled" style="cursor:not-allowed">落料车间</li>
+					<li class="el-select-dropdown__item" style="cursor:pointer">机加车间</li>
+				</ul>
+			</div>
+		`
+		const tree = buildDropdown(document.body.innerHTML)
+		const indexed = getIndexedOptions(tree)
+		expect(indexed.length).toBe(3)
+	})
+
+	it('still excludes disabled buttons outside dropdowns', () => {
+		document.body.innerHTML = `
+			<button style="cursor:not-allowed" disabled>保存</button>
+		`
+		const tree = buildDropdown(document.body.innerHTML)
+		const buttons = Object.values(tree.map).filter((n: any) => n.tagName === 'button')
+		expect(buttons.every((n: any) => n.highlightIndex === undefined)).toBe(true)
+	})
+})

--- a/packages/page-controller/src/dom/dom_tree/index.js
+++ b/packages/page-controller/src/dom/dom_tree/index.js
@@ -688,6 +688,39 @@ export default (
 	}
 
 	/**
+	 * @edit dropdown/menu option detection
+	 * li/option elements (or role=option/menuitem/listitem) inside a dropdown or menu
+	 * container are treated as indexable even when visually disabled (cursor: not-allowed),
+	 * so the LLM sees the complete option list.
+	 */
+	const DROPDOWN_OPTION_ROLES = new Set([
+		'option',
+		'menuitem',
+		'menuitemradio',
+		'menuitemcheckbox',
+		'listitem',
+	])
+	const DROPDOWN_CONTAINER_SELECTOR = [
+		'[role="listbox"]',
+		'[role="menu"]',
+		'[role="menubar"]',
+		'select',
+		'.el-select-dropdown',
+		'.el-dropdown-menu',
+		'[data-toggle="dropdown"]',
+	].join(', ')
+
+	function isDropdownOptionElement(element) {
+		if (!element || element.nodeType !== Node.ELEMENT_NODE) return false
+		const tagName = element.tagName.toLowerCase()
+		const role = element.getAttribute('role')
+		if (tagName !== 'li' && tagName !== 'option' && !(role && DROPDOWN_OPTION_ROLES.has(role))) {
+			return false
+		}
+		return Boolean(element.closest(DROPDOWN_CONTAINER_SELECTOR))
+	}
+
+	/**
 	 * Checks if an element is interactive.
 	 *
 	 * lots of comments, and uncommented code - to show the logic of what we already tried
@@ -709,6 +742,15 @@ export default (
 		}
 		if (interactiveWhitelist.includes(element)) {
 			return true // Skip whitelisted elements
+		}
+
+		/**
+		 * @edit dropdown options should stay indexable even when disabled,
+		 * otherwise the LLM cannot see or select the full option list
+		 * (e.g. Element UI / Avue selects with disabled options).
+		 */
+		if (isDropdownOptionElement(element)) {
+			return true
 		}
 
 		// Cache the tagName and style lookups


### PR DESCRIPTION
## Summary

Element UI / Avue selects commonly disable some options (rendered with `cursor: not-allowed`). `isInteractiveElement` treated them as non-interactive, so disabled options never received a highlight index and disappeared from the simplified DOM. The LLM then could not see or select the intended option, making `select_dropdown_option` unstable in common Element UI / Avue form scenarios (see #519).

This PR detects `li`/`option` elements inside dropdown/menu containers (`[role="listbox"]`, `[role="menu"]`, `select`, `.el-select-dropdown`, ...) and keeps them indexable even when visually disabled, so the complete option list stays visible to the LLM.

## Changes

- `packages/page-controller/src/dom/dom_tree/index.js`: add dropdown option detection (`isDropdownOptionElement`) and use it in `isInteractiveElement`
- `packages/page-controller/src/dom/dom_tree/dropdown-options.test.ts`: new tests (happy-dom, no `getEventListeners` — mirrors the real page-agent injection environment)

## Test plan

- [x] `npm test` in `packages/page-controller` passes (7 tests)
- [x] Verified in a real browser against an Element UI 2.x select with disabled options: all 6 options now get indexes
- [x] `npm run typecheck` and eslint pass

Fixes #519