### PR TITLE
chore(ext): upgrade wxt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -97,22 +97,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/@aklinker1/rollup-plugin-visualizer/node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
         "node_modules/@aklinker1/rollup-plugin-visualizer/node_modules/cliui": {
             "version": "8.0.1",
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -138,13 +122,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/@aklinker1/rollup-plugin-visualizer/node_modules/emoji-regex": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/@aklinker1/rollup-plugin-visualizer/node_modules/is-docker": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
@@ -159,16 +136,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@aklinker1/rollup-plugin-visualizer/node_modules/is-fullwidth-code-point": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/@aklinker1/rollup-plugin-visualizer/node_modules/is-wsl": {
@@ -225,21 +192,6 @@
                 "node": ">= 12"
             }
         },
-        "node_modules/@aklinker1/rollup-plugin-visualizer/node_modules/string-width": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/@aklinker1/rollup-plugin-visualizer/node_modules/strip-ansi": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -251,24 +203,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/@aklinker1/rollup-plugin-visualizer/node_modules/wrap-ansi": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^4.0.0",
-                "string-width": "^4.1.0",
-                "strip-ansi": "^6.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
             }
         },
         "node_modules/@aklinker1/rollup-plugin-visualizer/node_modules/yargs": {
@@ -299,6 +233,13 @@
             "engines": {
                 "node": ">=12"
             }
+        },
+        "node_modules/@aklinker1/zero-zip": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@aklinker1/zero-zip/-/zero-zip-1.0.1.tgz",
+            "integrity": "sha512-07a596Bd1QO0bi3tIyt2xruq6vKk7hCUt9enHBwggvipB0iiycoJ9/CqzN6UFawaKbOi6NBfMlUxUXzIOZ7Dsg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@babel/code-frame": {
             "version": "7.29.7",
@@ -379,14 +320,11 @@
             }
         },
         "node_modules/@babel/runtime": {
-            "version": "7.28.2",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.2.tgz",
-            "integrity": "sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-8.0.0.tgz",
+            "integrity": "sha512-sL6cvO2IfkSu/iU+zs2S/w01B7A8V7suXSIKEN4hPFFdZoiPGxrj5pAG0lCaqLWiEIrjKzdznIWuaLcxPR53qw==",
             "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
+            "license": "MIT"
         },
         "node_modules/@babel/template": {
             "version": "7.29.7",
@@ -725,9 +663,9 @@
             }
         },
         "node_modules/@devicefarmer/adbkit": {
-            "version": "3.3.8",
-            "resolved": "https://registry.npmjs.org/@devicefarmer/adbkit/-/adbkit-3.3.8.tgz",
-            "integrity": "sha512-7rBLLzWQnBwutH2WZ0EWUkQdihqrnLYCUMaB44hSol9e0/cdIhuNFcqZO0xNheAU6qqHVA8sMiLofkYTgb+lmw==",
+            "version": "3.3.9",
+            "resolved": "https://registry.npmjs.org/@devicefarmer/adbkit/-/adbkit-3.3.9.tgz",
+            "integrity": "sha512-AYxk5G/b2BPEfubcuxVEZEOpsLf0isqrPNJnnwAlUjZAiLdFg/uvLNRDuBhsC/Ar62X+rUhVlvlL+tKp9HCjfQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -1019,6 +957,142 @@
                 "node": "^20.19.0 || ^22.13.0 || >=24"
             }
         },
+        "node_modules/@eslint/eslintrc": {
+            "version": "3.3.7",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.7.tgz",
+            "integrity": "sha512-F42g89Qd5oAWtp0k0nnSrjziAKza7w8SVT4mStc18LZMaRb4J1HQAHLCalEtDCxrTuksx7NU9qsmeLwpOfPqWw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ajv": "^6.14.0",
+                "debug": "^4.3.2",
+                "espree": "^10.0.1",
+                "globals": "^14.0.0",
+                "ignore": "^5.2.0",
+                "import-fresh": "^3.2.1",
+                "js-yaml": "^4.3.2",
+                "minimatch": "^3.1.5",
+                "strip-json-comments": "^3.1.1"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/@eslint/eslintrc/node_modules/ajv": {
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+            "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/@eslint/eslintrc/node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+            "version": "1.1.18",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+            "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/@eslint/eslintrc/node_modules/eslint-visitor-keys": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+            "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/@eslint/eslintrc/node_modules/espree": {
+            "version": "10.4.0",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+            "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "acorn": "^8.15.0",
+                "acorn-jsx": "^5.3.2",
+                "eslint-visitor-keys": "^4.2.1"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/@eslint/eslintrc/node_modules/globals": {
+            "version": "14.0.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+            "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/@eslint/eslintrc/node_modules/strip-json-comments": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+            "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/@eslint/js": {
             "version": "10.0.1",
             "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
@@ -1105,6 +1179,27 @@
             "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@fluent/syntax": {
+            "version": "0.19.0",
+            "resolved": "https://registry.npmjs.org/@fluent/syntax/-/syntax-0.19.0.tgz",
+            "integrity": "sha512-5D2qVpZrgpjtqU4eNOcWGp1gnUCgjfM+vKGE2y03kKN6z5EBhtx0qdRFbg8QuNNj8wXNoX93KJoYb+NqoxswmQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=14.0.0",
+                "npm": ">=7.0.0"
+            }
+        },
+        "node_modules/@fregante/relaxed-json": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@fregante/relaxed-json/-/relaxed-json-2.0.0.tgz",
+            "integrity": "sha512-PyUXQWB42s4jBli435TDiYuVsadwRHnMc27YaLouINktvTWsL3FcKrRMGawTayFk46X+n5bE23RjUTWQwrukWw==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">= 0.10.0"
+            }
         },
         "node_modules/@hono/node-server": {
             "version": "2.1.0",
@@ -1233,6 +1328,13 @@
                 "@jridgewell/resolve-uri": "^3.1.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
+        },
+        "node_modules/@mdn/browser-compat-data": {
+            "version": "8.0.8",
+            "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-8.0.8.tgz",
+            "integrity": "sha512-Rutrrc3FYOc+um4/QC4WFETNk2fV8NKWoqQl3tQfcVTQ1WFaoJRbsJBasSF34ltitmnYYD6ZsKW1cOQtSj1jbQ==",
+            "dev": true,
+            "license": "CC0-1.0"
         },
         "node_modules/@microsoft/api-extractor": {
             "version": "7.59.0",
@@ -1404,6 +1506,13 @@
         "node_modules/@page-agent/website": {
             "resolved": "packages/website",
             "link": true
+        },
+        "node_modules/@pinojs/redact": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+            "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@pnpm/config.env-replace": {
             "version": "1.1.0",
@@ -2091,9 +2200,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2111,9 +2217,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2131,9 +2234,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2151,9 +2251,6 @@
                 "s390x"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2171,9 +2268,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2191,9 +2285,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2764,6 +2855,16 @@
                 "vite": "^5.2.0 || ^6 || ^7 || ^8"
             }
         },
+        "node_modules/@topcli/prompts": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@topcli/prompts/-/prompts-4.0.0.tgz",
+            "integrity": "sha512-kkKYPb4k/6kRdnESt77B5vJrrYnYHIYczwv0P1c+tfN/IWEx3KZeKEHoUq7sImIyBEXWdA2uakIroD9pmRJziQ==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=22.0.0"
+            }
+        },
         "node_modules/@trivago/prettier-plugin-sort-imports": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/@trivago/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-6.0.2.tgz",
@@ -2955,13 +3056,6 @@
             "peerDependencies": {
                 "@types/react": "^19.2.0"
             }
-        },
-        "node_modules/@types/webextension-polyfill": {
-            "version": "0.12.5",
-            "resolved": "https://registry.npmjs.org/@types/webextension-polyfill/-/webextension-polyfill-0.12.5.tgz",
-            "integrity": "sha512-uKSAv6LgcVdINmxXMKBuVIcg/2m5JZugoZO8x20g7j2bXJkPIl/lVGQcDlbV+aXAiTyXT2RA5U5mI4IGCDMQeg==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/@types/whatwg-mimetype": {
             "version": "3.0.2",
@@ -3406,13 +3500,13 @@
             }
         },
         "node_modules/@webext-core/fake-browser": {
-            "version": "1.5.2",
-            "resolved": "https://registry.npmjs.org/@webext-core/fake-browser/-/fake-browser-1.5.2.tgz",
-            "integrity": "sha512-nkDQwOJ23X5Q7cEtN6LRuBtVFf1KVOFi5GoQAro0lzqdh59F5E+K350j1isbnqYbzsXRh1NJtboudIcHfZtvOQ==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@webext-core/fake-browser/-/fake-browser-2.0.1.tgz",
+            "integrity": "sha512-4x5z1z8F0KU8ShF4ForXJ8qnA8oZTy7HYjI91Mbpdzp3H3hU9HR6TNPUxfWtSpFz2FwgEircuJKQg0qFIn6RLg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@types/webextension-polyfill": ">=0.10.5",
+                "@wxt-dev/browser": "*",
                 "lodash.merge": "^4.6.2"
             },
             "engines": {
@@ -3430,11 +3524,14 @@
             }
         },
         "node_modules/@webext-core/match-patterns": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@webext-core/match-patterns/-/match-patterns-1.0.3.tgz",
