### PR TITLE
chore: add `agentic-testing`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,6 +128,7 @@ const pageInfo = await this.pageController.getPageInfo()
 
 ## Testing
 
+- **Test value**: Do not add redundant tests or directly translate implementation code into assertions. Test meaningful behavior and realistic failure modes.
 - **Framework**: Vitest (unit tests only for now; future E2E goes to `packages/e2e/` with Playwright)
 - **Location**: co-located, `src/foo.test.ts` next to `src/foo.ts`
 - **Coverage today**: `packages/llms` only — other packages will follow incrementally

--- a/docs/agentic-testing/README.md
+++ b/docs/agentic-testing/README.md
@@ -1,0 +1,15 @@
+# Agentic interaction testing
+
+Interactive browser test checklists for a harness with **computer use and vision**, such as Codex.
+
+## Checklists
+
+- [Actions](actions.md): action functions on real pages and component demos.
+
+## Execution
+
+Use computer use for setup and vision to verify the resulting UI. Execute tested interactions through the code specified in each checklist.
+
+## Results
+
+Report revision (+ local changes), browser, case ID, target, status (`PASS` / `FAIL` / `BLOCKED` / `NOT RUN`), and evidence. Compare failures with the previous revision.

--- a/docs/agentic-testing/actions.md
+++ b/docs/agentic-testing/actions.md
@@ -4,7 +4,7 @@
 
 1. Build: `npm run build -w @page-agent/page-controller`.
 2. Load `packages/page-controller/dist/lib/page-controller.js` in the page via `import()` (URL or Blob).
-3. Call exported actions directly on DOM elements; do not instantiate `PageController` or modify the bundle.
+3. Call exported actions directly on DOM elements, never native input; do not instantiate `PageController` or modify the bundle.
 
 ## Cases
 

--- a/docs/agentic-testing/actions.md
+++ b/docs/agentic-testing/actions.md
@@ -1,0 +1,30 @@
+# Action regression checklist
+
+## Setup
+
+1. Build: `npm run build -w @page-agent/page-controller`.
+2. Load `packages/page-controller/dist/lib/page-controller.js` in the page via `import()` (URL or Blob).
+3. Call exported actions directly on DOM elements; do not instantiate `PageController` or modify the bundle.
+
+## Cases
+
+| ID           | Page / demo                                                                                               | Actions                                     | Expected                                              |
+| ------------ | --------------------------------------------------------------------------------------------------------- | ------------------------------------------- | ----------------------------------------------------- |
+| bing-suggest | [Bing](https://bing.com/)                                                                                 | Input `weather tomorrow`.                   | Suggestions appear; input retains focus.              |
+| bing-submit  | [Bing](https://bing.com/)                                                                                 | Input `weather tomorrow`; click search.     | Results page with the same query.                     |
+| antd-select  | [AntD Select](https://ant.design/components/select/) — searchable                                         | Filter, select, reopen.                     | Matching option selected; value retained.             |
+| el-select    | [Element Plus Select](https://element-plus.org/en-US/component/select.html) — clearable / disabled        | Select, clear, reselect.                    | Value updates; disabled options remain unavailable.   |
+| el-menu      | [Element Plus Menu](https://element-plus.org/en-US/component/menu.html) — Side bar                        | Click title/icon, select child, collapse.   | Submenu toggles once; child independently selectable. |
+| antd-tree    | [AntD Tree](https://ant.design/components/tree/) — Basic                                                  | Expand, select, check child.                | Corresponding states update.                          |
+| el-date      | [Element Plus DatePicker](https://element-plus.org/en-US/component/date-picker.html) — Date Range         | Pick range, reopen, clear.                  | Dates persist; clear removes both.                    |
+| quill        | [Quill](https://quilljs.com/docs/quickstart)                                                              | Replace, clear, retype, blur, edit again.   | No duplication or old content returning.              |
+| el-scroll    | [Element Plus Scrollbar](https://element-plus.org/en-US/component/scrollbar.html) — vertical / horizontal | Scroll target container in both directions. | Correct region and direction.                         |
+| mui-input    | [MUI Autocomplete](https://mui.com/material-ui/react-autocomplete/) — Controlled states                   | Type, select, clear.                        | Displayed inputValue/value stay consistent.           |
+| radix-select | [Radix Select](https://www.radix-ui.com/primitives/docs/components/select)                                | Select, reopen, select another.             | Value updates; focus returns to trigger.              |
+
+## References
+
+- el-menu: [PR #378](https://github.com/alibaba/page-agent/pull/378)
+- el-date: [Issue #336](https://github.com/alibaba/page-agent/issues/336)
+- quill: [PR #179](https://github.com/alibaba/page-agent/pull/179)
+- el-scroll: [PR #390](https://github.com/alibaba/page-agent/pull/390)


### PR DESCRIPTION
## What

Add `docs/agentic-testing/`: browser regression checklists for a computer-use harness to run PageController actions against real pages and component demos. Also add a "test value" guideline to `AGENTS.md`.

## Type

- [ ] Breaking change
- [ ] Bug fix
- [ ] Feature / Improvement
- [ ] Refactor / Chores
- [x] Documentation / Website / Demo / Testing

## Testing

- [x] `npm run ci` passes
- [ ] Tested in modern browsers
- [ ] Types/doc added

## Requirements / 要求

- [x] I have read and follow the [Code of Conduct](../docs/CODE_OF_CONDUCT.md) and [Contributing Guide](../CONTRIBUTING.md) . / 我已阅读并遵守行为准则。
- [x] This PR is NOT generated by a bot or AI agent acting autonomously. I have authored or meaningfully reviewed every change. / 此 PR 不是由 bot 或 AI 自主生成的，我已亲自编写或充分审查了每一处变更。
