### PR TITLE
feat(ui): make the agent panel draggable

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -42,6 +42,7 @@
     "homepage": "https://alibaba.github.io/page-agent/",
     "scripts": {
         "build": "vite build",
+        "test": "vitest run",
         "prepublishOnly": "node ../../scripts/pre-publish.js",
         "postpublish": "node ../../scripts/post-publish.js"
     }

--- a/packages/ui/src/panel/Panel.drag.test.ts
+++ b/packages/ui/src/panel/Panel.drag.test.ts
@@ -1,0 +1,589 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { Panel } from './Panel'
+import type { PanelAgentAdapter } from './types'
+
+import styles from './Panel.module.css'
+
+/** Minimal agent stub - Panel only needs the PanelAgentAdapter surface */
+class FakeAgent extends EventTarget implements PanelAgentAdapter {
+	status: PanelAgentAdapter['status'] = 'idle'
+	lastResult = null
+	history: PanelAgentAdapter['history'] = []
+	task = ''
+	execute = vi.fn(async () => undefined)
+	stop = vi.fn(async () => undefined)
+	dispose = vi.fn(() => undefined)
+}
+
+/** The panel's box with a zero drag offset: 360x40, bottom-centre of 1024x768 */
+const BASE = { top: 660, width: 360, height: 40 }
+// Resulting bounds at 1024x768 (margin 8): x in [-324, 324], y in [-652, 60]
+
+/**
+ * Where `left: 50%` + `translateX(-50%)` puts the panel: centred, so the base box
+ * moves whenever the viewport width does.
+ *
+ * Derived rather than fixed. A constant would hold the pre-resize geometry after
+ * a test shrinks the window, and the re-clamp assertions would then be checking a
+ * box no browser would ever lay out.
+ */
+const baseLeft = () => (window.innerWidth - BASE.width) / 2
+
+/** Matches `ENTRANCE_MS` in Panel.ts */
+const ENTRANCE_MS = 300
+
+/**
+ * How far the entrance transition still has to travel, in px.
+ *
+ * A real browser reports the box where it is being animated to, so anything
+ * measuring during the entrance reads it this far from where it will settle.
+ */
+let entranceShift = 0
+
+let active: Panel | null = null
+
+function mount() {
+	const panel = new Panel(new FakeAgent())
+	active = panel
+	const wrapper = panel.wrapper
+	const header = wrapper.querySelector<HTMLElement>(`.${styles.header}`)!
+
+	// The panel starts hidden; production only ever drags a visible one. Shown
+	// before the stub is installed, so this first clamp reads happy-dom's own
+	// zero rect and leaves the custom properties unset, as an untouched panel has.
+	panel.show()
+
+	// happy-dom has no layout engine, so stand in for one. The rect tracks the
+	// drag offset exactly as a real browser's would, collapses to zero while the
+	// panel is hidden, as a real `display: none` box does, and carries
+	// `entranceShift` while the entrance transition is still running.
+	wrapper.getBoundingClientRect = () => {
+		if (wrapper.style.display === 'none') return new DOMRect()
+		const x = parseFloat(wrapper.style.getPropertyValue('--drag-x') || '0')
+		const y = parseFloat(wrapper.style.getPropertyValue('--drag-y') || '0') + entranceShift
+		const left = baseLeft()
+		return {
+			left: left + x,
+			top: BASE.top + y,
+			right: left + x + BASE.width,
+			bottom: BASE.top + y + BASE.height,
+			x: left + x,
+			y: BASE.top + y,
+			width: BASE.width,
+			height: BASE.height,
+			toJSON: () => ({}),
+		} as DOMRect
+	}
+
+	return { panel, wrapper, header }
+}
+
+function pointer(
+	type: string,
+	clientX: number,
+	clientY: number,
+	button = 0,
+	init: PointerEventInit = {}
+): PointerEvent {
+	return new PointerEvent(type, {
+		bubbles: true,
+		clientX,
+		clientY,
+		button,
+		pointerId: 1,
+		isPrimary: true,
+		...init,
+	})
+}
+
+/** Press the header at (0,0), move by (dx,dy), release, then let the click fire */
+function drag(header: HTMLElement, dx: number, dy: number) {
+	header.dispatchEvent(pointer('pointerdown', 0, 0))
+	window.dispatchEvent(pointer('pointermove', dx, dy))
+	window.dispatchEvent(pointer('pointerup', dx, dy))
+	// Browsers fire `click` on the header after the gesture ends
+	header.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+}
+
+/** Resize the happy-dom viewport (not part of the standard Window type) */
+function setViewportWidth(width: number): void {
+	;(
+		window as unknown as { happyDOM: { setViewport(v: { width: number }): void } }
+	).happyDOM.setViewport({ width })
+}
+
+const offsetOf = (wrapper: HTMLElement) => ({
+	x: wrapper.style.getPropertyValue('--drag-x'),
+	y: wrapper.style.getPropertyValue('--drag-y'),
+})
+
+afterEach(() => {
+	active?.dispose()
+	active = null
+	document.body.innerHTML = ''
+	// Reset shared globals here rather than at the end of each test, or the first
+	// failure leaks its viewport and entrance state into everything after it.
+	entranceShift = 0
+	setViewportWidth(1024)
+	vi.useRealTimers()
+})
+
+describe('Panel dragging', () => {
+	const gestures = [
+		{ name: 'a press with no movement', dx: 0, dy: 0, isDrag: false },
+		{ name: 'a 3px wobble stays under the threshold', dx: 3, dy: 0, isDrag: false },
+		{ name: 'a 3px vertical wobble stays under the threshold', dx: 0, dy: -3, isDrag: false },
+		{ name: 'exactly 4px reaches the threshold', dx: 4, dy: 0, isDrag: true },
+		{ name: '3px on both axes exceeds the 4px radius', dx: 3, dy: 3, isDrag: true },
+		// 2+3 sums to 4 but measures 3.6 across: a Manhattan or per-axis test would
+		// start dragging here, a Euclidean radius keeps it a click.
+		{ name: 'a 2x3px diagonal stays inside the 4px radius', dx: 2, dy: 3, isDrag: false },
+		{ name: 'a drag to the right', dx: 120, dy: 0, isDrag: true },
+		{ name: 'a drag up and to the left', dx: -80, dy: -40, isDrag: true },
+		{ name: 'a drag down', dx: 0, dy: 50, isDrag: true },
+	]
+
+	it.each(gestures)('$name (moves the panel: $isDrag)', ({ dx, dy, isDrag }) => {
+		const { wrapper, header } = mount()
+		expect(wrapper.classList.contains(styles.expanded)).toBe(false)
+
+		drag(header, dx, dy)
+
+		// A drag moves the panel; a click leaves the offset untouched
+		expect(offsetOf(wrapper)).toEqual(isDrag ? { x: `${dx}px`, y: `${dy}px` } : { x: '', y: '' })
+		// ...and exactly one of the two behaviours happens: drag or toggle, never both
+		expect(wrapper.classList.contains(styles.expanded)).toBe(!isDrag)
+	})
+
+	it('clamps a drag that would leave the viewport', () => {
+		const { wrapper, header } = mount()
+
+		drag(header, 5000, 5000)
+
+		// x maxes out at 1024 - 8 - 360 - 332, y at 768 - 8 - 40 - 660
+		expect(offsetOf(wrapper)).toEqual({ x: '324px', y: '60px' })
+	})
+
+	it('keeps accumulated offset across successive drags', () => {
+		const { wrapper, header } = mount()
+
+		drag(header, 50, 20)
+		drag(header, -30, 10)
+
+		expect(offsetOf(wrapper)).toEqual({ x: '20px', y: '30px' })
+	})
+
+	const endEvents = ['pointerup', 'pointercancel']
+	it.each(endEvents)('adds the dragging class on drag start and drops it on %s', (end) => {
+		const { wrapper, header } = mount()
+
+		header.dispatchEvent(pointer('pointerdown', 0, 0))
+		expect(wrapper.classList.contains(styles.dragging)).toBe(false)
+
+		window.dispatchEvent(pointer('pointermove', 60, 0))
+		expect(wrapper.classList.contains(styles.dragging)).toBe(true)
+
+		window.dispatchEvent(pointer(end, 60, 0))
+		expect(wrapper.classList.contains(styles.dragging)).toBe(false)
+		expect(offsetOf(wrapper).x).toBe('60px')
+	})
+
+	const nonStarters = [
+		{ name: 'a secondary mouse button', button: 2, onButton: false },
+		{ name: 'a press on a control button', button: 0, onButton: true },
+	]
+	it.each(nonStarters)('does not start a drag from $name', ({ button, onButton }) => {
+		const { wrapper, header } = mount()
+		const target = onButton
+			? wrapper.querySelector<HTMLElement>(`.${styles.expandButton}`)!
+			: header
+
+		target.dispatchEvent(pointer('pointerdown', 0, 0, button))
+		window.dispatchEvent(pointer('pointermove', 200, 100))
+		window.dispatchEvent(pointer('pointerup', 200, 100))
+
+		expect(offsetOf(wrapper)).toEqual({ x: '', y: '' })
+		expect(wrapper.classList.contains(styles.dragging)).toBe(false)
+	})
+
+	it('leaves the control buttons working after a press on them', () => {
+		const { wrapper } = mount()
+		const expandButton = wrapper.querySelector<HTMLElement>(`.${styles.expandButton}`)!
+
+		expandButton.dispatchEvent(pointer('pointerdown', 0, 0))
+		expandButton.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+
+		expect(wrapper.classList.contains(styles.expanded)).toBe(true)
+	})
+
+	it('only suppresses the one click that ends a drag', () => {
+		const { wrapper, header } = mount()
+
+		drag(header, 100, 0) // drag: click suppressed
+		expect(wrapper.classList.contains(styles.expanded)).toBe(false)
+
+		header.dispatchEvent(new MouseEvent('click', { bubbles: true })) // plain click: works
+		expect(wrapper.classList.contains(styles.expanded)).toBe(true)
+	})
+
+	// show()/hide() write `transform` inline, which beats the class rule. If they
+	// drop the var() suffix the panel silently snaps back to its default spot.
+	const visibility = [
+		{ name: 'show', run: (p: Panel) => p.show() },
+		{ name: 'hide', run: (p: Panel) => p.hide() },
+	]
+	it.each(visibility)('$name() after a drag preserves the drag offset', ({ run }) => {
+		const { panel, wrapper, header } = mount()
+
+		drag(header, 90, -70)
+		run(panel)
+
+		expect(offsetOf(wrapper)).toEqual({ x: '90px', y: '-70px' })
+		expect(wrapper.style.transform).toContain('translate(var(--drag-x, 0px), var(--drag-y, 0px))')
+	})
+
+	// In quirks mode `documentElement.clientHeight` is the `<html>` box, so on a long
+	// page it reports the whole document and there is nothing left to clamp against.
+	it('never clamps against a viewport larger than the window', () => {
+		const { wrapper, header } = mount()
+		const clientHeight = vi
+			.spyOn(document.documentElement, 'clientHeight', 'get')
+			.mockReturnValue(3000) // a tall quirks-mode document in a 768px window
+
+		try {
+			drag(header, 0, 5000)
+
+			// 768 - 8 - 40 - 660, not the 2292 the document height would allow
+			expect(offsetOf(wrapper).y).toBe('60px')
+		} finally {
+			clientHeight.mockRestore()
+		}
+	})
+
+	// `innerWidth` counts a classic scrollbar, the layout viewport does not. Using
+	// the wider one parks the panel's edge underneath the scrollbar.
+	it('clamps against the layout viewport, not the scrollbar-inclusive one', () => {
+		const { wrapper, header } = mount()
+		// 1024 wide with a 24px classic scrollbar
+		const clientWidth = vi
+			.spyOn(document.documentElement, 'clientWidth', 'get')
+			.mockReturnValue(1000)
+
+		try {
+			drag(header, 5000, 0)
+
+			// 1000 - 8 - 360 - baseLeft(332), rather than the 324 innerWidth would allow
+			expect(offsetOf(wrapper).x).toBe('300px')
+		} finally {
+			clientWidth.mockRestore()
+		}
+	})
+
+	it('re-clamps when the window shrinks', () => {
+		vi.useFakeTimers()
+		const { wrapper, header } = mount()
+		vi.advanceTimersByTime(ENTRANCE_MS) // resizes are deferred until the entrance settles
+		drag(header, 300, 0)
+		expect(offsetOf(wrapper).x).toBe('300px')
+
+		// Narrower window re-centres the panel at (700 - 360) / 2 = 170,
+		// so x may now only reach 700 - 8 - 360 - 170 = 162
+		setViewportWidth(700)
+		window.dispatchEvent(new Event('resize'))
+
+		expect(offsetOf(wrapper).x).toBe('162px')
+	})
+
+	// A gesture that ends in `pointercancel` produces no click, so anything left
+	// armed to swallow one would eat the user's next real press instead.
+	const cancelledGestures = [
+		{ name: 'a cancelled drag', end: 'pointercancel', dx: 100 },
+		{ name: 'a cancelled press below the threshold', end: 'pointercancel', dx: 2 },
+	]
+	it.each(cancelledGestures)('leaves the header clickable after $name', ({ end, dx }) => {
+		const { wrapper, header } = mount()
+
+		header.dispatchEvent(pointer('pointerdown', 0, 0))
+		window.dispatchEvent(pointer('pointermove', dx, 0))
+		window.dispatchEvent(pointer(end, dx, 0))
+
+		// A fresh press-and-release must still toggle
+		drag(header, 0, 0)
+		expect(wrapper.classList.contains(styles.expanded)).toBe(true)
+	})
+
+	// The click that ends a drag lands on whatever is under the pointer, and
+	// bubbles to the header from there.
+	const clickTargets = [
+		{ name: 'the header itself', selector: null },
+		{ name: 'a header child', selector: 'statusSection' as const },
+	]
+	it.each(clickTargets)('suppresses the drag-ending click on $name', ({ selector }) => {
+		const { wrapper, header } = mount()
+		const target = selector ? wrapper.querySelector<HTMLElement>(`.${styles[selector]}`)! : header
+
+		header.dispatchEvent(pointer('pointerdown', 0, 0))
+		window.dispatchEvent(pointer('pointermove', 100, 0))
+		window.dispatchEvent(pointer('pointerup', 100, 0))
+		target.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+
+		expect(wrapper.classList.contains(styles.expanded)).toBe(false)
+	})
+
+	it('survives a second pointer lifting mid-drag', () => {
+		// The second finger never gets a gesture, but the browser still fires its
+		// `pointerup` at the window. Unguarded, that ends the drag the first finger
+		// is still performing, and the panel stops following it while it is down.
+		const { wrapper, header } = mount()
+
+		header.dispatchEvent(pointer('pointerdown', 0, 0))
+		window.dispatchEvent(pointer('pointermove', 100, 0))
+		expect(offsetOf(wrapper).x).toBe('100px')
+
+		const second = { pointerId: 2, isPrimary: false }
+		header.dispatchEvent(pointer('pointerdown', 500, 0, 0, second))
+		window.dispatchEvent(pointer('pointerup', 500, 0, 0, second))
+
+		window.dispatchEvent(pointer('pointermove', 200, 0))
+		expect(offsetOf(wrapper).x).toBe('200px')
+	})
+
+	it('ignores a second, non-primary pointer during a drag', () => {
+		const { wrapper, header } = mount()
+
+		header.dispatchEvent(pointer('pointerdown', 0, 0))
+		window.dispatchEvent(pointer('pointermove', 100, 0))
+		expect(offsetOf(wrapper).x).toBe('100px')
+
+		// A second finger presses elsewhere and drags back: unguarded, its own
+		// gesture would start from the current offset and yank the panel to -100px
+		header.dispatchEvent(pointer('pointerdown', 500, 0, 0, { pointerId: 2, isPrimary: false }))
+		window.dispatchEvent(pointer('pointermove', 300, 0, 0, { pointerId: 2, isPrimary: false }))
+		expect(offsetOf(wrapper).x).toBe('100px')
+
+		// ...and the first finger still owns the gesture
+		window.dispatchEvent(pointer('pointermove', 140, 0))
+		window.dispatchEvent(pointer('pointerup', 140, 0))
+		expect(offsetOf(wrapper).x).toBe('140px')
+	})
+
+	it('does not move a hidden panel', () => {
+		const { panel, wrapper, header } = mount()
+		panel.hide()
+
+		drag(header, 200, 100)
+
+		// A hidden panel measures zero; clamping against that would move it blindly
+		expect(offsetOf(wrapper)).toEqual({ x: '', y: '' })
+	})
+
+	// Measuring during the entrance reads a box that has not arrived yet. A panel
+	// parked against the bottom margin would be clamped by the leftover travel on
+	// every hide/show, walking it up the screen.
+	it('does not clamp against the entrance transition', () => {
+		vi.useFakeTimers()
+		const { panel, wrapper, header } = mount()
+
+		drag(header, 0, 5000) // park it against the bottom margin
+		expect(offsetOf(wrapper).y).toBe('60px')
+
+		panel.hide()
+		entranceShift = 20 // the entrance starts as soon as show() is called
+		panel.show()
+		expect(offsetOf(wrapper).y).toBe('60px')
+
+		entranceShift = 0 // ...and settles
+		vi.advanceTimersByTime(ENTRANCE_MS)
+
+		expect(offsetOf(wrapper).y).toBe('60px')
+	})
+
+	it('does not clamp a resize that lands during the entrance', () => {
+		// The resize handler measures the same in-flight box `show()` refuses to
+		// trust. Deferring to the re-clamp already scheduled for when the entrance
+		// settles keeps one code path honest instead of two.
+		vi.useFakeTimers()
+		const { panel, wrapper, header } = mount()
+
+		drag(header, 0, 5000) // park it against the bottom margin
+		expect(offsetOf(wrapper).y).toBe('60px')
+
+		panel.hide()
+		entranceShift = 20
+		panel.show()
+		window.dispatchEvent(new Event('resize'))
+		expect(offsetOf(wrapper).y).toBe('60px')
+
+		entranceShift = 0
+		vi.advanceTimersByTime(ENTRANCE_MS)
+
+		expect(offsetOf(wrapper).y).toBe('60px')
+	})
+
+	it('re-clamps on show after the window shrank while hidden', () => {
+		vi.useFakeTimers()
+		const { panel, wrapper, header } = mount()
+		drag(header, 300, 0)
+
+		panel.hide()
+		setViewportWidth(700)
+		window.dispatchEvent(new Event('resize'))
+		// The resize could not re-clamp: a hidden panel has no box to measure
+		expect(offsetOf(wrapper).x).toBe('300px')
+
+		panel.show()
+		vi.advanceTimersByTime(ENTRANCE_MS)
+
+		expect(offsetOf(wrapper).x).toBe('162px')
+	})
+
+	// A gesture is only half-owned by the panel: its move/end handlers live on
+	// `window`. Disposing mid-drag has to take them with it, or they outlive the
+	// panel holding a closure over a wrapper that is no longer on the page.
+	//
+	// Asserted as listener bookkeeping rather than by watching the offset: a real
+	// browser measures a detached wrapper as 0x0, so `#setDragOffset` would bail
+	// out on its own and hide a leak that is still there.
+	it('ignores a second primary pointer, so no gesture outlives dispose()', () => {
+		// A mouse and a pen report `isPrimary: true` at the same time, so the
+		// primary guard does not separate them. The second press used to overwrite
+		// the first gesture's teardown handle, and the first `pointerup` then
+		// cleared it — leaving the second gesture's listeners with nothing able to
+		// remove them.
+		const pointerListeners: string[] = []
+		const add = window.addEventListener.bind(window)
+		const remove = window.removeEventListener.bind(window)
+		const track = (set: 'add' | 'remove') => (type: string, fn: never, opts?: never) => {
+			if (type.startsWith('pointer')) {
+				if (set === 'add') pointerListeners.push(type)
+				else pointerListeners.splice(pointerListeners.indexOf(type), 1)
+			}
+			return set === 'add' ? add(type, fn, opts) : remove(type, fn, opts)
+		}
+		window.addEventListener = track('add') as typeof window.addEventListener
+		window.removeEventListener = track('remove') as typeof window.removeEventListener
+
+		try {
+			const { panel, header } = mount()
+
+			header.dispatchEvent(pointer('pointerdown', 0, 0))
+			window.dispatchEvent(pointer('pointermove', 60, 0))
+			// A pen lands while the mouse is still down
+			header.dispatchEvent(pointer('pointerdown', 0, 0, 0, { pointerId: 2 }))
+			expect(pointerListeners).toEqual(['pointermove', 'pointerup', 'pointercancel'])
+
+			// The mouse releases; the pen never got a gesture of its own to strand
+			window.dispatchEvent(pointer('pointerup', 60, 0))
+			panel.dispose()
+			active = null
+
+			expect(pointerListeners).toEqual([])
+		} finally {
+			window.addEventListener = add
+			window.removeEventListener = remove
+		}
+	})
+
+	it('detaches the in-flight gesture listeners when disposed mid-drag', () => {
+		// `pointerup` and `pointercancel` share one handler, so registrations are
+		// counted as (type, fn) pairs rather than by handler identity.
+		const pointerListeners: string[] = []
+		const add = window.addEventListener.bind(window)
+		const remove = window.removeEventListener.bind(window)
+		const track = (set: 'add' | 'remove') => (type: string, fn: never, opts?: never) => {
+			if (type.startsWith('pointer')) {
+				if (set === 'add') pointerListeners.push(type)
+				else pointerListeners.splice(pointerListeners.indexOf(type), 1)
+			}
+			return set === 'add' ? add(type, fn, opts) : remove(type, fn, opts)
+		}
+		window.addEventListener = track('add') as typeof window.addEventListener
+		window.removeEventListener = track('remove') as typeof window.removeEventListener
+
+		try {
+			const { panel, header } = mount()
+
+			header.dispatchEvent(pointer('pointerdown', 0, 0))
+			window.dispatchEvent(pointer('pointermove', 60, 0))
+			expect(pointerListeners).toEqual(['pointermove', 'pointerup', 'pointercancel'])
+
+			panel.dispose()
+			active = null
+
+			expect(pointerListeners).toEqual([])
+		} finally {
+			window.addEventListener = add
+			window.removeEventListener = remove
+		}
+	})
+
+	// A box with one zero axis is not a laid-out panel either, and clamping the
+	// other axis against a zero size would let it travel a full width off-screen.
+	const degenerateRects = [
+		{ name: 'zero width', width: 0, height: 40 },
+		{ name: 'zero height', width: 360, height: 0 },
+		{ name: 'zero on both axes', width: 0, height: 0 },
+	]
+	it.each(degenerateRects)(
+		'leaves the offset alone when the box has $name',
+		({ width, height }) => {
+			const { wrapper, header } = mount()
+
+			wrapper.getBoundingClientRect = () =>
+				({
+					left: 332,
+					top: 660,
+					right: 332 + width,
+					bottom: 660 + height,
+					x: 332,
+					y: 660,
+					width,
+					height,
+					toJSON: () => ({}),
+				}) as DOMRect
+
+			drag(header, 5000, 5000)
+
+			expect(offsetOf(wrapper)).toEqual({ x: '', y: '' })
+		}
+	)
+
+	// The trailing click of a drag is queued behind the `pointerup`. A press that
+	// cannot start a gesture must not clear the suppression flag in that gap, or
+	// the drag ends up toggling the panel as well as moving it.
+	const racingPresses = [
+		{ name: 'a secondary mouse button', button: 2, init: {} },
+		{ name: 'a second, non-primary contact', button: 0, init: { isPrimary: false } },
+	]
+	it.each(racingPresses)(
+		'still suppresses the drag click when $name races the click',
+		({ button, init }) => {
+			const { wrapper, header } = mount()
+
+			header.dispatchEvent(pointer('pointerdown', 0, 0))
+			window.dispatchEvent(pointer('pointermove', 80, 0))
+			window.dispatchEvent(pointer('pointerup', 80, 0))
+
+			// Lands after the gesture ended but before its click was delivered
+			header.dispatchEvent(pointer('pointerdown', 80, 0, button, init))
+			header.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+
+			expect(offsetOf(wrapper).x).toBe('80px')
+			expect(wrapper.classList.contains(styles.expanded)).toBe(false)
+		}
+	)
+
+	it('stops re-clamping once disposed', () => {
+		const { panel, wrapper, header } = mount()
+		drag(header, 300, 0)
+
+		panel.dispose()
+		active = null
+
+		setViewportWidth(700)
+		window.dispatchEvent(new Event('resize'))
+
+		expect(offsetOf(wrapper).x).toBe('300px')
+	})
+})

