### PR TITLE
fix(build): make cleanup script cross-platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "test:live": "npm run test:live --workspaces --if-present",
         "lint": "eslint .",
         "ci": "node scripts/ci.js",
-        "cleanup": "rm -rf packages/*/dist && rm -rf packages/*/.output",
+        "cleanup": "node scripts/cleanup.js",
         "prepare": "husky || true"
     },
     "devDependencies": {

--- a/scripts/cleanup.js
+++ b/scripts/cleanup.js
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+/**
+ * Removes build artifacts across every workspace.
+ *
+ * Uses Node's filesystem APIs so cleanup works consistently on Windows,
+ * macOS, and Linux instead of relying on a Unix-only rm command.
+ */
+import { readFileSync, rmSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const rootDir = join(dirname(fileURLToPath(import.meta.url)), '..')
+const artifactDirs = ['dist', '.output']
+const rootPkg = JSON.parse(readFileSync(join(rootDir, 'package.json'), 'utf-8'))
+
+for (const artifactDir of artifactDirs) {
+	for (const workspace of rootPkg.workspaces) {
+		rmSync(join(rootDir, workspace, artifactDir), { recursive: true, force: true })
+	}
+}


### PR DESCRIPTION
## What

Replace the Unix-only cleanup command (m -rf ... && rm -rf ...) in the root package.json with a small Node script that reads the workspace list and removes dist / .output directories using 
ode:fs. No new dependencies.

This keeps 
pm run cleanup portable across Windows, macOS, and Linux.

## Type

- [ ] Breaking change
- [ ] Bug fix
- [ ] Feature / Improvement
- [x] Refactor / Chores
- [ ] Documentation / Website / Demo / Testing

## Testing

- [ ] \
pm run ci\ passes
- [ ] Tested in modern browsers
- [ ] Types/doc added

Verified locally on Windows:

- Created fake artifacts in \packages/core/dist\ and \packages/website/.output\, ran \
pm run cleanup\, and both directories were removed.
- \
px prettier --check scripts/cleanup.js package.json\ passes.
- \
px eslint scripts/cleanup.js\ passes.

## Requirements / 要求

- [x] I have read and follow the [Code of Conduct](../docs/CODE_OF_CONDUCT.md) and [Contributing Guide](../CONTRIBUTING.md). / 我已阅读并遵守行为准则。
- [x] This PR is NOT generated by a bot or AI agent acting autonomously. I have authored or meaningfully reviewed every change. / 此 PR 不是由 bot 或 AI 自主生成的，我已亲自编写或充分审查了每一处变更。