### PR TITLE
fix(llms): take the last segment of a prefixed model id

### DIFF
--- a/packages/llms/src/utils.test.ts
+++ b/packages/llms/src/utils.test.ts
@@ -9,7 +9,24 @@ describe('normalizeModelName', () => {
 		['GPT-52-2026-01-01', 'gpt-52-2026-01-01'],
 		['openai/gpt-5.2-chat', 'gpt-52-chat'],
 		['claude_sonnet4_5', 'claudesonnet45'],
+		// A gateway id can carry more than one prefix; the model name is the
+		// last segment, not the second one.
+		['together/meta-llama/llama-3-70b', 'llama-3-70b'],
+		['openrouter/anthropic/claude-opus-4', 'claude-opus-4'],
+		['openrouter/qwen/qwen3-max', 'qwen3-max'],
+		['models/gpt-5.2/', 'gpt-52'],
 	])('%s -> %s', (input, expected) => {
 		expect(normalizeModelName(input)).toBe(expected)
+	})
+
+	it('applies model patches through a multi-prefix id', () => {
+		// 'openrouter/anthropic/claude-opus-4' normalised to 'anthropic', so the
+		// Claude patch below never ran.
+		expect(modelPatch({ model: 'openrouter/anthropic/claude-opus-4' })).toMatchObject({
+			thinking: { type: 'disabled' },
+		})
+		// 'openrouter/qwen/qwen3-max' normalised to 'qwen', which does not match
+		// /max|plus/, so the temperature was raised on a model that excludes it.
+		expect(modelPatch({ model: 'openrouter/qwen/qwen3-max' }).temperature).toBeUndefined()
 	})
 })

--- a/packages/llms/src/utils.ts
+++ b/packages/llms/src/utils.ts
@@ -213,9 +213,13 @@ export function modelPatch(body: Record<string, any>, baseURL?: string) {
 export function normalizeModelName(modelName: string): string {
 	let normalizedName = modelName.toLowerCase()
 
-	// remove prefix before '/'
-	if (normalizedName.includes('/')) {
-		normalizedName = normalizedName.split('/')[1]
+	// remove every prefix before the model name. Taking segment [1] only works
+	// for a two-part id: a gateway id like `together/meta-llama/llama-3-70b`
+	// resolved to `meta-llama`, and `provider/org/claude-opus-4` to `org`,
+	// so the model-specific patches in modelPatch never matched.
+	const segments = normalizedName.split('/').filter(Boolean)
+	if (segments.length > 0) {
+		normalizedName = segments[segments.length - 1]!
 	}
 
 	// remove '_'


### PR DESCRIPTION
## Summary

`normalizeModelName` strips the vendor prefix with `split('/')[1]`, which is correct only for a two-part id. A gateway or proxy id carries more than one prefix, and segment `[1]` is then another prefix rather than the model name:

| model id | normalized | should be |
|---|---|---|
| `openai/gpt-5.2-chat` | `gpt-52-chat` ✓ | — |
| `together/meta-llama/llama-3-70b` | `meta-llama` | `llama-3-70b` |
| `openrouter/anthropic/claude-opus-4` | `anthropic` | `claude-opus-4` |
| `openrouter/qwen/qwen3-max` | `qwen` | `qwen3-max` |

`modelPatch` matches on that name, so the patches silently stop applying:

- `openrouter/anthropic/claude-opus-4` → `anthropic`, which does not start with `claude`, so **thinking is never disabled**
- `openrouter/qwen/qwen3-max` → `qwen`, which starts with `qwen` so the Qwen patch does run — but `/max|plus/` no longer matches, so **the temperature is raised to 1.0 on exactly the model that check exists to exclude**

Both are silent: the request goes out with the wrong body and the model answers, just not the way the patch intended.

## Changes

Take the last non-empty segment. That is the model name for a prefix of any depth, and identical to the current behaviour for the two-part ids already covered by the tests. Filtering empties also handles a trailing slash (`models/gpt-5.2/`), which previously depended on segment `[1]` happening to be the name.

## Test

**Code**: `packages/llms/src/utils.test.ts` — four multi-prefix ids added to the existing table, plus a `modelPatch` assertion that the Claude and Qwen patches actually apply through a two-prefix id.

```
npm test --workspace=@page-agent/llms
```

**Result**: 48 passed. Reverting only `utils.ts` fails the 4 new cases; the 5 pre-existing rows pass either way.