-            "integrity": "sha512-NY39ACqCxdKBmHgw361M9pfJma8e4AZo20w9AY+5ZjIj1W2dvXC8J31G5fjfOGbulW9w4WKpT8fPooi0mLkn9A==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@webext-core/match-patterns/-/match-patterns-2.0.0.tgz",
+            "integrity": "sha512-EsyMMKfQuSE4rWCjP/TifwvUWlhC/OhiGn5OK3p9F0d57UmtLib0nzguzPKyxM1/kZV7SkE+jYXkE8gsdPRLmw==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "engines": {
+                "node": "*"
+            }
         },
         "node_modules/@wxt-dev/browser": {
             "version": "0.1.42",
@@ -3515,14 +3612,490 @@
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
             }
         },
-        "node_modules/adm-zip": {
-            "version": "0.5.17",
-            "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
-            "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+        "node_modules/addons-linter": {
+            "version": "10.10.0",
+            "resolved": "https://registry.npmjs.org/addons-linter/-/addons-linter-10.10.0.tgz",
+            "integrity": "sha512-1n5Xvn4DyHMsulchNDl4ucWnXXQhHwLif6eK80KjieI9KIK3xD+3OYXk5ZcA6a2J8y+Nrlvq9/vq6w7KOqT2MQ==",
+            "dev": true,
+            "license": "MPL-2.0",
+            "dependencies": {
+                "@fluent/syntax": "0.19.0",
+                "@fregante/relaxed-json": "2.0.0",
+                "@mdn/browser-compat-data": "8.0.8",
+                "addons-moz-compare": "1.3.0",
+                "addons-scanner-utils": "15.4.0",
+                "ajv": "8.20.0",
+                "cheerio": "1.2.0",
+                "columnify": "1.6.0",
+                "common-tags": "1.8.2",
+                "css-tree": "3.2.1",
+                "deepmerge": "4.3.1",
+                "eslint": "9.39.4",
+                "eslint-plugin-no-unsanitized": "4.1.5",
+                "eslint-visitor-keys": "5.0.1",
+                "espree": "11.2.0",
+                "esprima": "4.0.1",
+                "fast-json-patch": "3.1.1",
+                "image-size": "2.0.2",
+                "json-merge-patch": "1.0.2",
+                "pino": "10.3.1",
+                "semver": "7.8.5",
+                "source-map-support": "0.5.21",
+                "upath": "3.0.8",
+                "yargs": "17.7.2",
+                "yauzl": "3.4.0"
+            },
+            "bin": {
+                "addons-linter": "bin/addons-linter"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/addons-linter/node_modules/@eslint/config-array": {
+            "version": "0.21.2",
+            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+            "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@eslint/object-schema": "^2.1.7",
+                "debug": "^4.3.1",
+                "minimatch": "^3.1.5"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/addons-linter/node_modules/@eslint/config-helpers": {
+            "version": "0.4.2",
+            "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+            "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@eslint/core": "^0.17.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/addons-linter/node_modules/@eslint/core": {
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+            "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@types/json-schema": "^7.0.15"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/addons-linter/node_modules/@eslint/js": {
+            "version": "9.39.4",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+            "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">=12.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://eslint.org/donate"
+            }
+        },
+        "node_modules/addons-linter/node_modules/@eslint/object-schema": {
+            "version": "2.1.7",
+            "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+            "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/addons-linter/node_modules/@eslint/plugin-kit": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+            "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@eslint/core": "^0.17.0",
+                "levn": "^0.4.1"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/addons-linter/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/addons-linter/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/addons-linter/node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/addons-linter/node_modules/brace-expansion": {
+            "version": "1.1.18",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+            "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/addons-linter/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/addons-linter/node_modules/cliui": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+            "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.1",
+                "wrap-ansi": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/addons-linter/node_modules/eslint": {
+            "version": "9.39.4",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+            "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+            "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.8.0",
+                "@eslint-community/regexpp": "^4.12.1",
+                "@eslint/config-array": "^0.21.2",
+                "@eslint/config-helpers": "^0.4.2",
+                "@eslint/core": "^0.17.0",
+                "@eslint/eslintrc": "^3.3.5",
+                "@eslint/js": "9.39.4",
+                "@eslint/plugin-kit": "^0.4.1",
+                "@humanfs/node": "^0.16.6",
+                "@humanwhocodes/module-importer": "^1.0.1",
+                "@humanwhocodes/retry": "^0.4.2",
+                "@types/estree": "^1.0.6",
+                "ajv": "^6.14.0",
+                "chalk": "^4.0.0",
+                "cross-spawn": "^7.0.6",
+                "debug": "^4.3.2",
+                "escape-string-regexp": "^4.0.0",
+                "eslint-scope": "^8.4.0",
+                "eslint-visitor-keys": "^4.2.1",
+                "espree": "^10.4.0",
+                "esquery": "^1.5.0",
+                "esutils": "^2.0.2",
+                "fast-deep-equal": "^3.1.3",
+                "file-entry-cache": "^8.0.0",
+                "find-up": "^5.0.0",
+                "glob-parent": "^6.0.2",
+                "ignore": "^5.2.0",
+                "imurmurhash": "^0.1.4",
+                "is-glob": "^4.0.0",
+                "json-stable-stringify-without-jsonify": "^1.0.1",
+                "lodash.merge": "^4.6.2",
+                "minimatch": "^3.1.5",
+                "natural-compare": "^1.4.0",
+                "optionator": "^0.9.3"
+            },
+            "bin": {
+                "eslint": "bin/eslint.js"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://eslint.org/donate"
+            },
+            "peerDependencies": {
+                "jiti": "*"
+            },
+            "peerDependenciesMeta": {
+                "jiti": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/addons-linter/node_modules/eslint-scope": {
+            "version": "8.4.0",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+            "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "esrecurse": "^4.3.0",
+                "estraverse": "^5.2.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/addons-linter/node_modules/eslint-visitor-keys": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+            "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^20.19.0 || ^22.13.0 || >=24"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/addons-linter/node_modules/eslint/node_modules/ajv": {
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+            "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/addons-linter/node_modules/eslint/node_modules/eslint-visitor-keys": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+            "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/addons-linter/node_modules/eslint/node_modules/espree": {
+            "version": "10.4.0",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+            "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "acorn": "^8.15.0",
+                "acorn-jsx": "^5.3.2",
+                "eslint-visitor-keys": "^4.2.1"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/addons-linter/node_modules/json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/addons-linter/node_modules/minimatch": {
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/addons-linter/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/addons-linter/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/addons-linter/node_modules/yargs": {
+            "version": "17.7.2",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+            "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cliui": "^8.0.1",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "require-directory": "^2.1.1",
+                "string-width": "^4.2.3",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^21.1.1"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/addons-linter/node_modules/yargs-parser": {
+            "version": "21.1.1",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+            "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/addons-moz-compare": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/addons-moz-compare/-/addons-moz-compare-1.3.0.tgz",
+            "integrity": "sha512-/rXpQeaY0nOKhNx00pmZXdk5Mu+KhVlL3/pSBuAYwrxRrNiTvI/9xfQI8Lmm7DMMl+PDhtfAHY/0ibTpdeoQQQ==",
+            "dev": true,
+            "license": "MPL-2.0"
+        },
+        "node_modules/addons-scanner-utils": {
+            "version": "15.4.0",
+            "resolved": "https://registry.npmjs.org/addons-scanner-utils/-/addons-scanner-utils-15.4.0.tgz",
+            "integrity": "sha512-i3PnJx9YLZi96o4t4JWArP6JimC01949YVAcMJKHfyQ5qmUBaH21qNS8f12/RsloejW8IcCEljhh3Fq3gxFNsg==",
+            "dev": true,
+            "license": "MPL-2.0",
+            "dependencies": {
+                "common-tags": "1.8.2",
+                "first-chunk-stream": "3.0.0",
+                "jsonwebtoken": "^9.0.3",
+                "strip-bom-stream": "4.0.0",
+                "upath": "3.0.7",
+                "yauzl": "3.4.0"
+            },
+            "peerDependencies": {
+                "express": "5.2.1",
+                "safe-compare": "1.1.4"
+            },
+            "peerDependenciesMeta": {
+                "express": {
+                    "optional": true
+                },
+                "safe-compare": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/addons-scanner-utils/node_modules/upath": {
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/upath/-/upath-3.0.7.tgz",
+            "integrity": "sha512-VjBBquch25nUGMuVBpOb2Cj3gc8Kb7lJBqbsXR/0anZ/5uJsL14Kpth9JKfnBsckxCfgIp6hPvcvvmZ97R9X7g==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/anodynos"
+                },
+                {
+                    "type": "polar",
+                    "url": "https://polar.sh/anodynos"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/subscription/pkg/npm-upath"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/adm-zip": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+            "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0"
+            }
+        },
+        "node_modules/agent-base": {
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14"
             }
         },
         "node_modules/ai-motion": {
@@ -3587,77 +4160,6 @@
             "license": "ISC",
             "dependencies": {
                 "string-width": "^4.1.0"
-            }
-        },
-        "node_modules/ansi-align/node_modules/ansi-regex": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/ansi-align/node_modules/emoji-regex": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/ansi-align/node_modules/is-fullwidth-code-point": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/ansi-align/node_modules/string-width": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/ansi-align/node_modules/strip-ansi": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/ansi-escapes": {
-            "version": "7.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
-            "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "environment": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/ansi-regex": {
@@ -4101,6 +4603,60 @@
                 "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
+        "node_modules/cheerio": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+            "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cheerio-select": "^2.1.0",
+                "dom-serializer": "^2.0.0",
+                "domhandler": "^5.0.3",
+                "domutils": "^3.2.2",
+                "encoding-sniffer": "^0.2.1",
+                "htmlparser2": "^10.1.0",
+                "parse5": "^7.3.0",
+                "parse5-htmlparser2-tree-adapter": "^7.1.0",
+                "parse5-parser-stream": "^7.1.2",
+                "undici": "^7.19.0",
+                "whatwg-mimetype": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=20.18.1"
+            },
+            "funding": {
+                "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+            }
+        },
+        "node_modules/cheerio-select": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+            "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "boolbase": "^1.0.0",
+                "css-select": "^5.1.0",
+                "css-what": "^6.1.0",
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.3",
+                "domutils": "^3.0.1"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/fb55"
+            }
+        },
+        "node_modules/cheerio/node_modules/whatwg-mimetype": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+            "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/chokidar": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
@@ -4165,22 +4721,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/ci-info": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
-            "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/sibiraj-s"
-                }
-            ],
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/citty": {
             "version": "0.2.2",
             "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.2.tgz",
