### PR TITLE
fix(core): enforce maxSteps limit exactly

### DIFF
--- a/packages/core/src/PageAgentCore.test.ts
+++ b/packages/core/src/PageAgentCore.test.ts
@@ -140,6 +140,30 @@ describe.concurrent('PageAgentCore lifecycle', () => {
 			expect(agent.status).toBe('completed')
 		})
 
+		it('does not execute more than maxSteps steps', async () => {
+			const fetchMock = createFetchMock().mockImplementation(async () =>
+				agentResponse({ action: { noop: {} } })
+			)
+			const agent = createAgent(fetchMock, {
+				maxSteps: 1,
+				customTools: {
+					noop: tool({
+						description: 'Do nothing.',
+						inputSchema: z.object({}),
+						execute: async () => 'ok',
+					}),
+				},
+			})
+
+			const result = await agent.execute('keep going')
+
+			expect(result).toMatchObject({
+				success: false,
+				data: 'Step count exceeded maximum limit',
+			})
+			expect(fetchMock).toHaveBeenCalledTimes(1)
+		})
+
 		it('throws when a task is already running', async () => {
 			const fetchMock = createFetchMock().mockResolvedValueOnce(waitResponse())
 			const agent = createAgent(fetchMock)

--- a/packages/core/src/PageAgentCore.ts
+++ b/packages/core/src/PageAgentCore.ts
@@ -346,7 +346,7 @@ export class PageAgentCore extends EventTarget {
 				}
 
 				step++
-				if (step > maxSteps) {
+				if (step >= maxSteps) {
 					const message = 'Step count exceeded maximum limit'
 					console.error(message)
 					this.#emitActivity({ type: 'error', message: message })


### PR DESCRIPTION
## What

Fix an off-by-one error in `PageAgentCore.execute()` that allows one extra agent step beyond `maxSteps`.

`maxSteps` is documented as the maximum number of steps a task may take, but the loop currently increments `step` and only stops when `step > maxSteps`. As a result, `maxSteps: 1` can execute two LLM/tool steps, and the default `maxSteps: 40` can execute 41.

This changes the boundary check to stop when `step >= maxSteps` and adds a regression test that verifies `maxSteps: 1` performs exactly one LLM invocation before returning the step-limit error.

## Type

- [x] Bug fix
- [ ] Feature / Improvement
- [ ] Refactor / Chores
- [ ] Documentation / Website / Demo / Testing
- [ ] Breaking change

## Testing

- [x] `npm test -w @page-agent/core`
- [x] `npm run typecheck`
- [x] `npm run lint`

The patch was reviewed against current `main` (`632424b`). 

## Requirements / 要求

- [x] I have read and follow the Code of Conduct and Contributing Guide.
- [x] I have personally reviewed and meaningfully authored/reviewed every change before submission.