### PR TITLE
fix(page-controller): set a select through the native value setter

### DIFF
--- a/packages/page-controller/src/actions.test.ts
+++ b/packages/page-controller/src/actions.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { selectOptionElement } from './actions'
+
+function makeSelect(): HTMLSelectElement {
+	const select = document.createElement('select')
+	for (const [value, label] of [
+		['a', 'Apple'],
+		['b', 'Banana'],
+	]) {
+		const option = document.createElement('option')
+		option.value = value
+		option.textContent = label
+		select.appendChild(option)
+	}
+	document.body.appendChild(select)
+	return select
+}
+
+describe('selectOptionElement', () => {
+	it('selects the option whose text matches', async () => {
+		const select = makeSelect()
+		await selectOptionElement(select, 'Banana')
+		expect(select.value).toBe('b')
+	})
+
+	it('rejects an unknown option', async () => {
+		const select = makeSelect()
+		await expect(selectOptionElement(select, 'Cherry')).rejects.toThrow(/not found/)
+	})
+
+	it('assigns through the prototype setter, not the instance one', async () => {
+		// React installs its own `value` setter on the instance to track changes.
+		// A direct assignment goes through that one and leaves React's tracker
+		// holding the old value, so onChange never runs.
+		const select = makeSelect()
+		const prototypeSetter = vi.fn(
+			Object.getOwnPropertyDescriptor(Object.getPrototypeOf(select) as object, 'value')!
+				.set as (v: string) => void
+		)
+		const instanceSetter = vi.fn()
+		Object.defineProperty(Object.getPrototypeOf(select), 'value', {
+			configurable: true,
+			get: Object.getOwnPropertyDescriptor(Object.getPrototypeOf(select) as object, 'value')!.get,
+			set: prototypeSetter,
+		})
+		Object.defineProperty(select, 'value', {
+			configurable: true,
+			get: () => 'a',
+			set: instanceSetter,
+		})
+
+		await selectOptionElement(select, 'Banana')
+
+		expect(prototypeSetter).toHaveBeenCalledWith('b')
+		expect(instanceSetter).not.toHaveBeenCalled()
+	})
+
+	it('fires input before change', async () => {
+		const select = makeSelect()
+		const seen: string[] = []
+		select.addEventListener('input', () => seen.push('input'))
+		select.addEventListener('change', () => seen.push('change'))
+
+		await selectOptionElement(select, 'Banana')
+
+		expect(seen).toEqual(['input', 'change'])
+	})
+})

--- a/packages/page-controller/src/actions.ts
+++ b/packages/page-controller/src/actions.ts
@@ -247,7 +247,15 @@ export async function selectOptionElement(selectElement: HTMLSelectElement, opti
 		throw new Error(`Option with text "${optionText}" not found in select element`)
 	}
 
-	selectElement.value = option.value
+	// Go through the prototype's setter, as inputTextElement does. React
+	// installs its own `value` setter on the instance to track changes, so a
+	// direct assignment updates the DOM but leaves React's tracker holding the
+	// old value — it then treats the change event as a no-op and never runs
+	// onChange, so the component's state keeps the option that was replaced.
+	getNativeValueSetter(selectElement).call(selectElement, option.value)
+
+	// A real selection fires input before change; frameworks listen for either.
+	selectElement.dispatchEvent(new Event('input', { bubbles: true }))
 	selectElement.dispatchEvent(new Event('change', { bubbles: true }))
 
 	await waitFor(0.1) // Wait to ensure change event processing completes

--- a/packages/page-controller/src/utils/index.ts
+++ b/packages/page-controller/src/utils/index.ts
@@ -36,7 +36,9 @@ export function getIframeOffset(element: HTMLElement): { x: number; y: number } 
  * Get native value setter from the element's own prototype (iframe-safe).
  * @note for React
  */
-export function getNativeValueSetter(element: HTMLInputElement | HTMLTextAreaElement) {
+export function getNativeValueSetter(
+	element: HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
+) {
 	// eslint-disable-next-line @typescript-eslint/unbound-method
 	return Object.getOwnPropertyDescriptor(Object.getPrototypeOf(element) as object, 'value')!
 		.set as (v: string) => void


### PR DESCRIPTION
## Summary

`inputTextElement` routes its assignment through the prototype's `value` setter, and `getNativeValueSetter` says why: `@note for React`.

React installs its own `value` setter on the **instance** to track changes. A direct assignment goes through that one, updating the DOM while leaving React's tracker holding the previous value — React then reads the following `change` event as a no-op and never calls `onChange`.

`selectOptionElement` assigns directly:

```ts
selectElement.value = option.value
selectElement.dispatchEvent(new Event('change', { bubbles: true }))
```

so it has exactly the bug the input path was written to avoid. The dropdown visibly changes and `select.value` reads back correctly, but the component's state does not update — the form submits the option the agent replaced. From the agent's side the action reports success, which makes it hard to attribute the wrong value later.

It also fires only `change`. A real selection fires `input` first, and libraries bound to `input` on a `<select>` see nothing.

## Changes

- `selectOptionElement` assigns through `getNativeValueSetter`, as `inputTextElement` does
- `getNativeValueSetter` accepts `HTMLSelectElement` (its body already works for it — `HTMLSelectElement.prototype` has the `value` descriptor)
- Fire `input` before `change`, matching a real selection

## Test

**Code**: `packages/page-controller/src/actions.test.ts` — the matching option is selected, an unknown option still rejects, the assignment reaches the **prototype** setter and not an instance setter shadowing it (how React's tracker is modelled), and `input` fires before `change`.

```
npm test -w @page-agent/page-controller
```

**Result**: 8 passed (4 new + the existing suites). Reverting only `actions.ts` fails the setter and event-order tests.
