### PR TITLE
fix: correct typo in PageAgentCore.ts comment

### DIFF
--- a/packages/core/src/PageAgentCore.ts
+++ b/packages/core/src/PageAgentCore.ts
@@ -204,7 +204,7 @@ export class PageAgentCore extends EventTarget {
 	}
 
 	/**
-	 * external errors (pre-checks/config/hooks) will threw;
+	 * external errors (pre-checks/config/hooks) will throw;
 	 * agent errors will be caught and added to history, and return a failed result
 	 */
 	async execute(task: string): Promise<ExecutionResult> {


### PR DESCRIPTION
Fix typo in PageAgentCore.ts: changed will threw to will throw. Closes #582