@@ -4209,39 +4749,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/cli-cursor": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
-            "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "restore-cursor": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/cli-truncate": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
-            "integrity": "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "slice-ansi": "^8.0.0",
-                "string-width": "^8.2.0"
-            },
-            "engines": {
-                "node": ">=20"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -4298,6 +4805,16 @@
                 "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
             }
         },
+        "node_modules/clone": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+            "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.8"
+            }
+        },
         "node_modules/clsx": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -4328,6 +4845,43 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/columnify": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.6.0.tgz",
+            "integrity": "sha512-lomjuFZKfM6MSAnV9aCZC9sc0qGbmZdfygNv+nCpqVkSKdCxCklLtd16O0EILGkImHw9ZpHkAnHaB+8Zxq5W6Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "strip-ansi": "^6.0.1",
+                "wcwidth": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "node_modules/columnify/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/columnify/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/commander": {
             "version": "9.5.0",
             "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
@@ -4336,6 +4890,16 @@
             "license": "MIT",
             "engines": {
                 "node": "^12.20.0 || >=14"
+            }
+        },
+        "node_modules/common-tags": {
+            "version": "1.8.2",
+            "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
+            "integrity": "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4.0.0"
             }
         },
         "node_modules/compare-versions": {
@@ -4351,22 +4915,6 @@
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/concat-stream": {
-            "version": "1.6.2",
-            "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-            "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-            "dev": true,
-            "engines": [
-                "node >= 0.8"
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "buffer-from": "^1.0.0",
-                "inherits": "^2.0.3",
-                "readable-stream": "^2.2.2",
-                "typedarray": "^0.0.6"
-            }
         },
         "node_modules/concurrently": {
             "version": "10.0.5",
@@ -4689,6 +5237,20 @@
                 "url": "https://github.com/sponsors/fb55"
             }
         },
+        "node_modules/css-tree": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+            "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mdn-data": "2.27.1",
+                "source-map-js": "^1.2.1"
+            },
+            "engines": {
+                "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+            }
+        },
         "node_modules/css-what": {
             "version": "6.2.2",
             "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
@@ -4740,6 +5302,19 @@
                 }
             }
         },
+        "node_modules/decamelize": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-6.0.1.tgz",
+            "integrity": "sha512-G7Cqgaelq68XHJNGlZ7lrNQyhZGsFqpwtGFexqUv4IQdjKoSYF7ipZ9UuTJZUSQXFj/XaoBLuEVIVqr8EJngEQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/deep-extend": {
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
@@ -4756,6 +5331,16 @@
             "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/deepmerge": {
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+            "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
         "node_modules/default-browser": {
             "version": "5.5.0",
@@ -4782,6 +5367,19 @@
             "license": "MIT",
             "engines": {
                 "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/defaults": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+            "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "clone": "^1.0.2"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -4926,27 +5524,14 @@
             }
         },
         "node_modules/dotenv-expand": {
-            "version": "12.0.3",
-            "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-12.0.3.tgz",
-            "integrity": "sha512-uc47g4b+4k/M/SeaW1y4OApx+mtLWl92l5LMPP0GNXctZqELk+YGgOPIIC5elYmUH4OuoK3JLhuRUYegeySiFA==",
+            "version": "13.0.0",
+            "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-13.0.0.tgz",
+            "integrity": "sha512-aBfBS8eYIeXmpHI9ThIlA7/WLq+SLt18iXUZhb52rW89QLKQFoIpPG1bPeewoPZsTyjSSO3T7234FBVUM1V2rA==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
-                "dotenv": "^16.4.5"
+                "dotenv": "^17.4.2"
             },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://dotenvx.com"
-            }
-        },
-        "node_modules/dotenv-expand/node_modules/dotenv": {
-            "version": "16.6.1",
-            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-            "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
-            "dev": true,
-            "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=12"
             },
@@ -5000,6 +5585,33 @@
                 "node": ">= 0.8"
             }
         },
+        "node_modules/encoding-sniffer": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+            "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "iconv-lite": "^0.6.3",
+                "whatwg-encoding": "^3.1.1"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+            }
+        },
+        "node_modules/encoding-sniffer/node_modules/iconv-lite": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/enhanced-resolve": {
             "version": "5.24.3",
             "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.3.tgz",
@@ -5035,19 +5647,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6"
-            }
-        },
-        "node_modules/environment": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
-            "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/error-ex": {
@@ -5216,6 +5815,16 @@
                 "jiti": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/eslint-plugin-no-unsanitized": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-no-unsanitized/-/eslint-plugin-no-unsanitized-4.1.5.tgz",
+            "integrity": "sha512-MSB4hXPVFQrI8weqzs6gzl7reP2k/qSjtCoL2vUMSDejIIq9YL1ZKvq5/ORBXab/PvfBBrWO2jWviYpL+4Ghfg==",
+            "dev": true,
+            "license": "MPL-2.0",
+            "peerDependencies": {
+                "eslint": "^9 || ^10"
             }
         },
         "node_modules/eslint-plugin-react-dom": {
@@ -5483,6 +6092,20 @@
                 "url": "https://opencollective.com/eslint"
             }
         },
+        "node_modules/esprima": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "bin": {
+                "esparse": "bin/esparse.js",
+                "esvalidate": "bin/esvalidate.js"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/esquery": {
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
@@ -5544,13 +6167,6 @@
             "engines": {
                 "node": ">= 0.6"
             }
-        },
-        "node_modules/eventemitter3": {
-            "version": "5.0.4",
-            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
-            "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/eventsource": {
             "version": "3.0.7",
@@ -5657,6 +6273,13 @@
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
             "license": "MIT"
         },
+        "node_modules/fast-json-patch": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.1.1.tgz",
+            "integrity": "sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/fast-json-stable-stringify": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -5670,16 +6293,6 @@
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/fast-redact": {
-            "version": "3.5.0",
-            "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz",
-            "integrity": "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
         },
         "node_modules/fast-uri": {
             "version": "3.1.7",
@@ -5777,13 +6390,13 @@
             }
         },
         "node_modules/firefox-profile": {
-            "version": "4.7.0",
-            "resolved": "https://registry.npmjs.org/firefox-profile/-/firefox-profile-4.7.0.tgz",
-            "integrity": "sha512-aGApEu5bfCNbA4PGUZiRJAIU6jKmghV2UVdklXAofnNtiDjqYw0czLS46W7IfFqVKgKhFB8Ao2YoNGHY4BoIMQ==",
+            "version": "4.7.1",
+            "resolved": "https://registry.npmjs.org/firefox-profile/-/firefox-profile-4.7.1.tgz",
+            "integrity": "sha512-rUFGvJzXxhhOltBxf1aML9jTVismzgC3w00v2dG4Bxu5Xr6o9/D9QUT4do1ZUE9NHzmRFyQ6Bz+HBWnxZMO65w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "adm-zip": "~0.5.x",
+                "adm-zip": "~0.6.x",
                 "fs-extra": "^11.2.0",
                 "ini": "^4.1.3",
                 "minimist": "^1.2.8",
@@ -5806,6 +6419,16 @@
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
+        "node_modules/first-chunk-stream": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-3.0.0.tgz",
+            "integrity": "sha512-LNRvR4hr/S8cXXkIY5pTgVP7L3tq6LlYWcg9nWBuW7o1NMxKZo6oOVa/6GIekMGI0Iw7uC+HWimMe9u/VAeKqw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/flat-cache": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
@@ -5826,26 +6449,6 @@
             "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
             "dev": true,
             "license": "ISC"
-        },
-        "node_modules/form-data-encoder": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-4.1.0.tgz",
-            "integrity": "sha512-G6NsmEW15s0Uw9XnCg+33H3ViYRyiM0hMrMhhqQOR8NFc5GhYrI+6I3u7OTw7b91J2g8rtvMBZJDbcGb2YUniw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 18"
-            }
-        },
-        "node_modules/formdata-node": {
-            "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-6.0.3.tgz",
-            "integrity": "sha512-8e1++BCiTzUno9v5IZ2J6bv4RU+3UKDmqWUQD0MIMVCd9AdhWkO1gw57oo1mNEX1dMq2EGI+FbWz4B92pscSQg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 18"
-            }
         },
         "node_modules/forwarded": {
             "version": "0.2.0",
@@ -5933,17 +6536,15 @@
             }
         },
         "node_modules/fx-runner": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/fx-runner/-/fx-runner-1.4.0.tgz",
