### PR TITLE
fix(core): preserve custom ask_user override

### DIFF
--- a/packages/core/src/PageAgentCore.test.ts
+++ b/packages/core/src/PageAgentCore.test.ts
@@ -140,6 +140,31 @@ describe.concurrent('PageAgentCore lifecycle', () => {
 			expect(agent.status).toBe('completed')
 		})
 
+		it('preserves a custom ask_user override without onAskUser', async () => {
+			const customAskUser = vi.fn(async (question: string) => `custom: ${question}`)
+			const fetchMock = createFetchMock()
+				.mockResolvedValueOnce(
+					agentResponse({ action: { ask_user: { question: 'Which option?' } } })
+				)
+				.mockResolvedValueOnce(doneResponse('finished'))
+			const agent = createAgent(fetchMock, {
+				customTools: {
+					ask_user: tool({
+						description: 'Ask through a custom channel.',
+						inputSchema: z.object({ question: z.string() }),
+						execute: async (input) => customAskUser(input.question),
+					}),
+				},
+			})
+
+			const result = await agent.execute('ask then finish')
+
+			expect(result).toMatchObject({ success: true, data: 'finished' })
+			expect(customAskUser).toHaveBeenCalledOnce()
+			expect(customAskUser).toHaveBeenCalledWith('Which option?')
+			expect(fetchMock).toHaveBeenCalledTimes(2)
+		})
+
 		it('throws when a task is already running', async () => {
 			const fetchMock = createFetchMock().mockResolvedValueOnce(waitResponse())
 			const agent = createAgent(fetchMock)

--- a/packages/core/src/PageAgentCore.ts
+++ b/packages/core/src/PageAgentCore.ts
@@ -228,8 +228,11 @@ export class PageAgentCore extends EventTarget {
 		this.#setStatus('running')
 		this.#emitHistoryChange()
 
-		// Disable ask_user tool if onAskUser is not set
-		if (!this.onAskUser) this.tools.delete('ask_user')
+		// Disable only the built-in ask_user tool when onAskUser is not set.
+		// A custom tool with the same name must remain available without onAskUser.
+		if (!this.onAskUser && this.config.customTools?.ask_user === undefined) {
+			this.tools.delete('ask_user')
+		}
 
 		const onBeforeStep = this.config.onBeforeStep
 		const onAfterStep = this.config.onAfterStep


### PR DESCRIPTION
## What

Preserve a user-provided `customTools.ask_user` override when `onAskUser` is not configured.

`customTools` explicitly supports overriding internal tools by name, and the public API documentation uses `ask_user` as the override example. The constructor correctly installs that custom tool, but `execute()` currently deletes every tool named `ask_user` whenever `onAskUser` is unset. That unintentionally removes the custom override before the first LLM step.

This changes the guard so only the built-in `ask_user` is disabled when there is no `onAskUser` callback. An explicit `customTools.ask_user: null` remains disabled because it is already removed during construction. A regression test verifies a custom `ask_user` implementation executes successfully without `onAskUser`.

## Type

- [x] Bug fix
- [ ] Feature / Improvement
- [ ] Refactor / Chores
- [ ] Documentation / Website / Demo / Testing
- [ ] Breaking change

## Testing

- [x] `npm test -w @page-agent/core`
- [x] `npm run typecheck`
- [x] `npm run lint`

The patch was reviewed against current `main` (`632424b`). 

## Requirements / 要求

- [x] I have read and follow the Code of Conduct and Contributing Guide.
- [x] I have personally reviewed and meaningfully authored/reviewed every change before submission.