### PR TITLE
fix(ui): resolve translations from own properties and accept empty strings

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -42,6 +42,7 @@
     "homepage": "https://alibaba.github.io/page-agent/",
     "scripts": {
         "build": "vite build",
+        "test": "vitest run",
         "prepublishOnly": "node ../../scripts/pre-publish.js",
         "postpublish": "node ../../scripts/post-publish.js"
     }

--- a/packages/ui/src/i18n/index.test.ts
+++ b/packages/ui/src/i18n/index.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { I18n } from './index'
+
+describe('I18n.t', () => {
+	it('resolves a normal key', () => {
+		expect(new I18n('en-US').t('ui.panel.ready')).toBe('Ready')
+	})
+
+	it('does not resolve inherited properties', () => {
+		// `current?.[key]` walked the prototype chain, so these returned
+		// Object.prototype members from a method that promises a string.
+		const i18n = new I18n('en-US')
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+		for (const key of ['toString', 'constructor', 'valueOf', 'hasOwnProperty']) {
+			expect(i18n.t(key as never)).toBe(key)
+		}
+
+		warn.mockRestore()
+	})
+
+	it('does not return an intermediate object, with or without params', () => {
+		// 'ui.panel' resolves to an object. With params it reached interpolate()
+		// and threw `template.replace is not a function`.
+		const i18n = new I18n('en-US')
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+		expect(i18n.t('ui.panel' as never)).toBe('ui.panel')
+		expect(() => i18n.t('ui.panel' as never, { name: 'x' })).not.toThrow()
+		expect(i18n.t('ui.panel' as never, { name: 'x' })).toBe('ui.panel')
+
+		warn.mockRestore()
+	})
+
+	it('still interpolates params', () => {
+		const i18n = new I18n('en-US')
+		expect(i18n.t('ui.panel.step', { number: 3 })).toBe('Step 3')
+	})
+
+	it('keeps an empty translation instead of reporting it missing', () => {
+		// The old falsy check treated '' as absent and returned the key.
+		const i18n = new I18n('en-US')
+		// @ts-expect-error - reaching into the loaded table for a '' value
+		i18n.translations = { empty: '' }
+		expect(i18n.t('empty' as never)).toBe('')
+	})
+})

--- a/packages/ui/src/i18n/index.ts
+++ b/packages/ui/src/i18n/index.ts
@@ -18,7 +18,11 @@ export class I18n {
 	// 类型安全的翻译方法
 	t(key: TranslationKey, params?: TranslationParams): string {
 		const value = this.getNestedValue(this.translations, key)
-		if (!value) {
+		// Only a string is a translation. A key that lands on an intermediate
+		// object ('ui.panel') used to reach interpolate() and throw
+		// `template.replace is not a function`, and the previous falsy check
+		// also rejected a legitimately empty translation.
+		if (typeof value !== 'string') {
 			console.warn(`Translation key "${key}" not found for language "${this.language}"`)
 			return key
 		}
@@ -29,8 +33,19 @@ export class I18n {
 		return value
 	}
 
-	private getNestedValue(obj: any, path: string): string | undefined {
-		return path.split('.').reduce((current, key) => current?.[key], obj)
+	private getNestedValue(obj: unknown, path: string): unknown {
+		// Own properties only: `current?.[key]` walks the prototype chain, so
+		// t('toString') resolved to Object.prototype.toString — a Function
+		// returned from a method whose signature promises a string.
+		return path
+			.split('.')
+			.reduce<unknown>(
+				(current, key) =>
+					typeof current === 'object' && current !== null && Object.hasOwn(current, key)
+						? (current as Record<string, unknown>)[key]
+						: undefined,
+				obj
+			)
 	}
 
 	private interpolate(template: string, params: TranslationParams): string {

--- a/packages/ui/vitest.config.js
+++ b/packages/ui/vitest.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+	test: {
+		name: 'ui',
+		include: ['src/**/*.test.ts'],
+		silent: 'passed-only',
+	},
+})


### PR DESCRIPTION
## Summary

Three defects in the `I18n.t` lookup. They were mentioned at the end of #641 as separate from the language-validation bug, and #651 fixes only that one — the constructor takes `Object.hasOwn`, but the lookup below it still walks the prototype chain.

**1. `getNestedValue` resolves inherited properties.**

```ts
path.split('.').reduce((current, key) => current?.[key], obj)
```

`t('toString')` returns `Object.prototype.toString` — a `Function` from a method whose signature declares `string`. Same for `constructor`, `valueOf`, `hasOwnProperty`.

**2. A key that lands on an intermediate object throws when params are passed.**

`ui.panel` resolves to an object, which is truthy, so it passes the `if (!value)` gate. Without params it is returned as a "string"; with params it reaches `interpolate` and throws `template.replace is not a function`.

**3. An empty translation is reported as missing.**

`if (!value)` treats `''` as absent, so a locale that deliberately blanks a string logs `Translation key ... not found` and renders the raw key.

## Changes

- `getNestedValue` walks own properties only (`Object.hasOwn`), and returns `unknown` rather than claiming `string | undefined`
- `t` gates on `typeof value !== 'string'`, which rejects functions and intermediate objects while letting `''` through — one check covering all three
- `packages/ui` had no test setup: added `vitest.config.js` and the `test` script following the `packages/core` template, so `npm test` at the root now covers this package too

Not touched: the constructor line #651 changes, to keep the two independent.

## Test

**Code**: `packages/ui/src/i18n/index.test.ts` — inherited keys return the key, `ui.panel` returns the key with and without params (and does not throw), an empty translation stays empty, and ordinary lookup and interpolation are unchanged.

```
npm test --workspace=@page-agent/ui
```

**Result**: 5 passed. Reverting only `index.ts` fails 3 of them, one per defect above.