-            "integrity": "sha512-rci1g6U0rdTg6bAaBboP7XdRu01dzTAaKXxFf+PUqGuCv6Xu7o8NZdY1D5MvKGIjb6EdS1g3VlXOgksir1uGkg==",
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/fx-runner/-/fx-runner-1.6.0.tgz",
+            "integrity": "sha512-PEEUfnQJw0/io6SspBbR4EIeXFL/qe/sugesCyfr9M3llgyxNaOH8stvO6KJOKRjeUAvEB6oSZKS3lgjSEOsXg==",
             "dev": true,
             "license": "MPL-2.0",
             "dependencies": {
-                "commander": "2.9.0",
-                "shell-quote": "1.7.3",
-                "spawn-sync": "1.0.15",
-                "when": "3.7.7",
-                "which": "1.2.4",
+                "commander": "^12.1.0",
+                "shell-quote": "1.10.0",
+                "which": "^4.0.0",
                 "winreg": "0.0.12"
             },
             "bin": {
@@ -5951,44 +6552,52 @@
             }
         },
         "node_modules/fx-runner/node_modules/commander": {
-            "version": "2.9.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-            "integrity": "sha512-bmkUukX8wAOjHdN26xj5c4ctEV22TQ7dQYhSmuckKhToXrkUn0iIaolHdIxYYqD55nhpSPA9zPQ1yP57GdXP2A==",
+            "version": "12.1.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+            "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
             "dev": true,
             "license": "MIT",
-            "dependencies": {
-                "graceful-readlink": ">= 1.0.0"
-            },
             "engines": {
-                "node": ">= 0.6.x"
+                "node": ">=18"
             }
         },
         "node_modules/fx-runner/node_modules/isexe": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
-            "integrity": "sha512-d2eJzK691yZwPHcv1LbeAOa91yMJ9QmfTgSO1oXB65ezVhXQsxBac2vEB4bMVms9cGzaA99n6V2viHMq82VLDw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
+            "integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
             "dev": true,
-            "license": "ISC"
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=18"
+            }
         },
         "node_modules/fx-runner/node_modules/shell-quote": {
-            "version": "1.7.3",
-            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
-            "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+            "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
         },
         "node_modules/fx-runner/node_modules/which": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/which/-/which-1.2.4.tgz",
-            "integrity": "sha512-zDRAqDSBudazdfM9zpiI30Fu9ve47htYXcGi3ln0wfKu2a7SmrT6F3VDoYONu//48V8Vz4TdCRNPjtvyRO3yBA==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
+            "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
-                "is-absolute": "^0.1.7",
-                "isexe": "^1.1.1"
+                "isexe": "^3.1.1"
             },
             "bin": {
-                "which": "bin/which"
+                "node-which": "bin/which.js"
+            },
+            "engines": {
+                "node": "^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/get-caller-file": {
@@ -6038,13 +6647,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/get-port-please": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/get-port-please/-/get-port-please-3.2.0.tgz",
-            "integrity": "sha512-I9QVvBw5U/hw3RmWpYKRumUeaDgxTPd401x364rLmWBJcOQ753eov1eTgzDqRG9bqFIfDc7gfzcQEWrUri3o1A==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/get-proto": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
@@ -6080,13 +6682,6 @@
             "engines": {
                 "node": ">=10.13.0"
             }
-        },
-        "node_modules/glob-to-regexp": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-            "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-            "dev": true,
-            "license": "BSD-2-Clause"
         },
         "node_modules/global-directory": {
             "version": "5.0.0",
@@ -6135,20 +6730,6 @@
             "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
             "dev": true,
             "license": "ISC"
-        },
-        "node_modules/graceful-readlink": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-            "integrity": "sha512-8tLu60LgxF6XpdbK8OW3FA+IfTNBn1ZHGHKF4KQbEeSkajYw5PlYJcKluntgegDPTg8UkHjpet1T82vk6TQ68w==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/growly": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
-            "integrity": "sha512-+xGQY0YyAWCnqy7Cd++hc2JqMYzlm0dG30Jd0beaA64sROr8C4nt8Yc9V5Ro3avlSUDTN0ulqP/VBKi1/lLygw==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/happy-dom": {
             "version": "20.13.2",
@@ -6292,6 +6873,20 @@
                 "url": "https://opencollective.com/express"
             }
         },
+        "node_modules/https-proxy-agent": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+            "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^7.1.2",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
         "node_modules/husky": {
             "version": "9.1.7",
             "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
@@ -6341,6 +6936,19 @@
                 "node": ">= 4"
             }
         },
+        "node_modules/image-size": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/image-size/-/image-size-2.0.2.tgz",
+            "integrity": "sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "image-size": "bin/image-size.js"
+            },
+            "engines": {
+                "node": ">=16.x"
+            }
+        },
         "node_modules/immediate": {
             "version": "3.0.6",
             "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
@@ -6385,17 +6993,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/import-meta-resolve": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
-            "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
-            }
-        },
         "node_modules/imurmurhash": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -6404,6 +7001,19 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.8.19"
+            }
+        },
+        "node_modules/index-to-position": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.2.0.tgz",
+            "integrity": "sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/inherits": {
@@ -6438,19 +7048,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.10"
-            }
-        },
-        "node_modules/is-absolute": {
-            "version": "0.1.7",
-            "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
-            "integrity": "sha512-Xi9/ZSn4NFapG8RP98iNPMOeaV3mXPisxKxzKtHVqr3g56j/fBn+yZmnxSVAA8lmZbl2J9b/a4kJvfU3hqQYgA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-relative": "^0.1.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/is-arrayish": {
@@ -6503,19 +7100,13 @@
             }
         },
         "node_modules/is-fullwidth-code-point": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
-            "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
             "dev": true,
             "license": "MIT",
-            "dependencies": {
-                "get-east-asian-width": "^1.3.1"
-            },
             "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+                "node": ">=8"
             }
         },
         "node_modules/is-glob": {
@@ -6661,19 +7252,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/is-plain-object": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-            "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "isobject": "^3.0.1"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/is-potential-custom-element-name": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
@@ -6681,30 +7259,18 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/is-primitive": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-3.0.1.tgz",
-            "integrity": "sha512-GljRxhWvlCNRfZyORiH77FwdFwGcMO620o37EOYC0ORWdq+WYNVqW0w2Juzew4M+L81l6/QS3t5gkkihyRqv9w==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/is-promise": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
             "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
             "license": "MIT"
         },
-        "node_modules/is-relative": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz",
-            "integrity": "sha512-wBOr+rNM4gkAZqoLRJI4myw5WzzIdQosFAAbnvfXP5z1LyzgAI3ivOKehC5KfqlQJZoihVhirgtCBj378Eg8GA==",
+        "node_modules/is-utf8": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+            "integrity": "sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q==",
             "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
+            "license": "MIT"
         },
         "node_modules/is-wsl": {
             "version": "3.1.1",
@@ -6734,16 +7300,6 @@
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
             "license": "ISC"
-        },
-        "node_modules/isobject": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-            "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
         },
         "node_modules/javascript-natural-sort": {
             "version": "0.7.1",
@@ -6834,6 +7390,16 @@
             "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/json-merge-patch": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/json-merge-patch/-/json-merge-patch-1.0.2.tgz",
+            "integrity": "sha512-M6Vp2GN9L7cfuMXiWOmHj9bEFbeC250iVtcKQbqVgEsDVYnIsrNsbU+h/Y/PkbBQCtEa4Bez+Ebv0zfbC8ObLg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3"
+            }
         },
         "node_modules/json-parse-even-better-errors": {
             "version": "2.3.1",
@@ -6954,16 +7520,6 @@
             "license": "MIT",
             "dependencies": {
                 "json-buffer": "3.0.1"
-            }
-        },
-        "node_modules/kleur": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
-            "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/kolorist": {
@@ -7354,23 +7910,6 @@
                 "yaml": "^2.9.0"
             }
         },
-        "node_modules/listr2": {
-            "version": "10.2.1",
-            "resolved": "https://registry.npmjs.org/listr2/-/listr2-10.2.1.tgz",
-            "integrity": "sha512-7I5knELsJKTUjXG+A6BkKAiGkW1i25fNa/xlUl9hFtk15WbE9jndA89xu5FzQKrY5llajE1hfZZFMILXkDHk/Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "cli-truncate": "^5.2.0",
-                "eventemitter3": "^5.0.4",
-                "log-update": "^6.1.0",
-                "rfdc": "^1.4.1",
-                "wrap-ansi": "^10.0.0"
-            },
-            "engines": {
-                "node": ">=22.13.0"
-            }
-        },
         "node_modules/local-pkg": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-1.2.1.tgz",