--- a/packages/ui/src/panel/Panel.module.css
+++ b/packages/ui/src/panel/Panel.module.css
@@ -2,7 +2,14 @@
 	position: fixed;
 	bottom: 100px;
 	left: 50%;
-	transform: translateX(-50%) translateY(20px);
+	/* `--drag-x` / `--drag-y` are written by the drag handler. Panel.ts sets the
+	   same transform inline in show()/hide(), and must keep this suffix.
+	   Declared here rather than left to the `var()` fallback: custom properties
+	   inherit, and the panel is injected into pages we do not control, so a host
+	   page using these names would otherwise shift the panel across the screen. */
+	--drag-x: 0px;
+	--drag-y: 0px;
+	transform: translateX(-50%) translateY(20px) translate(var(--drag-x, 0px), var(--drag-y, 0px));
 	opacity: 0;
 	z-index: 2147483642; /* 比 SimulatorMask 高一层 */
 	box-sizing: border-box;
@@ -29,6 +36,11 @@
 	height: var(--height);
 
 	transition: all 0.3s ease-in-out;
+
+	/* No transition while dragging, or the panel lags behind the pointer */
+	&.dragging {
+		transition: none;
+	}
 
 	/* 响应式设计 */
 	@media (max-width: 480px) {
@@ -106,8 +118,14 @@
 	position: absolute;
 	inset: 0;
 
-	cursor: pointer;
+	/* The header doubles as the drag handle */
+	cursor: grab;
+	touch-action: none; /* Don't scroll the page while dragging by touch */
 	flex-shrink: 0; /* 防止 header 被压缩 */
+
+	.dragging & {
+		cursor: grabbing;
+	}
 
 	background: rgba(0, 0, 0, 0.5);
 	backdrop-filter: blur(10px);

--- a/packages/ui/src/panel/Panel.ts
+++ b/packages/ui/src/panel/Panel.ts
@@ -1,9 +1,21 @@
 import { I18n, type SupportedLanguage } from '../i18n'
 import { truncate } from '../utils'
 import { createCard, createReflectionLines } from './cards'
+import { DRAG_THRESHOLD, type DragOffset, clampDragOffset } from './drag'
 import type { AgentActivity, PanelAgentAdapter } from './types'
 
 import styles from './Panel.module.css'
+
+/**
+ * Drag offset carried in the wrapper transform.
+ *
+ * show()/hide() set `transform` inline, which overrides the class rule, so both
+ * must re-append this or the panel would jump back to its default position.
+ */
+const DRAG_TRANSFORM = 'translate(var(--drag-x, 0px), var(--drag-y, 0px))'
+
+/** How long the wrapper's entrance takes, matching `transition` in Panel.module.css */
+const ENTRANCE_MS = 300
 
 /**
  * Panel configuration
@@ -46,12 +58,44 @@ export class Panel {
 	#headerUpdateTimer: ReturnType<typeof setInterval> | null = null
 	#pendingHeaderText: string | null = null
 	#isAnimating = false
+	/** Current drag offset, mirrored into `--drag-x` / `--drag-y` */
+	#dragOffset: DragOffset = { x: 0, y: 0 }
+	/**
+	 * Set when a gesture ends after really dragging, cleared by the next press
+	 * and consumed by the click that follows the gesture.
+	 *
+	 * A flag rather than a one-shot listener on the header: a gesture that ends in
+	 * `pointercancel` (touch interrupted, palm rejected) is followed by no click at
+	 * all, so a listener would survive and swallow the user's next genuine press.
+	 */
+	#draggedSincePress = false
+	/**
+	 * Tears down the gesture currently in flight, or `null` when none is.
+	 *
+	 * The move/end handlers live on `window` for the length of one gesture, so a
+	 * `dispose()` mid-drag would otherwise leave them attached to a panel that is
+	 * already off the page, still writing offsets to the detached wrapper.
+	 */
+	#endActiveDrag: (() => void) | null = null
+	/** Pending post-entrance re-clamp scheduled by `show()` */
+	#entranceTimer: ReturnType<typeof setTimeout> | null = null
 
 	// Event handlers (bound for removal)
 	#onStatusChange = () => this.#handleStatusChange()
 	#onHistoryChange = () => this.#handleHistoryChange()
 	#onActivity = (e: Event) => this.#handleActivity((e as CustomEvent<AgentActivity>).detail)
 	#onAgentDispose = () => this.dispose()
+	/**
+	 * Re-clamp on resize, or shrinking the window would strand the panel off-screen.
+	 *
+	 * Not while the entrance is still running: that measures the box mid-animation,
+	 * which is the same reading `show()` refuses to trust. The re-clamp already
+	 * scheduled for when it settles sees the new viewport anyway.
+	 */
+	#onWindowResize = () => {
+		if (this.#entranceTimer !== null) return
+		this.#setDragOffset(this.#dragOffset)
+	}
 
 	get wrapper(): HTMLElement {
 		return this.#wrapper
@@ -85,6 +129,7 @@ export class Panel {
 		this.#agent.addEventListener('historychange', this.#onHistoryChange)
 		this.#agent.addEventListener('activity', this.#onActivity)
 		this.#agent.addEventListener('dispose', this.#onAgentDispose)
+		window.addEventListener('resize', this.#onWindowResize)
 
 		this.#setupEventListeners()
 		this.#startHeaderUpdateLoop()
@@ -227,12 +272,23 @@ export class Panel {
 		this.wrapper.style.display = 'block'
 		void this.wrapper.offsetHeight
 		this.wrapper.style.opacity = '1'
-		this.wrapper.style.transform = 'translateX(-50%) translateY(0)'
+		this.wrapper.style.transform = `translateX(-50%) translateY(0) ${DRAG_TRANSFORM}`
+		// A hidden panel measures zero, so resizes that happened while it was hidden
+		// never re-clamped it. Do that here, or a shrunken window strands the panel
+		// off-screen with its only drag handle out of reach.
+		//
+		// Once the entrance has settled, not now: `getBoundingClientRect()` reports
+		// the box as it is being animated, which puts the base a whole entrance
+		// offset out. A panel left against the bottom edge would then be clamped
+		// that far up by every hide/show.
+		this.#reclampWhenEntranceSettles()
 	}
 
 	hide(): void {
+		// Hidden again before the entrance settled: nothing left to measure
+		this.#cancelEntranceReclamp()
 		this.wrapper.style.opacity = '0'
-		this.wrapper.style.transform = 'translateX(-50%) translateY(20px)'
+		this.wrapper.style.transform = `translateX(-50%) translateY(20px) ${DRAG_TRANSFORM}`
 		this.wrapper.style.display = 'none'
 	}
 
@@ -265,6 +321,9 @@ export class Panel {
 		this.#agent.removeEventListener('historychange', this.#onHistoryChange)
 		this.#agent.removeEventListener('activity', this.#onActivity)
 		this.#agent.removeEventListener('dispose', this.#onAgentDispose)
+		window.removeEventListener('resize', this.#onWindowResize)
+		this.#endActiveDrag?.()
+		this.#cancelEntranceReclamp()
 
 		// Clean up UI
 		this.#isWaitingForUserAnswer = false
@@ -437,8 +496,15 @@ export class Panel {
 
 	#setupEventListeners(): void {
 		// Click header area to expand/collapse
-		const header = this.wrapper.querySelector(`.${styles.header}`)!
+		const header = this.wrapper.querySelector<HTMLElement>(`.${styles.header}`)!
+		this.#setupDragging(header)
 		header.addEventListener('click', (e) => {
+			// The click that ends a drag must not toggle as well. Read and clear, so
+			// the very next click works normally.
+			if (this.#draggedSincePress) {
+				this.#draggedSincePress = false
+				return
+			}
 			// Don't trigger expand/collapse if clicking on buttons
 			if ((e.target as HTMLElement).closest(`.${styles.controlButton}`)) {
 				return
@@ -471,6 +537,162 @@ export class Panel {
 		this.#inputSection.addEventListener('click', (e) => {
 			e.stopPropagation()
 		})
+	}
+
+	/**
+	 * Make the panel draggable by its header.
+	 *
+	 * Pointer Events cover mouse, touch and pen with one code path. A press only
+	 * becomes a drag once it travels past `DRAG_THRESHOLD`; below that it stays a
+	 * plain click and still toggles expand/collapse.
+	 */
+	#setupDragging(header: HTMLElement): void {
+		header.addEventListener('pointerdown', (e: PointerEvent) => {
+			if (e.button !== 0) return // primary button / contact only
+			// A second finger must not hijack a drag already in progress
+			if (!e.isPrimary) return
+			// Nor a second primary pointer. A mouse and a pen are primary at the same
+			// time, so the guard above lets both through, and the later press would
+			// overwrite the teardown handle for the gesture still running — leaving
+			// its listeners with nothing able to remove them.
+			if (this.#endActiveDrag) return
+
+			// Every press that could produce a click clears the flag: a cancelled drag
+			// leaves it set, and no click reaches the header without a pointerdown
+			// first. Deliberately after the two guards above, since a secondary button
+			// or a second finger landing between a drag's `pointerup` and its trailing
+			// `click` would otherwise clear the flag early and let that click toggle
+			// after all.
+			this.#draggedSincePress = false
+
+			// Let the control buttons keep their own behaviour
+			if ((e.target as HTMLElement).closest(`.${styles.controlButton}`)) return
+
+			const origin = { ...this.#dragOffset }
+			let dragging = false
+
+			// Keeps the gesture alive when the pointer leaves the header.
+			// Absent in some test DOMs and old browsers, hence the guard.
+			header.setPointerCapture?.(e.pointerId)
+
+			const onMove = (ev: PointerEvent) => {
+				if (ev.pointerId !== e.pointerId) return
+				const dx = ev.clientX - e.clientX
+				const dy = ev.clientY - e.clientY
+
+				if (!dragging) {
+					if (Math.hypot(dx, dy) < DRAG_THRESHOLD) return
+					dragging = true
+					this.wrapper.classList.add(styles.dragging)
+				}
+
+				this.#setDragOffset({ x: origin.x + dx, y: origin.y + dy })
+			}
+
+			const detach = () => {
+				window.removeEventListener('pointermove', onMove)
+				window.removeEventListener('pointerup', onEnd)
+				window.removeEventListener('pointercancel', onEnd)
+				this.#endActiveDrag = null
+			}
+
+			const onEnd = (ev: PointerEvent) => {
+				if (ev.pointerId !== e.pointerId) return
+				detach()
+
+				if (!dragging) return
+				this.wrapper.classList.remove(styles.dragging)
+				// A `pointerup` after a real drag is followed by a `click` on the header;
+				// the header's click handler consumes this flag instead of toggling.
+				this.#draggedSincePress = true
+			}
+
+			window.addEventListener('pointermove', onMove)
+			window.addEventListener('pointerup', onEnd)
+			window.addEventListener('pointercancel', onEnd)
+			// `dispose()` can land mid-gesture; give it a way to drop these again.
+			this.#endActiveDrag = detach
+		})
+	}
+
+	/**
+	 * Re-clamp once the entrance transition has finished.
+	 *
+	 * Timed rather than driven by `transitionend`: the wrapper transitions several
+	 * properties, and a panel shown while already visible fires nothing at all.
+	 */
+	#reclampWhenEntranceSettles(): void {
+		this.#cancelEntranceReclamp()
+		this.#entranceTimer = setTimeout(() => {
+			this.#entranceTimer = null
+			this.#setDragOffset(this.#dragOffset)
+		}, ENTRANCE_MS)
+	}
+
+	#cancelEntranceReclamp(): void {
+		if (this.#entranceTimer === null) return
+		clearTimeout(this.#entranceTimer)
+		this.#entranceTimer = null
+	}
+
+	/**
+	 * Clamp `next` into the viewport and write it to the CSS custom properties.
+	 *
+	 * The measured box is the wrapper — the collapsed header — not the expanded
+	 * panel: the history list and input row are absolutely positioned siblings that
+	 * sit outside it. Clamping their union would make a tall history exceed the
+	 * viewport and lock the drag through `clampDragOffset`'s degenerate branch,
+	 * which is far worse than letting them clip while the handle stays grabbable.
+	 *
+	 * The cost lands on the input row, which sits below the header: at the bottom
+	 * clamp only its top few pixels remain on screen, so a panel parked there
+	 * cannot be typed into until it is dragged back up. Reserving its height would
+	 * mean clamping against a box that changes with the panel's own state, so this
+	 * stays a known limitation rather than a special case here.
+	 */
+	/**
+	 * The box to clamp the panel inside.
+	 *
+	 * `documentElement.clientWidth/Height` is the layout viewport, which leaves out
+	 * a classic scrollbar; `innerWidth/Height` counts it, so the panel's edge would
+	 * come to rest underneath one.
+	 *
+	 * Capped by the window all the same. In quirks mode `clientHeight` is the
+	 * `<html>` box rather than the viewport, so on a long page it reads as the whole
+	 * document and the panel could be dragged below the fold with nothing to stop
+	 * it. Zero means an environment that lays nothing out, where only the window is
+	 * meaningful.
+	 */
+	#viewportSize(): { width: number; height: number } {
+		const doc = document.documentElement
+		return {
+			width: Math.min(doc.clientWidth || window.innerWidth, window.innerWidth),
+			height: Math.min(doc.clientHeight || window.innerHeight, window.innerHeight),
+		}
+	}
+
+	#setDragOffset(next: DragOffset): void {
+		const rect = this.wrapper.getBoundingClientRect()
+		// A zero-size rect means the panel is not rendered (e.g. hidden). Clamping
+		// against it would move the panel for no reason, so keep the offset as is.
+		// Either axis being zero is enough: clamping the other one against a zero
+		// size lets the panel travel a full box-width past the viewport edge.
+		if (rect.width === 0 || rect.height === 0) return
+
+		this.#dragOffset = clampDragOffset(
+			next,
+			{
+				// The rect already includes the current offset; undo it to get the base box.
+				left: rect.left - this.#dragOffset.x,
+				top: rect.top - this.#dragOffset.y,
+				width: rect.width,
+				height: rect.height,
+			},
+			this.#viewportSize()
+		)
+
+		this.wrapper.style.setProperty('--drag-x', `${this.#dragOffset.x}px`)
+		this.wrapper.style.setProperty('--drag-y', `${this.#dragOffset.y}px`)
 	}
 
 	#toggle(): void {

--- a/packages/ui/src/panel/drag.test.ts
+++ b/packages/ui/src/panel/drag.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest'
+
+import { type BaseRect, DRAG_MARGIN, type DragOffset, clampDragOffset } from './drag'
+
+/** A 360x40 panel sitting bottom-centre of a 1000x800 viewport, like the default panel. */
+const viewport = { width: 1000, height: 800 }
+const panel: BaseRect = { left: 320, top: 660, width: 360, height: 40 }
+
+// Bounds implied by `panel` + `viewport` + margin 8:
+//   x in [8 - 320, 1000 - 8 - 360 - 320] = [-312, 312]
+//   y in [8 - 660, 800 - 8 - 40 - 660]   = [-652, 92]
+
+const cases: {
+	name: string
+	offset: DragOffset
+	base?: BaseRect
+	viewport?: { width: number; height: number }
+	margin?: number
+	expected: DragOffset
+}[] = [
+	{ name: 'no-op drag stays put', offset: { x: 0, y: 0 }, expected: { x: 0, y: 0 } },
+	{ name: 'drag right', offset: { x: 100, y: 0 }, expected: { x: 100, y: 0 } },
+	{ name: 'drag left', offset: { x: -100, y: 0 }, expected: { x: -100, y: 0 } },
+	{ name: 'drag up', offset: { x: 0, y: -200 }, expected: { x: 0, y: -200 } },
+	{ name: 'drag down', offset: { x: 0, y: 50 }, expected: { x: 0, y: 50 } },
+	{ name: 'drag diagonally', offset: { x: -40, y: 60 }, expected: { x: -40, y: 60 } },
+
+	// Clamped at each edge
+	{ name: 'clamped at left edge', offset: { x: -9999, y: 0 }, expected: { x: -312, y: 0 } },
+	{ name: 'clamped at right edge', offset: { x: 9999, y: 0 }, expected: { x: 312, y: 0 } },
+	{ name: 'clamped at top edge', offset: { x: 0, y: -9999 }, expected: { x: 0, y: -652 } },
+	{ name: 'clamped at bottom edge', offset: { x: 0, y: 9999 }, expected: { x: 0, y: 92 } },
+	{
+		name: 'clamped on both axes at once',
+		offset: { x: -9999, y: 9999 },
+		expected: { x: -312, y: 92 },
+	},
+
+	// Exact boundary values are allowed through untouched
+	{ name: 'exactly on the left bound', offset: { x: -312, y: 0 }, expected: { x: -312, y: 0 } },
+	{ name: 'exactly on the right bound', offset: { x: 312, y: 0 }, expected: { x: 312, y: 0 } },
+	{ name: 'exactly on the top bound', offset: { x: 0, y: -652 }, expected: { x: 0, y: -652 } },
+	{ name: 'exactly on the bottom bound', offset: { x: 0, y: 92 }, expected: { x: 0, y: 92 } },
+	{ name: 'one px past the right bound', offset: { x: 313, y: 0 }, expected: { x: 312, y: 0 } },
+	{ name: 'one px inside the right bound', offset: { x: 311, y: 0 }, expected: { x: 311, y: 0 } },
+
+	// Margin is honoured
+	{
+		name: 'zero margin lets the panel touch the edge',
+		offset: { x: 9999, y: 9999 },
+		margin: 0,
+		expected: { x: 320, y: 100 },
+	},
+	{
+		name: 'a large margin shrinks the travel',
+		offset: { x: 9999, y: 9999 },
+		margin: 100,
+		expected: { x: 220, y: 0 },
+	},
+
+	// Degenerate: panel bigger than the viewport. The lower bound wins, so the
+	// top-left corner parks at `margin` and the overflow runs off bottom-right.
+	{
+		name: 'panel wider than the viewport pins its left edge to the margin',
+		offset: { x: 9999, y: 0 },
+		base: { left: 0, top: 660, width: 1200, height: 40 },
+		expected: { x: 8, y: 0 },
+	},
+	{
+		name: 'panel wider than the viewport ignores a leftward drag too',
+		offset: { x: -9999, y: 0 },
+		base: { left: 0, top: 660, width: 1200, height: 40 },
+		expected: { x: 8, y: 0 },
+	},
+	{
+		name: 'panel taller than the viewport pins its top edge to the margin',
+		offset: { x: 0, y: 9999 },
+		base: { left: 320, top: 0, width: 360, height: 900 },
+		expected: { x: 0, y: 8 },
+	},
+
+	// Degenerate: no layout information at all
+	{
+		name: 'zero-size rect at the origin snaps to the margin',
+		offset: { x: 0, y: 0 },
+		base: { left: 0, top: 0, width: 0, height: 0 },
+		expected: { x: 8, y: 8 },
+	},
+	{
+		name: 'zero-size rect still clamps to the far edge',
+		offset: { x: 9999, y: 9999 },
+		base: { left: 0, top: 0, width: 0, height: 0 },
+		expected: { x: 992, y: 792 },
+	},
+]
+
+describe('clampDragOffset', () => {
+	it.each(cases)('$name', ({ offset, base, viewport: vp, margin, expected }) => {
+		expect(clampDragOffset(offset, base ?? panel, vp ?? viewport, margin)).toEqual(expected)
+	})
+
+	it('defaults to an 8px margin', () => {
+		expect(DRAG_MARGIN).toBe(8)
+		expect(clampDragOffset({ x: 9999, y: 0 }, panel, viewport)).toEqual(
+			clampDragOffset({ x: 9999, y: 0 }, panel, viewport, 8)
+		)
+	})
+})

--- a/packages/ui/src/panel/drag.ts
+++ b/packages/ui/src/panel/drag.ts
@@ -1,0 +1,67 @@
+/**
+ * Geometry for dragging the panel.
+ *
+ * The panel is positioned by CSS (`position: fixed` + a `transform` that carries
+ * both the centring and the show/hide animation). Dragging therefore does not
+ * touch `left`/`top`; it only feeds an extra offset into the transform through
+ * the `--drag-x` / `--drag-y` custom properties. This module holds the pure maths
+ * so it can be tested without a layout engine.
+ */
+
+/** Minimum gap kept between the panel and each viewport edge, in px. */
+export const DRAG_MARGIN = 8
+
+/** Pointer movement (px) that turns a press into a drag instead of a click. */
+export const DRAG_THRESHOLD = 4
+
+export interface DragOffset {
+	x: number
+	y: number
+}
+
+/** The panel's box as it would sit with a zero drag offset. */
+export interface BaseRect {
+	left: number
+	top: number
+	width: number
+	height: number
+}
+
+export interface ViewportSize {
+	width: number
+	height: number
+}
+
+/**
+ * Clamp `offset` so the panel stays inside the viewport with `margin` to spare
+ * on every side.
+ *
+ * Degenerate case: when the panel is larger than the viewport minus both
+ * margins there is no offset that satisfies both bounds. The lower bound wins,
+ * which pins the panel's top-left corner at `margin` and lets the overflow run
+ * off the bottom-right — the header (drag handle and buttons) stays reachable.
+ */
+export function clampDragOffset(
+	offset: DragOffset,
+	base: BaseRect,
+	viewport: ViewportSize,
+	margin: number = DRAG_MARGIN
+): DragOffset {
+	return {
+		x: clampAxis(offset.x, base.left, base.width, viewport.width, margin),
+		y: clampAxis(offset.y, base.top, base.height, viewport.height, margin),
+	}
+}
+
+function clampAxis(
+	value: number,
+	baseStart: number,
+	size: number,
+	viewportSize: number,
+	margin: number
+): number {
+	const min = margin - baseStart
+	const max = viewportSize - margin - size - baseStart
+	// `min` last so it wins when min > max (panel bigger than the viewport).
+	return Math.max(Math.min(value, max), min)
+}

--- a/packages/ui/vitest.config.js
+++ b/packages/ui/vitest.config.js
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+	test: {
+		name: 'ui',
+		environment: 'happy-dom',
+		include: ['src/**/*.test.ts'],
+		silent: 'passed-only',
+	},
+})


### PR DESCRIPTION
## What

The panel is fixed at bottom-centre and cannot be moved, so it sits on top of the page content the agent is working on. This makes the header a drag handle.

The offset is applied as a CSS custom property rather than by rewriting `left`/`top`. The wrapper's `transform` already carries the `translateX(-50%)` centring and the show/hide entrance animation, and a media query resizes it under 480px, so rewriting the positioning would fight all three. `.wrapper` gains `translate(var(--drag-x, 0px), var(--drag-y, 0px))` and declares both to `0px`, and dragging sets only those two properties. The declaration matters because custom properties inherit and the panel is injected into pages we do not control: left to the `var()` fallback, a host page using either name shifts the panel across the screen.

- `.header` is the handle, on Pointer Events so mouse, touch and pen share one path. `touch-action: none`, `cursor: grab`/`grabbing`. Presses on the control buttons, on a non-primary button, or from a second contact are ignored.
- A 4px threshold on true distance separates a click from a drag, so the header's expand/collapse toggle still works. The click that ends a drag is consumed by a flag cleared on the next press. A one-shot capture listener does not work here: a gesture ending in `pointercancel` is followed by no click at all, so the listener survives and eats the user's next genuine press.
- Offsets keep an 8px margin inside the layout viewport — `documentElement.clientWidth/Height`, which excludes a classic scrollbar, capped by the window so quirks mode cannot report the whole document as the viewport — during a drag, on window resize, and on `show()`. A hidden panel measures zero, so a resize while it is hidden never re-clamps. Without the `show()` clamp, dragging right, closing, then narrowing the window leaves the panel off-screen with its only handle out of reach. That clamp waits for the entrance transition to settle: `getBoundingClientRect()` reports the box mid-animation, and a panel parked against the bottom edge would otherwise be walked upwards by every hide/show. A resize landing inside that window is deferred to the same scheduled clamp for the same reason — clamping a corrupted offset later is a no-op, so the error would stick.
- `dispose()` tears down a gesture still in flight, whose move and end handlers live on `window` rather than on the panel. Only one gesture runs at a time: a mouse and a pen are both primary at once, so a second primary press is ignored rather than allowed to overwrite the teardown handle for the gesture already running.
- `show()` and `hide()` write `transform` inline, which overrides the class rule, so both carry the same `var()` suffix. Without it, every show/hide resets the drag.
- The clamping maths is a pure module so it can be tested without a layout engine.

The default position is unchanged.

Known limitation: clamping measures the wrapper, which is the collapsed header. The history list and input row are absolutely positioned siblings outside that box, so an expanded panel dragged to the top clips history off-screen, and one parked at the bottom clamp leaves only the top few pixels of the input row visible — 8px of 48px — so it cannot be typed into until it is dragged back up. Clamping their union instead would let a tall history exceed the viewport and lock the drag through the degenerate branch, which is worse, and reserving the input row's height would mean clamping against a box that changes with the panel's own state. The handle stays grabbable either way.

The 8px margin is the interactive one. `.background` overhangs the wrapper by 8px horizontally and carries a 16px blur, so the glow is clipped at the edge; fully containing it would need a 24px dead zone, which costs more than it buys.

Closes #547

## Type

- [ ] Breaking change
- [ ] Bug fix
- [x] Feature / Improvement
- [ ] Refactor / Chores
- [ ] Documentation / Website / Demo / Testing

## Testing

- [x] `npm run ci` passes
- [x] Tested in modern browsers
- [x] Types/doc added

`packages/ui` had no test setup. This adds `vitest.config.js` (happy-dom) and a `test` script, matching the config style in `page-controller`.

65 tests. A table over the clamping maths covers all four edges, both axes at once, exact boundaries, a panel larger than the viewport, a zero rect, and margins of 0, 8 and 100. A table over the gesture in happy-dom covers the threshold at 0, 3, 2+3, 3+3 and 4px, drag versus click, `pointercancel`, a second contact, the control buttons, presses that race a drag's trailing click, show/hide preserving the offset, resize and entrance re-clamp, a resize that lands mid-entrance, a scrollbar-inclusive viewport, a quirks-mode viewport larger than the window, degenerate boxes, a second pointer lifting mid-drag, and gesture teardown on dispose for both a single gesture and an overlapping second primary pointer.

Every production line the tests cover was mutation-checked: reverting it makes a named test fail. That caught two tests that had been passing for the wrong reason, one measuring from a base the viewport had moved and one unable to tell `Math.hypot` from a Manhattan distance.

Verified in Chrome against a built demo bundle driven by real mouse input: the drag tracks the cursor 1:1, clamps to 8px at every edge, a crisp click and a 3px wobble both toggle while a deliberate drag does not, `grabbing` and the suppressed transition apply mid-drag only, narrowing the window walks the panel back inward to the pixel the unit test predicts, dragging to the bottom edge then hiding and showing leaves the offset untouched, `dispose()` mid-drag detaches all three window listeners, and the default position matches main exactly at x=460, y=580.

## Requirements / 要求

- [x] I have read and follow the [Code of Conduct](../docs/CODE_OF_CONDUCT.md) and [Contributing Guide](../CONTRIBUTING.md) . / 我已阅读并遵守行为准则。
- [x] This PR is NOT generated by a bot or AI agent acting autonomously. I have authored or meaningfully reviewed every change. / 此 PR 不是由 bot 或 AI 自主生成的，我已亲自编写或充分审查了每一处变更。





