### PR TITLE
feat: gate experimental pointer hover action

### DIFF
--- a/packages/core/src/PageAgentCore.test.ts
+++ b/packages/core/src/PageAgentCore.test.ts
@@ -363,3 +363,25 @@ describe.concurrent('PageAgentCore lifecycle', () => {
 		})
 	})
 })
+
+describe.concurrent('experimental tool gating', () => {
+	it('omits hover_element_by_index by default', () => {
+		const agent = createAgent(createFetchMock())
+		expect(agent.tools.has('hover_element_by_index')).toBe(false)
+	})
+
+	it('keeps hover_element_by_index available when experimentalPointerActions is true', () => {
+		const agent = createAgent(createFetchMock(), { experimentalPointerActions: true })
+		expect(agent.tools.has('hover_element_by_index')).toBe(true)
+	})
+
+	it('removes execute_javascript when experimentalScriptExecutionTool is false', () => {
+		const agent = createAgent(createFetchMock())
+		expect(agent.tools.has('execute_javascript')).toBe(false)
+	})
+
+	it('keeps execute_javascript when experimentalScriptExecutionTool is true', () => {
+		const agent = createAgent(createFetchMock(), { experimentalScriptExecutionTool: true })
+		expect(agent.tools.has('execute_javascript')).toBe(true)
+	})
+})

--- a/packages/core/src/PageAgentCore.ts
+++ b/packages/core/src/PageAgentCore.ts
@@ -144,6 +144,10 @@ export class PageAgentCore extends EventTarget {
 		if (!this.config.experimentalScriptExecutionTool) {
 			this.tools.delete('execute_javascript')
 		}
+
+		if (!this.config.experimentalPointerActions) {
+			this.tools.delete('hover_element_by_index')
+		}
 	}
 
 	/** Get current agent status */

--- a/packages/core/src/tools/index.ts
+++ b/packages/core/src/tools/index.ts
@@ -135,6 +135,22 @@ tools.set(
 	})
 )
 
+tools.set(
+	'hover_element_by_index',
+	tool({
+		// @experimental Tool surface gated by `experimentalPointerActions` in PageAgentCore.
+		description:
+			'Hover over element by index. Use this to reveal dropdown menus or hidden submenus before clicking on their items. Requires the `experimentalPointerActions` flag to be enabled.',
+		inputSchema: z.object({
+			index: z.int().min(0),
+		}),
+		execute: async function (this: PageAgentCore, input) {
+			const result = await this.pageController.hoverElement(input.index)
+			return result.message
+		},
+	})
+)
+
 /**
  * @note Reference from browser-use
  */

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -132,6 +132,18 @@ export interface AgentConfig extends LLMConfig {
 	experimentalLlmsTxt?: boolean
 
 	/**
+	 * @experimental
+	 * Enable experimental pointer-based tools (currently only `hover_element_by_index`).
+	 * Disabled by default — keep tool surface minimal until real usage shows the value.
+	 * Also pass `experimentalPointerActions: true` to the underlying `PageControllerConfig`
+	 * to actually allow the action to run; mismatched flags will cause the tool to
+	 * fail with an explanatory message.
+	 * @see https://github.com/alibaba/page-agent/issues/222
+	 * @default false
+	 */
+	experimentalPointerActions?: boolean
+
+	/**
 	 * Transform page content before sending to LLM.
 	 * Called after DOM extraction and simplification, before LLM invocation.
 	 * Use cases: inspect extraction results, modify page info, mask sensitive data.

--- a/packages/page-controller/src/PageController.test.ts
+++ b/packages/page-controller/src/PageController.test.ts
@@ -37,4 +37,37 @@ describe('PageController', () => {
 			expect(result.message).toContain('❌')
 		})
 	})
+
+	describe('hoverElement (experimental)', () => {
+		it('returns a disabled failure when experimentalPointerActions is not set', async () => {
+			const controller = new PageController()
+			const result = await controller.hoverElement(0)
+			expect(result.success).toBe(false)
+			expect(result.message).toContain('experimentalPointerActions')
+		})
+
+		it('dispatches hover events when experimentalPointerActions is enabled', async () => {
+			document.body.innerHTML = '<button id="target">Hover me</button>'
+			const target = document.querySelector<HTMLButtonElement>('#target')!
+
+			const seen: string[] = []
+			for (const evt of ['pointerover', 'pointerenter', 'mouseover', 'mouseenter']) {
+				target.addEventListener(evt, () => seen.push(evt))
+			}
+
+			// Stub index 0 -> our target.
+			const controller = new PageController({ experimentalPointerActions: true })
+			;(controller as unknown as { isIndexed: boolean }).isIndexed = true
+			;(controller as unknown as { selectorMap: Map<number, unknown> }).selectorMap.set(0, {
+				ref: target,
+			})
+
+			const result = await controller.hoverElement(0)
+			expect(result.success).toBe(true)
+			expect(result.message).toContain('Hovered over element')
+			expect(seen).toEqual(
+				expect.arrayContaining(['pointerover', 'pointerenter', 'mouseover', 'mouseenter'])
+			)
+		})
+	})
 })

--- a/packages/page-controller/src/PageController.ts
+++ b/packages/page-controller/src/PageController.ts
@@ -9,6 +9,7 @@
 import {
 	clickElement,
 	getElementByIndex,
+	hoverElement,
 	inputTextElement,
 	scrollHorizontally,
 	scrollVertically,
@@ -26,6 +27,14 @@ import { isAnchorElement } from './utils'
 export interface PageControllerConfig extends dom.DomConfig {
 	/** Enable visual mask overlay during operations (default: false) */
 	enableMask?: boolean
+
+	/**
+	 * Enable experimental pointer-based actions (currently only hover).
+	 * @experimental Disabled by default. Tool registration in `PageAgentCore` is gated on
+	 * this flag — see `AgentConfig.experimentalPointerActions`.
+	 * @default false
+	 */
+	experimentalPointerActions?: boolean
 }
 
 /**
@@ -308,6 +317,39 @@ export class PageController extends EventTarget {
 			return {
 				success: false,
 				message: `❌ Failed to select option: ${error}`,
+			}
+		}
+	}
+
+	/**
+	 * Hover over element by index (reveal dropdown menus / hidden submenus before clicking).
+	 * Requires `experimentalPointerActions: true` in PageControllerConfig — the matching
+	 * `hover_element_by_index` tool is gated on `AgentConfig.experimentalPointerActions`.
+	 * @experimental
+	 */
+	async hoverElement(index: number): Promise<ActionResult> {
+		if (!this.config.experimentalPointerActions) {
+			return {
+				success: false,
+				message:
+					'❌ hoverElement is disabled. Set `experimentalPointerActions: true` in PageControllerConfig to enable it.',
+			}
+		}
+
+		try {
+			this.assertIndexed()
+			const element = getElementByIndex(this.selectorMap, index)
+			const elemText = this.elementTextMap.get(index)
+			await hoverElement(element)
+
+			return {
+				success: true,
+				message: `✅ Hovered over element (${elemText ?? index}).`,
+			}
+		} catch (error) {
+			return {
+				success: false,
+				message: `❌ Failed to hover over element: ${error}`,
 			}
 		}
 	}