@@ -7468,79 +8007,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/log-update": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
-            "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-escapes": "^7.0.0",
-                "cli-cursor": "^5.0.0",
-                "slice-ansi": "^7.1.0",
-                "strip-ansi": "^7.1.0",
-                "wrap-ansi": "^9.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/log-update/node_modules/slice-ansi": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
-            "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^6.2.1",
-                "is-fullwidth-code-point": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/slice-ansi?sponsor=1"
-            }
-        },
-        "node_modules/log-update/node_modules/string-width": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-            "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "emoji-regex": "^10.3.0",
-                "get-east-asian-width": "^1.0.0",
-                "strip-ansi": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/log-update/node_modules/wrap-ansi": {
-            "version": "9.0.2",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
-            "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^6.2.1",
-                "string-width": "^7.0.0",
-                "strip-ansi": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-            }
-        },
         "node_modules/lucide-react": {
             "version": "1.40.0",
             "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.40.0.tgz",
@@ -7609,6 +8075,13 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/mdn-data": {
+            "version": "2.27.1",
+            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+            "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+            "dev": true,
+            "license": "CC0-1.0"
+        },
         "node_modules/media-typer": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
@@ -7653,19 +8126,6 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/express"
-            }
-        },
-        "node_modules/mimic-function": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
-            "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/minimatch": {
@@ -7833,19 +8293,6 @@
                 "node": "*"
             }
         },
-        "node_modules/nano-spawn": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/nano-spawn/-/nano-spawn-2.1.0.tgz",
-            "integrity": "sha512-yTW+2okrElHiH4fsiz/+/zc0EDo9BDDoC3iKk8dpv1GeRc9nUWzUZHx6TofMWErchhUQR8hY9/Eu1Uja9x1nqA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=20.17"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/nano-spawn?sponsor=1"
-            }
-        },
         "node_modules/nanoid": {
             "version": "3.3.18",
             "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
@@ -7863,16 +8310,6 @@
             },
             "engines": {
                 "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-            }
-        },
-        "node_modules/nanospinner": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/nanospinner/-/nanospinner-1.2.2.tgz",
-            "integrity": "sha512-Zt/AmG6qRU3e+WnzGGLuMCEAO/dAu45stNbHY223tUxldaDAeE+FxSPsd9Q+j+paejmm0ZbrNVs5Sraqy3dRxA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "picocolors": "^1.1.1"
             }
         },
         "node_modules/natural-compare": {
@@ -7902,13 +8339,6 @@
                 "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
             }
         },
-        "node_modules/node-fetch-native": {
-            "version": "1.6.7",
-            "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
-            "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/node-forge": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
@@ -7917,60 +8347,6 @@
             "license": "(BSD-3-Clause OR GPL-2.0)",
             "engines": {
                 "node": ">= 6.13.0"
-            }
-        },
-        "node_modules/node-notifier": {
-            "version": "10.0.1",
-            "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-10.0.1.tgz",
-            "integrity": "sha512-YX7TSyDukOZ0g+gmzjB6abKu+hTGvO8+8+gIFDsRCU2t8fLV/P2unmt+LGFaIa4y64aX98Qksa97rgz4vMNeLQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "growly": "^1.3.0",
-                "is-wsl": "^2.2.0",
-                "semver": "^7.3.5",
-                "shellwords": "^0.1.1",
-                "uuid": "^8.3.2",
-                "which": "^2.0.2"
-            }
-        },
-        "node_modules/node-notifier/node_modules/is-docker": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-            "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "is-docker": "cli.js"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/node-notifier/node_modules/is-wsl": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-            "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-docker": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/normalize-path": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-            "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/nth-check": {
@@ -8036,18 +8412,6 @@
             ],
             "license": "MIT"
         },
-        "node_modules/ofetch": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.5.1.tgz",
-            "integrity": "sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "destr": "^2.0.5",
-                "node-fetch-native": "^1.6.7",
-                "ufo": "^1.6.1"
-            }
-        },
         "node_modules/ohash": {
             "version": "2.0.11",
             "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
@@ -8084,22 +8448,6 @@
             "license": "ISC",
             "dependencies": {
                 "wrappy": "1"
-            }
-        },
-        "node_modules/onetime": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
-            "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "mimic-function": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/open": {
@@ -8139,15 +8487,6 @@
             },
             "engines": {
                 "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/os-shim": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
-            "integrity": "sha512-jd0cvB8qQ5uVt0lvCIexBaROw1KyKm5sbulg2fWOHjETisuCzWyt+eTZKEMs8v6HwzoGs8xik26jg7eCM6pS+A==",
-            "dev": true,
-            "engines": {
-                "node": ">= 0.4.0"
             }
         },
         "node_modules/p-limit": {
@@ -8261,6 +8600,59 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/parse5": {
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+            "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "entities": "^6.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/inikulin/parse5?sponsor=1"
+            }
+        },
+        "node_modules/parse5-htmlparser2-tree-adapter": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+            "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "domhandler": "^5.0.3",
+                "parse5": "^7.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/inikulin/parse5?sponsor=1"
+            }
+        },
+        "node_modules/parse5-parser-stream": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+            "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "parse5": "^7.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/inikulin/parse5?sponsor=1"
+            }
+        },
+        "node_modules/parse5/node_modules/entities": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+            "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
         "node_modules/parseurl": {
             "version": "1.3.3",
             "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -8320,6 +8712,13 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/pend": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+            "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/perfect-debounce": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-2.1.0.tgz",
@@ -8348,32 +8747,32 @@
             }
         },
         "node_modules/pino": {
-            "version": "9.7.0",
-            "resolved": "https://registry.npmjs.org/pino/-/pino-9.7.0.tgz",
-            "integrity": "sha512-vnMCM6xZTb1WDmLvtG2lE/2p+t9hDEIvTWJsu6FejkE62vB7gDhvzrpFR4Cw2to+9JNQxVnkAKVPA1KPB98vWg==",
+            "version": "10.3.1",
+            "resolved": "https://registry.npmjs.org/pino/-/pino-10.3.1.tgz",
+            "integrity": "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
+                "@pinojs/redact": "^0.4.0",
                 "atomic-sleep": "^1.0.0",
-                "fast-redact": "^3.1.1",
                 "on-exit-leak-free": "^2.1.0",
-                "pino-abstract-transport": "^2.0.0",
+                "pino-abstract-transport": "^3.0.0",
                 "pino-std-serializers": "^7.0.0",
                 "process-warning": "^5.0.0",
                 "quick-format-unescaped": "^4.0.3",
                 "real-require": "^0.2.0",
                 "safe-stable-stringify": "^2.3.1",
                 "sonic-boom": "^4.0.1",
-                "thread-stream": "^3.0.0"
+                "thread-stream": "^4.0.0"
             },
             "bin": {
                 "pino": "bin.js"
             }
         },
         "node_modules/pino-abstract-transport": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
-            "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
+            "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8484,9 +8883,9 @@
             "license": "MIT"
         },
         "node_modules/process-warning": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
-            "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.1.0.tgz",
+            "integrity": "sha512-jQSaVHsPgtyw60e1rQ/A+/ArPEj/S8pS/vFnyGa/gYFXrKk/6RuDkoqVDQ5NI5MmS01698ltlAk0NoDBNLujRw==",
             "dev": true,
             "funding": [
                 {
@@ -8513,20 +8912,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/prompts": {
-            "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
-            "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "kleur": "^3.0.3",
-                "sisteransi": "^1.0.5"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
         "node_modules/proto-list": {
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
@@ -8548,37 +8933,21 @@
             }
         },
         "node_modules/publish-browser-extension": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/publish-browser-extension/-/publish-browser-extension-4.0.5.tgz",
-            "integrity": "sha512-EePAn3VIHJS/jqCuvs1NgPgoecCT8+RsES76hbgYe2Ze1dyvB0tX60C1PCrV8Z8fv56mW3E59s9Gd/GwWiw7dw==",
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/publish-browser-extension/-/publish-browser-extension-6.1.1.tgz",
+            "integrity": "sha512-ovfBOz+cZIOBHZ+oxTfpv1kSGU7ruzy8CXoFGvhXsUbJuty45srGzf1ufEePs69virOWXfFbhZRoNQUdgPvwXA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "cac": "^6.7.14",
-                "consola": "^3.4.2",
-                "dotenv": "^17.2.4",
-                "form-data-encoder": "^4.1.0",
-                "formdata-node": "^6.0.3",
-                "jsonwebtoken": "^9.0.3",
-                "listr2": "^10.1.0",
-                "ofetch": "^1.5.1",
-                "zod": "3.25.76 || ^4.3.6"
+                "@topcli/prompts": "^4.0.0",
+                "cac": "^7.0.0",
+                "tasuku": "^2.3.0"
             },
             "bin": {
                 "publish-extension": "bin/publish-extension.mjs"
             },
             "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/publish-browser-extension/node_modules/cac": {
-            "version": "6.7.14",
-            "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
-            "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
+                "node": ">=22.0.0"
             }
         },
         "node_modules/punycode": {
@@ -8875,30 +9244,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/restore-cursor": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
-            "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "onetime": "^7.0.0",
-                "signal-exit": "^4.1.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/rfdc": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
-            "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/rolldown": {
             "version": "1.2.7",
             "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.7.tgz",
@@ -9017,9 +9362,9 @@
             "license": "MIT"
         },
         "node_modules/sax": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
-            "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+            "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
@@ -9041,9 +9386,9 @@
             "license": "MIT"
         },
         "node_modules/semver": {
-            "version": "7.8.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
-            "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -9098,25 +9443,6 @@
                 "url": "https://opencollective.com/express"
             }
         },
