### PR TITLE
fix(page-controller): sum every frame offset for a nested iframe

### DIFF
--- a/packages/page-controller/src/utils/index.test.ts
+++ b/packages/page-controller/src/utils/index.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+
+import { getIframeOffset } from './index'
+
+/**
+ * Build an element inside a chain of frames. `offsets[0]` is the innermost
+ * frame's position in its parent, and so on outward.
+ */
+function elementInFrames(offsets: { x: number; y: number }[]): HTMLElement {
+	// The top window has no frameElement.
+	let view: unknown = { frameElement: null }
+
+	for (const { x, y } of [...offsets].reverse()) {
+		const frame = {
+			getBoundingClientRect: () => ({ left: x, top: y }),
+			ownerDocument: { defaultView: view },
+		}
+		view = { frameElement: frame }
+	}
+
+	return { ownerDocument: { defaultView: view } } as unknown as HTMLElement
+}
+
+describe('getIframeOffset', () => {
+	it('is zero in the top frame', () => {
+		expect(getIframeOffset(elementInFrames([]))).toEqual({ x: 0, y: 0 })
+	})
+
+	it('reads a single frame', () => {
+		expect(getIframeOffset(elementInFrames([{ x: 10, y: 20 }]))).toEqual({ x: 10, y: 20 })
+	})
+
+	it('sums every frame in a nested chain', () => {
+		// Only the innermost frame used to be read, so the pointer landed
+		// 100,200 short of the element.
+		expect(
+			getIframeOffset(
+				elementInFrames([
+					{ x: 10, y: 20 },
+					{ x: 100, y: 200 },
+				])
+			)
+		).toEqual({ x: 110, y: 220 })
+	})
+
+	it('stops on a frame chain that does not terminate', () => {
+		const frame: any = { getBoundingClientRect: () => ({ left: 1, top: 1 }) }
+		frame.ownerDocument = { defaultView: { frameElement: frame } }
+		const element = { ownerDocument: { defaultView: { frameElement: frame } } } as HTMLElement
+
+		expect(() => getIframeOffset(element)).not.toThrow()
+	})
+})

--- a/packages/page-controller/src/utils/index.ts
+++ b/packages/page-controller/src/utils/index.ts
@@ -26,10 +26,26 @@ export function isAnchorElement(el: Element): el is HTMLAnchorElement {
 
 /** Iframe offset for translating element coordinates to top-frame viewport. */
 export function getIframeOffset(element: HTMLElement): { x: number; y: number } {
-	const frame = element.ownerDocument.defaultView?.frameElement as HTMLElement | null
-	if (!frame) return { x: 0, y: 0 }
-	const rect = frame.getBoundingClientRect()
-	return { x: rect.left, y: rect.top }
+	// Walk every frame up to the top one. Reading only the immediate
+	// frameElement leaves out the offset of each frame above it, so in a nested
+	// iframe the pointer is placed short of the element by the outer frames'
+	// combined offset.
+	let view = element.ownerDocument.defaultView
+	let x = 0
+	let y = 0
+
+	// A cycle is not reachable through real frame parentage, but the loop reads
+	// host-controlled objects, so bound it rather than trust that.
+	for (let depth = 0; depth < 32; depth++) {
+		const frame = view?.frameElement as HTMLElement | null
+		if (!frame) break
+		const rect = frame.getBoundingClientRect()
+		x += rect.left
+		y += rect.top
+		view = frame.ownerDocument.defaultView
+	}
+
+	return { x, y }
 }
 
 /**


### PR DESCRIPTION
## Summary

`getIframeOffset` reads only the element's immediate `frameElement`:

```ts
const frame = element.ownerDocument.defaultView?.frameElement as HTMLElement | null
if (!frame) return { x: 0, y: 0 }
```

For an element one frame deep that is the whole offset. One frame deeper it is not: the offsets of every frame above the innermost one are left out.

With an inner frame at `(10, 20)` inside an outer frame at `(100, 200)`, the element's top-frame position is `+110, +220`, but the function returns `10, 20`. `movePointerToElement` — its only caller — translates the click coordinates with that value, so the visual pointer lands 100,200 px short of the element it is pointing at.

Nested iframes are ordinary on the pages this drives: an embedded checkout, a payment widget, or an editor preview inside an already-framed app.

## Changes

Walk up to the top frame and accumulate each frame's `getBoundingClientRect()`. The single-frame and top-frame cases return exactly what they did before.

The walk is bounded to 32 hops. A real frame chain always terminates, but the loop reads host-page objects, so a malformed chain stops instead of hanging the page — in line with the "make risks visible, keep behaviour predictable" note in AGENTS.md.

## Test

**Code**: `packages/page-controller/src/utils/index.test.ts` — top frame is `0,0`; one frame returns its own offset; two nested frames sum to `110,220`; a non-terminating chain returns rather than hanging.

```
npm test -w @page-agent/page-controller
```

**Result**: 4 passed. Reverting only `utils/index.ts` fails the nested case with `{ x: 10, y: 20 }`.
