### PR TITLE
feat(page-controller): expose doHighlightElements and highlightLabelTextOpacity

### DIFF
--- a/packages/page-controller/src/dom/dom_tree/index.d.ts
+++ b/packages/page-controller/src/dom/dom_tree/index.d.ts
@@ -9,6 +9,7 @@ interface DomTreeArgs {
 	interactiveWhitelist?: Element[]
 	highlightOpacity?: number
 	highlightLabelOpacity?: number
+	highlightLabelTextOpacity?: number
 }
 
 declare const domTree: (args?: DomTreeArgs) => FlatDomTree

--- a/packages/page-controller/src/dom/dom_tree/index.js
+++ b/packages/page-controller/src/dom/dom_tree/index.js
@@ -19,7 +19,20 @@
  * @edit exclude aria-hidden elements
  * @edit make sure attributes exist for interactive candidates.
  * @edit fix "aria-*" attributes check
+ * @edit adjustable label text opacity
+ * @edit doHighlightElements only skips painting, indexing is unaffected
  */
+
+/**
+ * @edit adjustable opacity
+ * Encodes an opacity (0-1) as the alpha byte suffix of a #rrggbb color.
+ * @param {number} opacity
+ * @returns {string}
+ */
+const toAlphaHex = (opacity) =>
+	Math.floor(opacity * 255)
+		.toString(16)
+		.padStart(2, '0')
 
 export default (
 	args = {
@@ -37,13 +50,19 @@ export default (
 		interactiveWhitelist: [],
 		highlightOpacity: 0.1,
 		highlightLabelOpacity: 0.5,
+		highlightLabelTextOpacity: 1,
 	}
 ) => {
 	/**
 	 * @edit
 	 */
-	const { interactiveBlacklist, interactiveWhitelist, highlightOpacity, highlightLabelOpacity } =
-		args
+	const {
+		interactiveBlacklist,
+		interactiveWhitelist,
+		highlightOpacity,
+		highlightLabelOpacity,
+		highlightLabelTextOpacity,
+	} = args
 
 	const { doHighlightElements, focusHighlightIndex, viewportExpansion, debugMode } = args
 	let highlightIndex = 0 // Reset highlight index
@@ -227,16 +246,8 @@ export default (
 			 * @edit adjustable opacity
 			 */
 			// const backgroundColor = baseColor + "1A"; // 10% opacity version of the color
-			const backgroundColor =
-				baseColor +
-				Math.floor(highlightOpacity * 255)
-					.toString(16)
-					.padStart(2, '0')
-			baseColor =
-				baseColor +
-				Math.floor(highlightLabelOpacity * 255)
-					.toString(16)
-					.padStart(2, '0')
+			const backgroundColor = baseColor + toAlphaHex(highlightOpacity)
+			baseColor = baseColor + toAlphaHex(highlightLabelOpacity)
 
 			// Get iframe offset if necessary
 			let iframeOffset = { x: 0, y: 0 }
@@ -278,7 +289,10 @@ export default (
 			label.className = 'playwright-highlight-label'
 			label.style.position = 'fixed'
 			label.style.background = baseColor
-			label.style.color = 'white'
+			/**
+			 * @edit adjustable label text opacity
+			 */
+			label.style.color = '#ffffff' + toAlphaHex(highlightLabelTextOpacity ?? 1)
 			label.style.padding = '1px 4px'
 			label.style.borderRadius = '4px'
 			label.style.fontSize = `${Math.min(12, Math.max(8, firstRect.height / 2))}px`
@@ -1415,7 +1429,10 @@ export default (
    * @param {HTMLElement} node - The node to highlight.
    * @param {HTMLElement | null} parentIframe - The parent iframe node.
    * @param {boolean} isParentHighlighted - Whether the parent node is highlighted.
-   * @returns {boolean} Whether the element was highlighted.
+   * @edit reports index assignment, not painting. Since doHighlightElements only skips
+   * painting, an element can be indexed without an overlay being drawn. Children read
+   * this as their `isParentHighlighted`, so it must not depend on the overlay.
+   * @returns {boolean} Whether a highlight index was assigned to the element.
    */
 	function handleHighlighting(nodeData, node, parentIframe, isParentHighlighted) {
 		if (!nodeData.isInteractive) return false // Not interactive, definitely don't highlight
@@ -1451,14 +1468,20 @@ export default (
 					} else {
 						highlightElement(node, nodeData.highlightIndex, parentIframe)
 					}
-					return true // Successfully highlighted
 				}
+
+				/**
+				 * @edit doHighlightElements only skips painting, indexing is unaffected.
+				 * Children must see the same parent-highlighted status either way,
+				 * otherwise turning off the overlay would change the assigned indexes.
+				 */
+				return true // Index assigned
 			} else {
 				// console.log(`Skipping highlight for ${nodeData.tagName} (outside viewport)`);
 			}
 		}
 
-		return false // Did not highlight
+		return false // No index assigned
 	}
 
 	/**

--- a/packages/page-controller/src/dom/dom_tree/index.test.ts
+++ b/packages/page-controller/src/dom/dom_tree/index.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { cleanUpHighlights } from '../index'
+import domTree from './index.js'
+
+const LABEL_SELECTOR = '.playwright-highlight-label'
+const CONTAINER_ID = 'playwright-highlight-container'
+
+/**
+ * happy-dom does no layout, so offsetWidth/offsetHeight are always 0 and the
+ * element would be treated as invisible. Fake the box the visibility check reads.
+ */
+function makeVisible<T extends HTMLElement>(element: T): T {
+	Object.defineProperty(element, 'offsetWidth', { value: 100 })
+	Object.defineProperty(element, 'offsetHeight', { value: 40 })
+	return element
+}
+
+function addVisibleButton(text: string): HTMLButtonElement {
+	const button = document.createElement('button')
+	button.textContent = text
+	document.body.appendChild(button)
+	return makeVisible(button)
+}
+
+function run(args: Record<string, unknown>) {
+	return domTree({
+		focusHighlightIndex: -1,
+		viewportExpansion: -1,
+		debugMode: false,
+		interactiveBlacklist: [],
+		interactiveWhitelist: [],
+		highlightOpacity: 0.5,
+		highlightLabelOpacity: 0.5,
+		...args,
+	})
+}
+
+function highlightIndexes(tree: ReturnType<typeof domTree>): number[] {
+	return Object.values(tree.map)
+		.map((node) => (node as { highlightIndex?: number }).highlightIndex)
+		.filter((index): index is number => typeof index === 'number')
+}
+
+describe('domTree highlighting', () => {
+	beforeEach(() => {
+		document.body.innerHTML = ''
+	})
+
+	afterEach(() => {
+		document.getElementById(CONTAINER_ID)?.remove()
+		;((window as any)._highlightCleanupFunctions || []).forEach((fn: () => void) => fn())
+		;(window as any)._highlightCleanupFunctions = []
+	})
+
+	const labelTextOpacityCases: { name: string; args: Record<string, unknown>; color: string }[] = [
+		{ name: 'omitted defaults to fully opaque', args: {}, color: '#ffffffff' },
+		{
+			name: '0 makes the index invisible',
+			args: { highlightLabelTextOpacity: 0 },
+			color: '#ffffff00',
+		},
+		{ name: '0.1', args: { highlightLabelTextOpacity: 0.1 }, color: '#ffffff19' },
+		{ name: '0.5', args: { highlightLabelTextOpacity: 0.5 }, color: '#ffffff7f' },
+		{ name: '1 stays fully opaque', args: { highlightLabelTextOpacity: 1 }, color: '#ffffffff' },
+		// Not clamped, so an out-of-range value encodes to something no parser accepts.
+		// The declaration is dropped and the digits inherit their colour; the label is
+		// still painted, which is what the option's `@note` promises.
+		{
+			name: 'above 1 drops the colour declaration',
+			args: { highlightLabelTextOpacity: 2 },
+			color: '',
+		},
+		{ name: 'below 0 drops it too', args: { highlightLabelTextOpacity: -0.5 }, color: '' },
+	]
+
+	describe('highlightLabelTextOpacity', () => {
+		it.each(labelTextOpacityCases)('$name', ({ args, color }) => {
+			addVisibleButton('click me')
+
+			run({ doHighlightElements: true, ...args })
+
+			const label = document.querySelector<HTMLElement>(LABEL_SELECTOR)
+			expect(label?.textContent).toBe('0')
+			expect(label?.style.color).toBe(color)
+		})
+	})
+
+	const paintingCases = [
+		{ name: 'true paints the overlay', doHighlightElements: true, labelCount: 1 },
+		{ name: 'false skips the overlay', doHighlightElements: false, labelCount: 0 },
+	]
+
+	describe('doHighlightElements', () => {
+		it.each(paintingCases)('$name', ({ doHighlightElements, labelCount }) => {
+			addVisibleButton('click me')
+
+			const tree = run({ doHighlightElements })
+
+			expect(document.querySelectorAll(LABEL_SELECTOR)).toHaveLength(labelCount)
+			// indexes are assigned either way, so indexed actions keep working
+			expect(highlightIndexes(tree)).toEqual([0])
+		})
+
+		it('assigns the same indexes for nested interactive elements either way', () => {
+			// a non-distinct interactive child is skipped because its parent is indexed;
+			// that must not depend on whether the overlay is painted
+			document.body.innerHTML =
+				'<a href="#" id="outer"><div id="inner" style="cursor: pointer">nested</div></a>'
+			makeVisible(document.getElementById('outer')!)
+			makeVisible(document.getElementById('inner')!)
+
+			const painted = highlightIndexes(run({ doHighlightElements: true }))
+
+			document.getElementById(CONTAINER_ID)?.remove()
+
+			const silent = highlightIndexes(run({ doHighlightElements: false }))
+
+			expect(painted).toEqual([0])
+			expect(silent).toEqual(painted)
+		})
+
+		// `PageController.updateTree` runs `cleanUpHighlights()` before every
+		// extraction, which is the only thing that takes the previous run's overlays
+		// down. Turning painting off has to leave a clean page rather than the last
+		// painted run frozen on it, and repeated painted runs must not stack up.
+		it('takes the previous overlays down when painting is turned off', () => {
+			addVisibleButton('click me')
+			const labels = () => document.querySelectorAll(LABEL_SELECTOR).length
+
+			cleanUpHighlights()
+			run({ doHighlightElements: true })
+			expect(labels()).toBe(1)
+
+			cleanUpHighlights()
+			run({ doHighlightElements: true })
+			expect(labels()).toBe(1)
+
+			cleanUpHighlights()
+			run({ doHighlightElements: false })
+			expect(labels()).toBe(0)
+		})
+
+		it('assigns the same indexes when the nested child is a distinct interaction', () => {
+			// mirror of the case above: a distinct child (button) IS indexed alongside its
+			// parent, so parity has to hold for the "extra index" direction too
+			document.body.innerHTML =
+				'<div id="outer" style="cursor: pointer"><button id="inner">nested</button></div>'
+			makeVisible(document.getElementById('outer')!)
+			makeVisible(document.getElementById('inner')!)
+
+			const painted = highlightIndexes(run({ doHighlightElements: true }))
+
+			document.getElementById(CONTAINER_ID)?.remove()
+
+			const silent = highlightIndexes(run({ doHighlightElements: false }))
+
+			// tree.map is keyed by node id, so sort before checking which indexes exist
+			expect([...painted].sort()).toEqual([0, 1])
+			expect(silent).toEqual(painted)
+		})
+	})
+})

--- a/packages/page-controller/src/dom/index.test.ts
+++ b/packages/page-controller/src/dom/index.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import domTree from './dom_tree/index.js'
+import { type DomConfig, getFlatTree } from './index'
+
+vi.mock('./dom_tree/index.js', () => ({
+	default: vi.fn(() => ({ map: {}, rootId: '0' })),
+}))
+
+const domTreeMock = vi.mocked(domTree)
+
+/**
+ * The full args object getFlatTree passes to the DOM engine for an empty config.
+ * Every case below is asserted against this object plus its own overrides,
+ * so an accidentally added or dropped arg fails the whole table.
+ */
+const DEFAULT_ARGS = {
+	doHighlightElements: true,
+	debugMode: true,
+	focusHighlightIndex: -1,
+	viewportExpansion: -1,
+	interactiveBlacklist: [],
+	interactiveWhitelist: [],
+	highlightOpacity: 0,
+	highlightLabelOpacity: 0.1,
+	highlightLabelTextOpacity: 1,
+}
+
+const cases: { name: string; config: DomConfig; expected: Partial<typeof DEFAULT_ARGS> }[] = [
+	{
+		name: 'empty config falls back to painted highlights with opaque label text',
+		config: {},
+		expected: {},
+	},
+	{
+		name: 'doHighlightElements: false disables painting',
+		config: { doHighlightElements: false },
+		expected: { doHighlightElements: false },
+	},
+	{
+		name: 'doHighlightElements: true keeps painting',
+		config: { doHighlightElements: true },
+		expected: { doHighlightElements: true },
+	},
+	{
+		name: 'highlightLabelTextOpacity: 0 is kept, not replaced by the default',
+		config: { highlightLabelTextOpacity: 0 },
+		expected: { highlightLabelTextOpacity: 0 },
+	},
+	{
+		name: 'highlightLabelTextOpacity: 1 passes through',
+		config: { highlightLabelTextOpacity: 1 },
+		expected: { highlightLabelTextOpacity: 1 },
+	},
+	{
+		name: 'highlightOpacity: 0 is kept',
+		config: { highlightOpacity: 0 },
+		expected: { highlightOpacity: 0 },
+	},
+	{
+		name: 'highlightOpacity: 1 passes through',
+		config: { highlightOpacity: 1 },
+		expected: { highlightOpacity: 1 },
+	},
+	{
+		name: 'highlightLabelOpacity: 0 is kept, not replaced by the default',
+		config: { highlightLabelOpacity: 0 },
+		expected: { highlightLabelOpacity: 0 },
+	},
+	{
+		name: 'highlightLabelOpacity: 1 passes through',
+		config: { highlightLabelOpacity: 1 },
+		expected: { highlightLabelOpacity: 1 },
+	},
+	{
+		name: 'all three opacities at 0 hide the whole overlay',
+		config: { highlightOpacity: 0, highlightLabelOpacity: 0, highlightLabelTextOpacity: 0 },
+		expected: { highlightOpacity: 0, highlightLabelOpacity: 0, highlightLabelTextOpacity: 0 },
+	},
+	{
+		name: 'viewportExpansion: 0 passes through',
+		config: { viewportExpansion: 0 },
+		expected: { viewportExpansion: 0 },
+	},
+	{
+		name: 'viewportExpansion: 200 passes through',
+		config: { viewportExpansion: 200 },
+		expected: { viewportExpansion: 200 },
+	},
+]
+
+describe('getFlatTree', () => {
+	beforeEach(() => {
+		domTreeMock.mockClear()
+	})
+
+	it.each(cases)('$name', ({ config, expected }) => {
+		getFlatTree(config)
+
+		expect(domTreeMock).toHaveBeenCalledWith({ ...DEFAULT_ARGS, ...expected })
+	})
+
+	it('resolves lazy blacklist and whitelist entries', () => {
+		const blacklisted = document.createElement('div')
+		const whitelisted = document.createElement('span')
+
+		getFlatTree({
+			interactiveBlacklist: [() => blacklisted],
+			interactiveWhitelist: [whitelisted],
+		})
+
+		expect(domTreeMock).toHaveBeenCalledWith({
+			...DEFAULT_ARGS,
+			interactiveBlacklist: [blacklisted],
+			interactiveWhitelist: [whitelisted],
+		})
+	})
+})

--- a/packages/page-controller/src/dom/index.ts
+++ b/packages/page-controller/src/dom/index.ts
@@ -30,6 +30,27 @@ export interface DomConfig {
 	highlightLabelOpacity?: number
 
 	/**
+	 * Paint the highlight overlay (boxes and index labels) while observing the page.
+	 * Set to `false` to keep the page visually untouched, e.g. for embedded guides or custom UI.
+	 * @note Element indexes are still assigned, so all indexed actions keep working.
+	 *       Only the painting is skipped.
+	 * @default true
+	 **/
+	doHighlightElements?: boolean
+
+	/**
+	 * Opacity of the index number text inside the highlight label, between 0 and 1.
+	 * Set to 0, along with `highlightOpacity` and `highlightLabelOpacity`,
+	 * to hide the highlight overlay while keeping it in the DOM.
+	 * @note Not clamped, matching `highlightOpacity` and `highlightLabelOpacity`.
+	 *       A value outside 0-1 encodes to an unparseable color, so the browser drops
+	 *       the declaration and the digits fall back to the inherited color. The label
+	 *       itself still renders.
+	 * @default 1
+	 **/
+	highlightLabelTextOpacity?: number
+
+	/**
 	 * Preserve semantic landmark tags in dehydrated output even if not interactive
 	 * @note maybe confusing for LLM combining with page scrolling, use with caution
 	 **/
@@ -76,7 +97,7 @@ export function getFlatTree(config: DomConfig): FlatDomTree {
 	}
 
 	const elements = domTree({
-		doHighlightElements: true,
+		doHighlightElements: config.doHighlightElements ?? true,
 		debugMode: true,
 		focusHighlightIndex: -1,
 		viewportExpansion,
@@ -84,6 +105,7 @@ export function getFlatTree(config: DomConfig): FlatDomTree {
 		interactiveWhitelist,
 		highlightOpacity: config.highlightOpacity ?? 0.0,
 		highlightLabelOpacity: config.highlightLabelOpacity ?? 0.1,
+		highlightLabelTextOpacity: config.highlightLabelTextOpacity ?? 1,
 	}) as FlatDomTree
 
 	const currentUrl = window.location.href

--- a/packages/website/src/pages/docs/advanced/page-controller/page.tsx
+++ b/packages/website/src/pages/docs/advanced/page-controller/page.tsx
@@ -109,6 +109,22 @@ const agent = new PageAgentCore({
 								: 'Additional HTML attributes to include in DOM extraction. Supports wildcard * (e.g. data-* matches all data- prefixed attributes). Common attributes like role, aria-label are included by default.',
 						},
 						{
+							name: 'doHighlightElements',
+							type: 'boolean',
+							defaultValue: 'true',
+							description: isZh
+								? '观察页面时绘制高亮框选层（边框 + 序号标签）。设为 false 可以完全不改变页面外观，元素序号仍会照常分配，所有基于序号的操作不受影响。'
+								: 'Paint the highlight overlay (boxes and index labels) while observing the page. Set to false to leave the page visually untouched. Element indexes are still assigned, so all indexed actions keep working.',
+						},
+						{
+							name: 'highlightLabelTextOpacity',
+							type: 'number',
+							defaultValue: '1',
+							description: isZh
+								? '序号文字的不透明度，取值 0-1。与 highlightOpacity、highlightLabelOpacity 一起设为 0 可以隐藏整个高亮层。超出范围的值不会被裁剪。'
+								: 'Opacity of the index number text in the highlight label, between 0 and 1. Set to 0 along with highlightOpacity and highlightLabelOpacity to hide the whole highlight overlay. Values outside the range are not clamped.',
+						},
+						{
 							name: 'keepSemanticTags',
 							type: 'boolean',
 							defaultValue: 'false',


### PR DESCRIPTION
## What

`highlightOpacity` and `highlightLabelOpacity` can be set to 0, but the index numbers stay fully visible, and there is no public way to turn the overlay off at all. Both causes are in the reporter's diagnosis on #661 and both check out:

- `getFlatTree` hardcoded `doHighlightElements: true` when calling `domTree()`. The flag existed internally but never reached `DomConfig`.
- `dom_tree/index.js` hardcoded `label.style.color = 'white'`, so the badge text ignored every opacity option.

This adds two options to `DomConfig`, which `PageControllerConfig` and `PageAgentConfig` already inherit:

- `doHighlightElements` (default `true`) skips painting the overlay entirely.
- `highlightLabelTextOpacity` (default `1`) sets the alpha of the index text, encoded the same way as the two existing opacity options. The default keeps today's fully opaque white, since `'white'` is opaque and reusing `highlightLabelOpacity` (default `0.1`) here would have blanked every existing user's badge numbers.

One extra fix was needed to make `doHighlightElements: false` safe. `handleHighlighting` returned `true` from inside the `if (doHighlightElements)` block, and children read that return value as `isParentHighlighted`. With painting off, a parent reported "not highlighted" and nested interactive elements picked up extra indexes, so the flag changed the index space the model operates on rather than just the pixels. Measured on `<a href="#"><div style="cursor:pointer">nested</div></a>`: `{ painted: [0], silent: [1, 0] }`. The `return` now reports index assignment, which is what the callers actually consume, and behaviour is identical whenever `doHighlightElements` is `true`.

Closes #661

## Type

- [ ] Breaking change
- [x] Bug fix
- [x] Feature / Improvement
- [ ] Refactor / Chores
- [ ] Documentation / Website / Demo / Testing

## Testing

- [x] `npm run ci` passes
- [x] Tested in modern browsers
- [x] Types/doc added

29 tests in `page-controller`. `src/dom/index.test.ts` mocks the engine and drives 12 configs through `it.each`, asserting the whole args object so an added or dropped argument fails the table; it covers each of the three opacity options at `0`, which is the value a `||` default would silently discard. `src/dom/dom_tree/index.test.ts` runs the real engine and asserts the rendered label's colour across `undefined/0/0.1/0.5/1` plus the two out-of-range values, that the label is painted or absent per `doHighlightElements` while the index is assigned either way, and index parity for nested interactive elements in both the distinct and non-distinct directions. One test runs the sequence a consumer actually gets — `cleanUpHighlights()` before each extraction, as `PageController.updateTree` does — to pin that repeated painted runs do not stack overlays and that turning painting off takes the previous run's overlays down rather than freezing them on the page.

Verified in Chrome against a built demo bundle, comparing this branch with `main` on the same page:

| config | `main` | this branch |
| --- | --- | --- |
| defaults | 9 labels, `rgb(255,255,255)` | 9 labels, `rgb(255,255,255)` |
| `doHighlightElements: false` | 9 labels, opaque (option ignored) | 0 labels, 0 overlay nodes, indexes still 0-8 |
| all three opacities `0` | 9 labels, opaque white | 9 labels, `rgba(255,255,255,0)` |

Element indexes stay `0-8` in every case, so nothing the agent does by index changes.

## Requirements / 要求

- [x] I have read and follow the [Code of Conduct](../docs/CODE_OF_CONDUCT.md) and [Contributing Guide](../CONTRIBUTING.md) . / 我已阅读并遵守行为准则。
- [x] This PR is NOT generated by a bot or AI agent acting autonomously. I have authored or meaningfully reviewed every change. / 此 PR 不是由 bot 或 AI 自主生成的，我已亲自编写或充分审查了每一处变更。