-        "node_modules/set-value": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/set-value/-/set-value-4.1.0.tgz",
-            "integrity": "sha512-zTEg4HL0RwVrqcWs3ztF+x1vkxfm0lP+MQQFPiMJTKVceBwEV0A569Ou8l9IYQG8jOZdMVI1hGsc0tmeD2o/Lw==",
-            "dev": true,
-            "funding": [
-                "https://github.com/sponsors/jonschlinkert",
-                "https://paypal.me/jonathanschlinkert",
-                "https://jonschlinkert.dev/sponsor"
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "is-plain-object": "^2.0.4",
-                "is-primitive": "^3.0.1"
-            },
-            "engines": {
-                "node": ">=11.0"
-            }
-        },
         "node_modules/setimmediate": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
@@ -9163,13 +9489,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
-        },
-        "node_modules/shellwords": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
-            "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/side-channel": {
             "version": "1.1.1",
@@ -9250,19 +9569,6 @@
             "dev": true,
             "license": "ISC"
         },
-        "node_modules/signal-exit": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": ">=14"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
         "node_modules/simple-icons": {
             "version": "16.29.0",
             "resolved": "https://registry.npmjs.org/simple-icons/-/simple-icons-16.29.0.tgz",
@@ -9281,30 +9587,6 @@
             "license": "CC0-1.0",
             "engines": {
                 "node": ">=0.12.18"
-            }
-        },
-        "node_modules/sisteransi": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
-            "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/slice-ansi": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
-            "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^6.2.3",
-                "is-fullwidth-code-point": "^5.1.0"
-            },
-            "engines": {
-                "node": ">=20"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/slice-ansi?sponsor=1"
             }
         },
         "node_modules/sonic-boom": {
@@ -9363,18 +9645,6 @@
             "dependencies": {
                 "buffer-from": "^1.0.0",
                 "source-map": "^0.6.0"
-            }
-        },
-        "node_modules/spawn-sync": {
-            "version": "1.0.15",
-            "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
-            "integrity": "sha512-9DWBgrgYZzNghseho0JOuh+5fg9u6QWhAWa51QC7+U5rCheZ/j1DrEZnyE0RBBRqZ9uEXGPgSSM0nky6burpVw==",
-            "dev": true,
-            "hasInstallScript": true,
-            "license": "MIT",
-            "dependencies": {
-                "concat-stream": "^1.4.7",
-                "os-shim": "^0.1.2"
             }
         },
         "node_modules/split": {
@@ -9465,20 +9735,48 @@
             "license": "MIT"
         },
         "node_modules/string-width": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
-            "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "get-east-asian-width": "^1.5.0",
-                "strip-ansi": "^7.1.2"
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
             },
             "engines": {
-                "node": ">=20"
+                "node": ">=8"
+            }
+        },
+        "node_modules/string-width/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/string-width/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/string-width/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
             },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/strip-ansi": {
@@ -9510,10 +9808,37 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/strip-bom-buf": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/strip-bom-buf/-/strip-bom-buf-2.0.0.tgz",
+            "integrity": "sha512-gLFNHucd6gzb8jMsl5QmZ3QgnUJmp7qn4uUSHNwEXumAp7YizoGYw19ZUVfuq4aBOQUtyn2k8X/CwzWB73W2lQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-utf8": "^0.2.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/strip-bom-stream": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-4.0.0.tgz",
+            "integrity": "sha512-0ApK3iAkHv6WbgLICw/J4nhwHeDZsBxIIsOD+gHgZICL6SeJ0S9f/WZqemka9cjkTyMN5geId6e8U5WGFAn3cQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "first-chunk-stream": "^3.0.0",
+                "strip-bom-buf": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/strip-json-comments": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.2.tgz",
-            "integrity": "sha512-4X2FR3UwhNUE9G49aIsJW5hRRR3GXGTBTZRMfv568O60ojM8HcWjV/VxAxCDW3SUND33O6ZY66ZuRcdkj73q2g==",
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
+            "integrity": "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -9559,6 +9884,16 @@
             "integrity": "sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/superlock": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/superlock/-/superlock-1.3.5.tgz",
+            "integrity": "sha512-XpWNthvezZnWp0u7/UL8rBbBOnq2Qx39fw+0RNMC/+eotOd81glzsmIWVH0ejarhTeDQihxOKSbjm2XXFo5a8w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14"
+            }
         },
         "node_modules/supports-color": {
             "version": "8.1.1",
@@ -9621,20 +9956,47 @@
                 "url": "https://opencollective.com/webpack"
             }
         },
+        "node_modules/tasuku": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/tasuku/-/tasuku-2.3.0.tgz",
+            "integrity": "sha512-9Jtk+XAnttslCw4i9RceSZGr2PT5TLn0vUyWnoP2SdlSYzkiYRY6kB5qnPi5IQ/Em8e4oBow1rpaA39iijTIrA==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/privatenumber/tasuku?sponsor=1"
+            }
+        },
         "node_modules/thread-stream": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
-            "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.2.0.tgz",
+            "integrity": "sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "real-require": "^0.2.0"
+                "real-require": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=20"
             }
+        },
+        "node_modules/thread-stream/node_modules/real-require": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/real-require/-/real-require-1.0.0.tgz",
+            "integrity": "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/through": {
             "version": "2.3.8",
             "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
             "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/tiny-open": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/tiny-open/-/tiny-open-1.3.0.tgz",
+            "integrity": "sha512-GUFS8yjJZq0oWqCKCJVHcBgMpmi2WEGXY1le3E5ncR0DsgTII5uUyxtfk8/vGyDDGBE42UYHR6Ocvlk8mkXSRg==",
             "dev": true,
             "license": "MIT"
         },
@@ -9683,9 +10045,9 @@
             }
         },
         "node_modules/tmp": {
-            "version": "0.2.5",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-            "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+            "version": "0.2.7",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+            "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -9805,13 +10167,6 @@
                 "url": "https://opencollective.com/express"
             }
         },
-        "node_modules/typedarray": {
-            "version": "0.0.6",
-            "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-            "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/typescript": {
             "version": "6.0.3",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
@@ -9863,6 +10218,16 @@
             "integrity": "sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==",
             "dev": true,
             "license": "ISC"
+        },
+        "node_modules/undici": {
+            "version": "7.29.1",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.1.tgz",
+            "integrity": "sha512-RYONW2MeafgYlkVOKYKkA/Ag7BmXqgIWCa8t1m0JcxrQg9pI9lEqRhAOruOBCbAohOa/gkCF+iPi9hrgvTzu6Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.18.1"
+            }
         },
         "node_modules/undici-types": {
             "version": "8.3.0",
@@ -10053,6 +10418,30 @@
                 "url": "https://github.com/sponsors/sxzz"
             }
         },
+        "node_modules/upath": {
+            "version": "3.0.8",
+            "resolved": "https://registry.npmjs.org/upath/-/upath-3.0.8.tgz",
+            "integrity": "sha512-YAsrLMIlhfSCm9rga5TZsJ1mXgahs7N0qOTokzU8mFz35hUrYMvVkaEPefI3rEb/vkAWAOj1Km/qdije9RC1kQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/anodynos"
+                },
+                {
+                    "type": "polar",
+                    "url": "https://polar.sh/anodynos"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/subscription/pkg/npm-upath"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
+            }
+        },
         "node_modules/update-notifier": {
             "version": "7.3.1",
             "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-7.3.1.tgz",
@@ -10117,17 +10506,6 @@
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/uuid": {
-            "version": "8.3.2",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-            "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "uuid": "dist/bin/uuid"
-            }
         },
         "node_modules/vary": {
             "version": "1.1.2",
@@ -10214,29 +10592,6 @@
                 "yaml": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/vite-node": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-6.0.0.tgz",
-            "integrity": "sha512-oj4PVrT+pDh6GYf5wfUXkcZyekYS8kKPfLPXVl8qe324Ec6l4K2DUKNadRbZ3LQl0qGcDz+PyOo7ZAh00Y+JjQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "cac": "^7.0.0",
-                "es-module-lexer": "^2.0.0",
-                "obug": "^2.1.1",
-                "pathe": "^2.0.3",
-                "vite": "^8.0.0"
-            },
-            "bin": {
-                "vite-node": "dist/cli.mjs"
-            },
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/antfu"
             }
         },
         "node_modules/vite-plugin-css-injected-by-js": {
@@ -10392,9 +10747,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -10416,9 +10768,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -10440,9 +10789,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -10464,9 +10810,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -10620,103 +10963,163 @@
             "license": "MIT"
         },
         "node_modules/watchpack": {
-            "version": "2.4.4",
-            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.4.tgz",
-            "integrity": "sha512-c5EGNOiyxxV5qmTtAB7rbiXxi1ooX1pQKMLX/MIabJjRA0SJBQOjKF+KSVfHkr9U1cADPon0mRiVe/riyaiDUA==",
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.2.tgz",
+            "integrity": "sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "glob-to-regexp": "^0.4.1",
                 "graceful-fs": "^4.1.2"
             },
             "engines": {
                 "node": ">=10.13.0"
             }
         },