--- a/packages/page-controller/src/actions.ts
+++ b/packages/page-controller/src/actions.ts
@@ -41,6 +41,38 @@ export function getElementByIndex(
 	return element
 }
 
+/**
+ * @experimental Pointer hover — opt-in via PageControllerConfig.experimentalPointerActions.
+ * Move the pointer over the element and dispatch hover-related events without clicking
+ * or focusing it. Intended for revealing dropdown menus / hidden submenus before
+ * clicking on their items.
+ * @private Internal method, subject to change at any time.
+ */
+export async function hoverElement(element: HTMLElement) {
+	await scrollIntoViewIfNeeded(element)
+
+	const rect = element.getBoundingClientRect()
+	const x = rect.left + rect.width / 2
+	const y = rect.top + rect.height / 2
+
+	await movePointerToElement(element, x, y)
+
+	const pointerOpts = {
+		bubbles: true,
+		cancelable: true,
+		clientX: x,
+		clientY: y,
+		pointerType: 'mouse',
+	}
+	const mouseOpts = { bubbles: true, cancelable: true, clientX: x, clientY: y }
+
+	// Hover — pointer events first, then mouse events (spec order)
+	element.dispatchEvent(new PointerEvent('pointerover', pointerOpts))
+	element.dispatchEvent(new PointerEvent('pointerenter', { ...pointerOpts, bubbles: false }))
+	element.dispatchEvent(new MouseEvent('mouseover', mouseOpts))
+	element.dispatchEvent(new MouseEvent('mouseenter', { ...mouseOpts, bubbles: false }))
+}
+
 let lastClickedElement: HTMLElement | null = null
 
 function blurLastClickedElement() {


### PR DESCRIPTION
## Summary

- add opt-in `experimentalPointerActions` configuration to the agent and page controller
- expose `hover_element_by_index` only when the experimental flag is enabled
- dispatch pointer/mouse hover events without clicking and add focused core/controller tests

Related to #222.

## Validation

- `npm run typecheck`
- `npm test --workspace=@page-agent/page-controller` (6 tests)
- `vitest run --config packages/core/vitest.config.js` (21 tests)

The change is intentionally opt-in and does not alter the default tool surface.