### PR TITLE
docs(website): fix Chinese heading typo and remove stale TODO

### DIFF
--- a/packages/website/src/pages/docs/features/chrome-extension/page.tsx
+++ b/packages/website/src/pages/docs/features/chrome-extension/page.tsx
@@ -287,10 +287,9 @@ window.PAGE_AGENT_EXT.stop()`
 						className="text-2xl font-bold mb-4"
 					>
 						{isZh
-							? '将 MultiPageAgent 集成你自己的插件'
+							? '将 MultiPageAgent 集成到你自己的插件'
 							: 'Integrate MultiPageAgent into Your Extension'}
 					</Heading>
-					<p>@TODO</p>
 					<p className="text-gray-600 dark:text-gray-300 mb-4">
 						{isZh
 							? '建议先阅读扩展 API 文档，再参考 background entry implementation。'


### PR DESCRIPTION
## What

Fixes the Chinese heading on the Chrome extension integration page by adding the missing preposition, and removes a user-visible `@TODO` line that is no longer part of the intended documentation content.

## Type

- [ ] Breaking change
- [ ] Bug fix
- [ ] Feature / Improvement
- [ ] Refactor / Chores
- [x] Documentation / Website / Demo / Testing

## Testing

- [ ] `npm run ci` passes
- [ ] Tested in modern browsers
- [x] Types/doc added

Validated the changed files with Prettier and ESLint, and ran `npm run typecheck`.

## Requirements / 要求

- [x] I have read and follow the [Code of Conduct](../docs/CODE_OF_CONDUCT.md) and [Contributing Guide](../CONTRIBUTING.md) . / 我已阅读并遵守行为准则。
- [x] This PR is NOT generated by a bot or AI agent acting autonomously. I have authored or meaningfully reviewed every change. / 此 PR 不是由 bot 或 AI 自主生成的，我已亲自编写或充分审查了每一处变更。