-        "node_modules/web-ext-run": {
-            "version": "0.2.4",
-            "resolved": "https://registry.npmjs.org/web-ext-run/-/web-ext-run-0.2.4.tgz",
-            "integrity": "sha512-rQicL7OwuqWdQWI33JkSXKcp7cuv1mJG8u3jRQwx/8aDsmhbTHs9ZRmNYOL+LX0wX8edIEQX8jj4bB60GoXtKA==",
+        "node_modules/wcwidth": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+            "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "defaults": "^1.0.3"
+            }
+        },
+        "node_modules/web-ext": {
+            "version": "10.6.0",
+            "resolved": "https://registry.npmjs.org/web-ext/-/web-ext-10.6.0.tgz",
+            "integrity": "sha512-r1MfSwVy5wRQw3UgTUCw9CDViFIoDPri1Wq8qh/mRjC8T+K0TfuxKz68bzYTEP3rbAW6Wn8y7v/jXzBYd3LLGA==",
             "dev": true,
             "license": "MPL-2.0",
             "dependencies": {
-                "@babel/runtime": "7.28.2",
-                "@devicefarmer/adbkit": "3.3.8",
+                "@babel/runtime": "8.0.0",
+                "@devicefarmer/adbkit": "3.3.9",
+                "addons-linter": "10.10.0",
+                "camelcase": "8.0.0",
                 "chrome-launcher": "1.2.0",
                 "debounce": "1.2.1",
+                "decamelize": "6.0.1",
                 "es6-error": "4.1.1",
-                "firefox-profile": "4.7.0",
-                "fx-runner": "1.4.0",
+                "firefox-profile": "4.7.1",
+                "fx-runner": "1.6.0",
+                "https-proxy-agent": "^7.0.0",
+                "jose": "5.9.6",
+                "jszip": "3.10.1",
                 "multimatch": "6.0.0",
-                "node-notifier": "10.0.1",
-                "parse-json": "7.1.1",
-                "pino": "9.7.0",
+                "open": "11.0.0",
+                "parse-json": "8.3.0",
+                "pino": "10.3.1",
                 "promise-toolbox": "0.21.0",
-                "set-value": "4.1.0",
                 "source-map-support": "0.5.21",
                 "strip-bom": "5.0.0",
-                "strip-json-comments": "5.0.2",
-                "tmp": "0.2.5",
+                "strip-json-comments": "5.0.3",
+                "tmp": "0.2.7",
                 "update-notifier": "7.3.1",
-                "watchpack": "2.4.4",
+                "watchpack": "2.5.2",
+                "yargs": "17.7.2",
                 "zip-dir": "2.0.0"
             },
+            "bin": {
+                "web-ext": "bin/web-ext.js"
+            },
             "engines": {
-                "node": ">=18.0.0",
+                "node": ">=20.0.0",
                 "npm": ">=8.0.0"
             }
         },
-        "node_modules/web-ext-run/node_modules/json-parse-even-better-errors": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-3.0.2.tgz",
-            "integrity": "sha512-fi0NG4bPjCHunUJffmLd0gxssIgkNmArMvis4iNah6Owg1MCJjWhEcDLmsK6iGkJq3tHwbDkTlce70/tmXN4cQ==",
+        "node_modules/web-ext/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+                "node": ">=8"
             }
         },
-        "node_modules/web-ext-run/node_modules/lines-and-columns": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-2.0.4.tgz",
-            "integrity": "sha512-wM1+Z03eypVAVUCE7QdSqpVIvelbOakn1M0bPDoA4SGWPx3sNDVUiMo3L6To6WWGClB7VyXnhQ4Sn7gxiJbE6A==",
+        "node_modules/web-ext/node_modules/cliui": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+            "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.1",
+                "wrap-ansi": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/web-ext/node_modules/jose": {
+            "version": "5.9.6",
+            "resolved": "https://registry.npmjs.org/jose/-/jose-5.9.6.tgz",
+            "integrity": "sha512-AMlnetc9+CV9asI19zHmrgS/WYsWUwCn2R7RzlbJWD7F9eWYUTGyBmU9o6PxngtLGOiDGPRu+Uc4fhKzbpteZQ==",
             "dev": true,
             "license": "MIT",
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            "funding": {
+                "url": "https://github.com/sponsors/panva"
             }
         },
