### PR TITLE
docs(developer): align Node and npm version constraints

### DIFF
--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -10,7 +10,7 @@ For contribution rules and expectations, see [../CONTRIBUTING.md](../CONTRIBUTIN
 
 1. **Prerequisites**
     - `macOS` / `Linux` / `WSL`
-    - `node.js ^22.13 || >=24` with `npm >= 11`
+    - `node.js ^22.22.1 || >=24` with `npm ^11.6.3`
     - An editor that supports `ts/eslint/prettier`
     - Make sure `eslint`, `prettier` and `commitlint` work well. Un-linted code won't pass the CI.
 


### PR DESCRIPTION
## What

Align the Node.js and npm prerequisites in the developer guide with the versions declared in the root \package.json\:

\\\diff
-node.js ^22.13 || >=24 with npm >= 11
+node.js ^22.22.1 || >=24 with npm ^11.6.3
\\\

This avoids docs that suggest unsupported toolchain versions.

## Type

- [ ] Breaking change
- [ ] Bug fix
- [ ] Feature / Improvement
- [ ] Refactor / Chores
- [x] Documentation / Website / Demo / Testing

## Testing

- [ ] \
pm run ci\ passes
- [ ] Tested in modern browsers
- [ ] Types/doc added

Verified locally with \
px prettier --check docs/developer-guide.md\.

## Requirements / 要求

- [x] I have read and follow the [Code of Conduct](../docs/CODE_OF_CONDUCT.md) and [Contributing Guide](../CONTRIBUTING.md). / 我已阅读并遵守行为准则。
- [x] This PR is NOT generated by a bot or AI agent acting autonomously. I have authored or meaningfully reviewed every change. / 此 PR 不是由 bot 或 AI 自主生成的，我已亲自编写或充分审查了每一处变更。