### PR TITLE
fix(page-controller): dispatch input before change on select option

### DIFF
--- a/packages/page-controller/src/actions.test.ts
+++ b/packages/page-controller/src/actions.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+
+import { selectOptionElement } from './actions'
+
+describe('selectOptionElement', () => {
+	it('updates the value and dispatches input before change', async () => {
+		const select = document.createElement('select')
+		const firstOption = document.createElement('option')
+		firstOption.value = 'one'
+		firstOption.textContent = 'One'
+		const secondOption = document.createElement('option')
+		secondOption.value = 'two'
+		secondOption.textContent = 'Two'
+
+		select.append(firstOption, secondOption)
+		document.body.append(select)
+
+		const events: string[] = []
+		select.addEventListener('input', () => events.push('input'))
+		select.addEventListener('change', () => events.push('change'))
+
+		await selectOptionElement(select, 'Two')
+
+		expect(select.value).toBe('two')
+		expect(events).toEqual(['input', 'change'])
+
+		select.remove()
+	})
+})

--- a/packages/page-controller/src/actions.ts
+++ b/packages/page-controller/src/actions.ts
@@ -248,6 +248,7 @@ export async function selectOptionElement(selectElement: HTMLSelectElement, opti
 	}
 
 	selectElement.value = option.value
+	selectElement.dispatchEvent(new Event('input', { bubbles: true }))
 	selectElement.dispatchEvent(new Event('change', { bubbles: true }))
 
 	await waitFor(0.1) // Wait to ensure change event processing completes


### PR DESCRIPTION
## What

Native `<select>` interactions dispatch `input` before `change`. This updates `selectOptionElement` to follow that order so React-controlled and other event-driven forms receive both events.

## Type

- [ ] Breaking change
- [x] Bug fix
- [ ] Feature / Improvement
- [ ] Refactor / Chores
- [ ] Documentation / Website / Demo / Testing

## Testing

- [ ] `npm run ci` passes
- [x] Tested with a happy-dom unit test
- [ ] Types/doc added

Added a `page-controller` test asserting that the selected value updates and that `input` is dispatched before `change`.

## Requirements / 要求

- [x] I have read and follow the [Code of Conduct](../docs/CODE_OF_CONDUCT.md) and [Contributing Guide](../CONTRIBUTING.md) . / 我已阅读并遵守行为准则。
- [x] This PR is NOT generated by a bot or AI agent acting autonomously. I have authored or meaningfully reviewed every change. / 此 PR 不是由 bot 或 AI 自主生成的，我已亲自编写或充分审查了每一处变更。