-        "node_modules/web-ext-run/node_modules/parse-json": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-7.1.1.tgz",
-            "integrity": "sha512-SgOTCX/EZXtZxBE5eJ97P4yGM5n37BwRU+YMsH4vNzFqJV/oWFXXCmwFlgWUM4PrakybVOueJJ6pwHqSVhTFDw==",
+        "node_modules/web-ext/node_modules/parse-json": {
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
+            "integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.21.4",
-                "error-ex": "^1.3.2",
-                "json-parse-even-better-errors": "^3.0.0",
-                "lines-and-columns": "^2.0.3",
-                "type-fest": "^3.8.0"
+                "@babel/code-frame": "^7.26.2",
+                "index-to-position": "^1.1.0",
+                "type-fest": "^4.39.1"
             },
             "engines": {
-                "node": ">=16"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/web-ext-run/node_modules/type-fest": {
-            "version": "3.13.1",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
-            "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==",
+        "node_modules/web-ext/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
             "dev": true,
-            "license": "(MIT OR CC0-1.0)",
-            "engines": {
-                "node": ">=14.16"
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
             },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/web-ext/node_modules/yargs": {
+            "version": "17.7.2",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+            "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cliui": "^8.0.1",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "require-directory": "^2.1.1",
+                "string-width": "^4.2.3",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^21.1.1"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/web-ext/node_modules/yargs-parser": {
+            "version": "21.1.1",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+            "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/webpack-virtual-modules": {
@@ -10725,6 +11128,33 @@
             "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/whatwg-encoding": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+            "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+            "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "iconv-lite": "0.6.3"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
         "node_modules/whatwg-mimetype": {
             "version": "3.0.0",
@@ -10735,13 +11165,6 @@
             "engines": {
                 "node": ">=12"
             }
-        },
-        "node_modules/when": {
-            "version": "3.7.7",
-            "resolved": "https://registry.npmjs.org/when/-/when-3.7.7.tgz",
-            "integrity": "sha512-9lFZp/KHoqH6bPKjbWqa+3Dg/K/r2v0X/3/G2x4DBGchVS2QX2VXL3cZV994WQVnTM1/PD71Az25nAzryEUugw==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/when-exit": {
             "version": "2.1.5",
@@ -10849,21 +11272,60 @@
             }
         },
         "node_modules/wrap-ansi": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-10.0.0.tgz",
-            "integrity": "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "ansi-styles": "^6.2.3",
-                "string-width": "^8.2.0",
-                "strip-ansi": "^7.1.2"
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
             },
             "engines": {
-                "node": ">=20"
+                "node": ">=10"
             },
             "funding": {
                 "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/wrap-ansi/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/wrap-ansi/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/wrap-ansi/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/wrappy": {
@@ -10912,54 +11374,41 @@
             }
         },
         "node_modules/wxt": {
-            "version": "0.20.27",
-            "resolved": "https://registry.npmjs.org/wxt/-/wxt-0.20.27.tgz",
-            "integrity": "sha512-dm6yixz2awM4YMqpTJnsCa8aOPiTrjiIjbWslgR5hCjgwhuft+hLlla339Dt7gIKwQloee4oOruoK++vaX0APA==",
+            "version": "0.21.4",
+            "resolved": "https://registry.npmjs.org/wxt/-/wxt-0.21.4.tgz",
+            "integrity": "sha512-iyVMTXb37BQAbsPHCuPzrK3ZxnO9pZmvbKl7VJWIHe3RG40On2NyP2FOjArtOITO96plEYnh3o+iUlRp9qE90w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@1natsu/wait-element": "^4.1.2",
                 "@aklinker1/rollup-plugin-visualizer": "5.12.0",
-                "@webext-core/fake-browser": "^1.3.4",
-                "@webext-core/isolated-element": "^1.1.3",
-                "@webext-core/match-patterns": "^1.0.3",
-                "@wxt-dev/browser": "^0.2.0",
+                "@aklinker1/zero-zip": "^1.0.1",
+                "@topcli/prompts": "^4.0.0",
+                "@webext-core/fake-browser": "^2.0.1",
+                "@webext-core/isolated-element": "^1.1.3 || ^2 || ^3",
+                "@webext-core/match-patterns": "^2.0.0",
+                "@wxt-dev/browser": ">=0.1",
                 "@wxt-dev/storage": "^1.0.0",
-                "async-mutex": "^0.5.0",
                 "c12": "^3.3.4",
                 "cac": "^6.7.14 || ^7.0.0",
                 "chokidar": "^5.0.0",
-                "ci-info": "^4.4.0",
                 "consola": "^3.4.2",
                 "defu": "^6.1.4",
-                "dotenv-expand": "^12.0.3",
-                "esbuild": "^0.27.1",
+                "dotenv-expand": "^13.0.0",
                 "filesize": "^11.0.17",
-                "get-port-please": "^3.2.0",
                 "giget": "^1.2.3 || ^2.0.0 || ^3.0.0",
                 "hookable": "^6.1.0",
-                "import-meta-resolve": "^4.2.0",
-                "is-wsl": "^3.1.1",
                 "json5": "^2.2.3",
-                "jszip": "^3.10.1",
                 "linkedom": "^0.18.12",
                 "magicast": "^0.5.2",
-                "nano-spawn": "^2.0.0",
-                "nanospinner": "^1.2.2",
-                "normalize-path": "^3.0.0",
                 "nypm": "^0.6.5",
-                "ohash": "^2.0.11",
-                "open": "^11.0.0",
-                "perfect-debounce": "^2.1.0",
                 "picomatch": "^4.0.3",
-                "prompts": "^2.4.2",
-                "publish-browser-extension": "^2.3.0 || ^3.0.2 || ^4.0.5",
-                "scule": "^1.3.0",
+                "publish-browser-extension": "^5.1.0 || ^6.0.0",
+                "superlock": "^1.3.2",
+                "tiny-open": "^1.3.0",
+                "tinyexec": "^1.2.4",
                 "tinyglobby": "^0.2.16",
-                "unimport": "^3.13.1 || ^4.0.0 || ^5.0.0 || ^6.0.0",
-                "vite": "^5.4.19 || ^6.3.4 || ^7.0.0 || ^8.0.0-0",
-                "vite-node": "^3.2.4 || ^5.0.0 || ^6.0.0",
-                "web-ext-run": "^0.2.4"
+                "unimport": "^3.13.1 || ^4.0.0 || ^5.0.0 || ^6.0.0"
             },
             "bin": {
                 "wxt": "bin/wxt.mjs",
@@ -10967,513 +11416,27 @@
             },
             "engines": {
                 "bun": ">=1.2.0",
-                "node": ">=20.12.0"
+                "node": ">=22"
             },
             "funding": {
                 "url": "https://github.com/sponsors/wxt-dev"
             },
             "peerDependencies": {
-                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0"
+                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+                "typescript": ">=5.4",
+                "vite": "^6.3.4 || ^7.0.0 || ^8.0.0-0",
+                "web-ext": ">=9.2.0"
             },
             "peerDependenciesMeta": {
                 "eslint": {
                     "optional": true
+                },
+                "typescript": {
+                    "optional": true
+                },
+                "web-ext": {
+                    "optional": true
                 }
-            }
-        },
-        "node_modules/wxt/node_modules/@esbuild/aix-ppc64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
-            "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
-            "cpu": [
-                "ppc64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "aix"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/wxt/node_modules/@esbuild/android-arm": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
-            "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
-            "cpu": [
-                "arm"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/wxt/node_modules/@esbuild/android-arm64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
-            "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/wxt/node_modules/@esbuild/android-x64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
-            "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/wxt/node_modules/@esbuild/darwin-arm64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
-            "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/wxt/node_modules/@esbuild/darwin-x64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
-            "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/wxt/node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
-            "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/wxt/node_modules/@esbuild/freebsd-x64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
-            "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/wxt/node_modules/@esbuild/linux-arm": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
-            "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
-            "cpu": [
-                "arm"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/wxt/node_modules/@esbuild/linux-arm64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
-            "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/wxt/node_modules/@esbuild/linux-ia32": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
-            "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
-            "cpu": [
-                "ia32"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/wxt/node_modules/@esbuild/linux-loong64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
-            "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
-            "cpu": [
-                "loong64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/wxt/node_modules/@esbuild/linux-mips64el": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
-            "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
-            "cpu": [
-                "mips64el"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/wxt/node_modules/@esbuild/linux-ppc64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
-            "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
-            "cpu": [
-                "ppc64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/wxt/node_modules/@esbuild/linux-riscv64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
-            "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
-            "cpu": [
-                "riscv64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/wxt/node_modules/@esbuild/linux-s390x": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
-            "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
-            "cpu": [
-                "s390x"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/wxt/node_modules/@esbuild/linux-x64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
-            "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/wxt/node_modules/@esbuild/netbsd-arm64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
-            "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "netbsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/wxt/node_modules/@esbuild/netbsd-x64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
-            "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "netbsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/wxt/node_modules/@esbuild/openbsd-arm64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
-            "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "openbsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/wxt/node_modules/@esbuild/openbsd-x64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
-            "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "openbsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/wxt/node_modules/@esbuild/openharmony-arm64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
-            "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "openharmony"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/wxt/node_modules/@esbuild/sunos-x64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
-            "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "sunos"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/wxt/node_modules/@esbuild/win32-arm64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
-            "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/wxt/node_modules/@esbuild/win32-ia32": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
-            "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
-            "cpu": [
-                "ia32"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/wxt/node_modules/@esbuild/win32-x64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
-            "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/wxt/node_modules/@wxt-dev/browser": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/@wxt-dev/browser/-/browser-0.2.0.tgz",
-            "integrity": "sha512-gURcpkDUknl6FGe8LTsFqv4ZWfi/EacAalJ18qmtVzOnicCZRKkIGK2SApO7JxG4Ig589UexM/CADbKJ66h8aw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/filesystem": "*",
-                "@types/har-format": "*"
-            }
-        },
-        "node_modules/wxt/node_modules/esbuild": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
-            "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
-            "dev": true,
-            "hasInstallScript": true,
-            "license": "MIT",
-            "bin": {
-                "esbuild": "bin/esbuild"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "optionalDependencies": {
-                "@esbuild/aix-ppc64": "0.27.7",
-                "@esbuild/android-arm": "0.27.7",
-                "@esbuild/android-arm64": "0.27.7",
-                "@esbuild/android-x64": "0.27.7",
-                "@esbuild/darwin-arm64": "0.27.7",
-                "@esbuild/darwin-x64": "0.27.7",
-                "@esbuild/freebsd-arm64": "0.27.7",
-                "@esbuild/freebsd-x64": "0.27.7",
-                "@esbuild/linux-arm": "0.27.7",
-                "@esbuild/linux-arm64": "0.27.7",
-                "@esbuild/linux-ia32": "0.27.7",
-                "@esbuild/linux-loong64": "0.27.7",
-                "@esbuild/linux-mips64el": "0.27.7",
-                "@esbuild/linux-ppc64": "0.27.7",
-                "@esbuild/linux-riscv64": "0.27.7",
-                "@esbuild/linux-s390x": "0.27.7",
-                "@esbuild/linux-x64": "0.27.7",
-                "@esbuild/netbsd-arm64": "0.27.7",
-                "@esbuild/netbsd-x64": "0.27.7",
-                "@esbuild/openbsd-arm64": "0.27.7",
-                "@esbuild/openbsd-x64": "0.27.7",
-                "@esbuild/openharmony-arm64": "0.27.7",
-                "@esbuild/sunos-x64": "0.27.7",
-                "@esbuild/win32-arm64": "0.27.7",
-                "@esbuild/win32-ia32": "0.27.7",
-                "@esbuild/win32-x64": "0.27.7"
             }
         },
         "node_modules/xdg-basedir": {
@@ -11586,6 +11549,19 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/yauzl": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.4.0.tgz",
+            "integrity": "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "pend": "~1.2.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/yocto-queue": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -11682,7 +11658,8 @@
                 "tailwind-merge": "^3.6.0",
                 "tailwindcss": "^4.3.2",
                 "tw-animate-css": "^1.4.0",
-                "wxt": "^0.20.27"
+                "web-ext": "^10.6.0",
+                "wxt": "^0.21.4"
             },
             "peerDependencies": {
                 "zod": "^3.25.0 || ^4.0.0"

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -36,7 +36,8 @@
         "tailwind-merge": "^3.6.0",
         "tailwindcss": "^4.3.2",
         "tw-animate-css": "^1.4.0",
-        "wxt": "^0.20.27"
+        "web-ext": "^10.6.0",
+        "wxt": "^0.21.4"
     },
     "dependencies": {
         "@page-agent/core": "1.12.2",

--- a/packages/extension/tsconfig.json
+++ b/packages/extension/tsconfig.json
@@ -4,6 +4,11 @@
         "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.tsbuildinfo",
         "useDefineForClassFields": true,
         "strictNullChecks": true,
+
+        "verbatimModuleSyntax": false,
+        "noUncheckedIndexedAccess": false,
+        "noImplicitOverride": false,
+
         "jsx": "react-jsx",
         "types": ["node", "chrome"],
         "paths": {


### PR DESCRIPTION
## What

Upgrade the extension's WXT from 0.20 to 0.21, add `web-ext` as a direct dependency, and keep the current TypeScript flags against the stricter generated tsconfig.

## Type

- [ ] Breaking change
- [ ] Bug fix
- [ ] Feature / Improvement
- [x] Refactor / Chores
- [ ] Documentation / Website / Demo / Testing

## Testing

- [x] `npm run ci` passes
- [x] Tested in modern browsers
- [ ] Types/doc added

## Requirements / 要求

- [x] I have read and follow the [Code of Conduct](../docs/CODE_OF_CONDUCT.md) and [Contributing Guide](../CONTRIBUTING.md) . / 我已阅读并遵守行为准则。
- [x] This PR is NOT generated by a bot or AI agent acting autonomously. I have authored or meaningfully reviewed every change. / 此 PR 不是由 bot 或 AI 自主生成的，我已亲自编写或充分审查了每一处变更。