### PR TITLE
fix(ui): use Object.hasOwn to prevent prototype chain bypass in i18n language validation

### DIFF
--- a/packages/ui/src/i18n/index.ts
+++ b/packages/ui/src/i18n/index.ts
@@ -11,7 +11,7 @@ export class I18n {
 	private translations: TranslationSchema
 
 	constructor(language: SupportedLanguage = 'en-US') {
-		this.language = language in locales ? language : 'en-US'
+		this.language = Object.hasOwn(locales, language) ? language : 'en-US'
 		this.translations = locales[this.language]
 	}
 


### PR DESCRIPTION
## What

Fix a bug where the `in` operator in `I18n` constructor allows `Object.prototype` keys (`constructor`, `__proto__`, `toString`, etc.) to bypass the language whitelist validation, breaking the entire Panel UI.

Closes #641

## Root Cause

`packages/ui/src/i18n/index.ts:14`:
```ts
this.language = language in locales ? language : 'en-US'
```

The `in` operator checks the **entire prototype chain**, not just own properties. Every object inherits `constructor`, `toString`, `valueOf`, `hasOwnProperty`, `__proto__` from `Object.prototype`. So:

- `'fr-FR' in locales` → `false` → fallback works
- `'constructor' in locales` → `true` (inherited) → bypasses validation

When triggered (e.g. via `?lang=constructor` in the demo URL), `this.translations = locales['constructor']` becomes the `Object` constructor function, not a translations object. All subsequent `t()` calls fail to find keys → return raw translation keys + emit `console.warn`.

## Fix

```ts
this.language = Object.hasOwn(locales, language) ? language : 'en-US'
```

`Object.hasOwn` (ES2022, within the project's `target: es2025`) checks only own properties.

## Reachability

The `language` parameter comes from `URLSearchParams.get('lang')` in `demo.ts:35`, cast via `as` with zero runtime validation — `?lang=constructor` is sufficient to trigger.

## Testing

- [x] `npm run ci` passes (lint + format + typecheck + test + build, 7/7)
- [x] Verified: `constructor`, `__proto__`, `toString` all correctly fall back to `en-US` after the fix
- [x] Normal languages (`en-US`, `zh-CN`) unaffected

## Checklist

- [x] I have read and follow the Code of Conduct and Contributing Guide.
- [x] This PR is NOT generated by a bot or AI agent acting autonomously. I have authored or meaningfully reviewed every change.