### PR TITLE
fix(deps): resolve critical/high npm audit advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -97,6 +97,22 @@
                 "node": ">=8"
             }
         },
+        "node_modules/@aklinker1/rollup-plugin-visualizer/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
         "node_modules/@aklinker1/rollup-plugin-visualizer/node_modules/cliui": {
             "version": "8.0.1",
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -122,34 +138,12 @@
                 "node": ">=8"
             }
         },
-        "node_modules/@aklinker1/rollup-plugin-visualizer/node_modules/is-docker": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-            "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+        "node_modules/@aklinker1/rollup-plugin-visualizer/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
             "dev": true,
-            "license": "MIT",
-            "bin": {
-                "is-docker": "cli.js"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@aklinker1/rollup-plugin-visualizer/node_modules/is-wsl": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-            "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-docker": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
+            "license": "MIT"
         },
         "node_modules/@aklinker1/rollup-plugin-visualizer/node_modules/open": {
             "version": "8.4.2",
@@ -192,6 +186,21 @@
                 "node": ">= 12"
             }
         },
+        "node_modules/@aklinker1/rollup-plugin-visualizer/node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/@aklinker1/rollup-plugin-visualizer/node_modules/strip-ansi": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -205,10 +214,28 @@
                 "node": ">=8"
             }
         },
+        "node_modules/@aklinker1/rollup-plugin-visualizer/node_modules/wrap-ansi": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
         "node_modules/@aklinker1/rollup-plugin-visualizer/node_modules/yargs": {
-            "version": "17.7.2",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-            "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+            "version": "17.7.3",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+            "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -257,14 +284,14 @@
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.29.7",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
-            "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+            "version": "7.29.8",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+            "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/parser": "^7.29.7",
-                "@babel/types": "^7.29.7",
+                "@babel/parser": "^7.29.8",
+                "@babel/types": "^7.29.8",
                 "@jridgewell/gen-mapping": "^0.3.12",
                 "@jridgewell/trace-mapping": "^0.3.28",
                 "jsesc": "^3.0.2"
@@ -304,13 +331,13 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.29.7",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
-            "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+            "version": "7.29.8",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+            "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.29.7"
+                "@babel/types": "^7.29.8"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -342,18 +369,18 @@
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.29.7",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
-            "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+            "version": "7.29.8",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+            "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/code-frame": "^7.29.7",
-                "@babel/generator": "^7.29.7",
+                "@babel/generator": "^7.29.8",
                 "@babel/helper-globals": "^7.29.7",
-                "@babel/parser": "^7.29.7",
+                "@babel/parser": "^7.29.8",
                 "@babel/template": "^7.29.7",
-                "@babel/types": "^7.29.7",
+                "@babel/types": "^7.29.8",
                 "debug": "^4.3.1"
             },
             "engines": {
@@ -361,9 +388,9 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.29.7",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
-            "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+            "version": "7.29.8",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+            "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -372,6 +399,30 @@
             },
             "engines": {
                 "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@cacheable/memory": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.2.0.tgz",
+            "integrity": "sha512-CTLKqLItRCEixEAewD3/j9DB3/o96gpTPD4eJ1v+DGOlxZRZncRQkGYqqnAGCscYd6RNeXfGeiuCphsPtqyIfQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@cacheable/utils": "^2.5.0",
+                "@keyv/bigmap": "^1.3.1",
+                "hookified": "^1.15.1",
+                "keyv": "^5.6.0"
+            }
+        },
+        "node_modules/@cacheable/utils": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.5.0.tgz",
+            "integrity": "sha512-buipgOVDkkPXNR5+xBpDw7Zk2n1EvU7qBJCNUcL7rhQ//kfpOXPAvQ511Os0vpLYJ1pZnvudNytkQt2hst3wqA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "hashery": "^1.5.1",
+                "keyv": "^5.6.0"
             }
         },
         "node_modules/@commitlint/cli": {
@@ -626,9 +677,9 @@
             }
         },
         "node_modules/@conventional-changelog/git-client": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@conventional-changelog/git-client/-/git-client-3.1.0.tgz",
-            "integrity": "sha512-Tqa/gHco2WJWa740NRjOrfKVvzIqxkZpecb8bemaQ8sKM5PXb1UK4uTyTb/1wIqNuOVaDOFxyBdhTIQZn6gdjQ==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@conventional-changelog/git-client/-/git-client-3.1.2.tgz",
+            "integrity": "sha512-jZqwnJwf7nboIlAcw/mkOjVa6DexCcUOgT2oOQgkoi3z9vR8tGFkcMy2BFcYwjhL9sYcDDXkRQDayiDieCoW7A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -641,7 +692,7 @@
             },
             "peerDependencies": {
                 "conventional-commits-filter": "^6.0.1",
-                "conventional-commits-parser": "^7.0.1"
+                "conventional-commits-parser": "^7.1.2"
             },
             "peerDependenciesMeta": {
                 "conventional-commits-filter": {
@@ -723,9 +774,9 @@
             }
         },
         "node_modules/@eslint-community/eslint-utils": {
-            "version": "4.9.1",
-            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
-            "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+            "version": "4.10.1",
+            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+            "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -752,9 +803,9 @@
             }
         },
         "node_modules/@eslint-react/ast": {
-            "version": "5.18.7",
-            "resolved": "https://registry.npmjs.org/@eslint-react/ast/-/ast-5.18.7.tgz",
-            "integrity": "sha512-Nh7g4EXD1N4gkyX8h4c9BYZjxSZXXX+dv+hnmmGTeTrLrJiEVXYRWHeKAUXw8t6Bslr2Vcc/7Ane2ljnbPkdpw==",
+            "version": "5.19.0",
+            "resolved": "https://registry.npmjs.org/@eslint-react/ast/-/ast-5.19.0.tgz",
+            "integrity": "sha512-6d9UY/CVz+zGMi6+aext7HSOVAj2Fa9eL7okBRnjBeMrRhmRAqtbm1oK7J+VlWrmUNLsiNXpyklhq36BsmYddg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -772,16 +823,16 @@
             }
         },
         "node_modules/@eslint-react/core": {
-            "version": "5.18.7",
-            "resolved": "https://registry.npmjs.org/@eslint-react/core/-/core-5.18.7.tgz",
-            "integrity": "sha512-e/5QiwAmRGSxGnxIoG9zuu1jaOcSpAfEwkIysS1NDcSz3+o1BvhEGvJDR/yt/XzuFEJvNtqUxu59KLXt0XAgQQ==",
+            "version": "5.19.0",
+            "resolved": "https://registry.npmjs.org/@eslint-react/core/-/core-5.19.0.tgz",
+            "integrity": "sha512-PFhetWfvG6ZhLiJomkzjKKCLu6DVbKdyeYZ7HE7/rvAvmfsNi9iCGBqxkgXWfWpWEf24KrRUVpS3wLGJpPL8+g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@eslint-react/ast": "5.18.7",
-                "@eslint-react/eslint": "5.18.7",
-                "@eslint-react/shared": "5.18.7",
-                "@eslint-react/var": "5.18.7",
+                "@eslint-react/ast": "5.19.0",
+                "@eslint-react/eslint": "5.19.0",
+                "@eslint-react/shared": "5.19.0",
+                "@eslint-react/var": "5.19.0",
                 "@typescript-eslint/scope-manager": "^8.69.0",
                 "@typescript-eslint/types": "^8.69.0",
                 "@typescript-eslint/utils": "^8.69.0",
@@ -796,9 +847,9 @@
             }
         },
         "node_modules/@eslint-react/eslint": {
-            "version": "5.18.7",
-            "resolved": "https://registry.npmjs.org/@eslint-react/eslint/-/eslint-5.18.7.tgz",
-            "integrity": "sha512-84wrJbYN+d6LgUk7zbfVIGUFjvChFZxiDrCRHcUbUOeFBe1qTMbT14tv/ERIsBtJcJK1WehMrYREMYD9GRqmpw==",
+            "version": "5.19.0",
+            "resolved": "https://registry.npmjs.org/@eslint-react/eslint/-/eslint-5.19.0.tgz",
+            "integrity": "sha512-wod1Yd/atJbUD36naGirzztZ9w4BAWSxwIxF8/6qT7PaN/Q9r/vTB/T5rmmgvMa3C/hp0yI3uqr4zbO2mRPBOQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -813,19 +864,19 @@
             }
         },
         "node_modules/@eslint-react/eslint-plugin": {
-            "version": "5.18.7",
-            "resolved": "https://registry.npmjs.org/@eslint-react/eslint-plugin/-/eslint-plugin-5.18.7.tgz",
-            "integrity": "sha512-eQx3sI/mT3yppF3zjnUtU2lXPVbpvN/l42lErw4r5/qVqShvDL0MsF7dHv7+TmJmsHJ8m6nPc8boIp0SNDsE6Q==",
+            "version": "5.19.0",
+            "resolved": "https://registry.npmjs.org/@eslint-react/eslint-plugin/-/eslint-plugin-5.19.0.tgz",
+            "integrity": "sha512-SA3+Iz87sH3pq8hFHb+QhYrOpOyzut+k9YCx2WCJsapK3fu7odk73GRXB6J/W5f8tz0J0ARj1r+DsaSdGtF/zw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@eslint-react/shared": "5.18.7",
-                "eslint-plugin-react-dom": "5.18.7",
-                "eslint-plugin-react-jsx": "5.18.7",
-                "eslint-plugin-react-naming-convention": "5.18.7",
-                "eslint-plugin-react-rsc": "5.18.7",
-                "eslint-plugin-react-web-api": "5.18.7",
-                "eslint-plugin-react-x": "5.18.7"
+                "@eslint-react/shared": "5.19.0",
+                "eslint-plugin-react-dom": "5.19.0",
+                "eslint-plugin-react-jsx": "5.19.0",
+                "eslint-plugin-react-naming-convention": "5.19.0",
+                "eslint-plugin-react-rsc": "5.19.0",
+                "eslint-plugin-react-web-api": "5.19.0",
+                "eslint-plugin-react-x": "5.19.0"
             },
             "engines": {
                 "node": ">=22.0.0"
@@ -836,16 +887,16 @@
             }
         },
         "node_modules/@eslint-react/jsx": {
-            "version": "5.18.7",
-            "resolved": "https://registry.npmjs.org/@eslint-react/jsx/-/jsx-5.18.7.tgz",
-            "integrity": "sha512-gUrnempknop6lGx8ufz3dbq8r208pdMddLdsWi1N7FnfYHFBgJJdiOQ8hC7apIgOfxrsYq1J3l9y4U0t88hBpg==",
+            "version": "5.19.0",
+            "resolved": "https://registry.npmjs.org/@eslint-react/jsx/-/jsx-5.19.0.tgz",
+            "integrity": "sha512-iqauNb+qeNaEbG7VfDj+8taRLJFbEkptzdPx+YnIbyxhCVAnMaB3s/yeVyi4nszja7YwE/FccFInPZ4Qv8fVZw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@eslint-react/ast": "5.18.7",
-                "@eslint-react/eslint": "5.18.7",
-                "@eslint-react/shared": "5.18.7",
-                "@eslint-react/var": "5.18.7",
+                "@eslint-react/ast": "5.19.0",
+                "@eslint-react/eslint": "5.19.0",
+                "@eslint-react/shared": "5.19.0",
+                "@eslint-react/var": "5.19.0",
                 "@typescript-eslint/types": "^8.69.0",
                 "@typescript-eslint/utils": "^8.69.0",
                 "ts-pattern": "^5.9.0"
@@ -859,13 +910,13 @@
             }
         },
         "node_modules/@eslint-react/shared": {
-            "version": "5.18.7",
-            "resolved": "https://registry.npmjs.org/@eslint-react/shared/-/shared-5.18.7.tgz",
-            "integrity": "sha512-pratz9V1ScUNRthqFzRYGjDaUT5M6Lzf5kjbpo8u3tvV+1IpXwRxCbJOTZ3mc7AcsTG0lT/vWn/eK+bO9pM+Vg==",
+            "version": "5.19.0",
+            "resolved": "https://registry.npmjs.org/@eslint-react/shared/-/shared-5.19.0.tgz",
+            "integrity": "sha512-4x56YzT3Gph725Z8x1vMbOYUkOpbqp2v9NuFb9F7GqVmyZq9OxAQPEj5b7o+Fd2C1VIC3mHNCfL3FHVZ1YH8mA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@eslint-react/eslint": "5.18.7",
+                "@eslint-react/eslint": "5.19.0",
                 "@typescript-eslint/utils": "^8.69.0",
                 "ts-pattern": "^5.9.0",
                 "zod": "^3.25.0 || ^4.0.0"
@@ -879,14 +930,14 @@
             }
         },
         "node_modules/@eslint-react/var": {
-            "version": "5.18.7",
-            "resolved": "https://registry.npmjs.org/@eslint-react/var/-/var-5.18.7.tgz",
-            "integrity": "sha512-apOepZR4QO92j16CD3L/3467eiq4gcOtq/DILm8cNUkFeuKkhU9DuMeYJisjVFYMUgapfpq8lk1ustljyhvBgA==",
+            "version": "5.19.0",
+            "resolved": "https://registry.npmjs.org/@eslint-react/var/-/var-5.19.0.tgz",
+            "integrity": "sha512-dRRM/AYqQli1VNijY7n0+q4zUlNCGiOY1wGr1r+c5ajvlv/XwGibhTJjY6zGZWIjL9TUMIbIEH8aOdRaw2iNQg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@eslint-react/ast": "5.18.7",
-                "@eslint-react/eslint": "5.18.7",
+                "@eslint-react/ast": "5.19.0",
+                "@eslint-react/eslint": "5.19.0",
                 "@typescript-eslint/scope-manager": "^8.69.0",
                 "@typescript-eslint/types": "^8.69.0",
                 "@typescript-eslint/utils": "^8.69.0",
@@ -916,13 +967,13 @@
             }
         },
         "node_modules/@eslint/config-array/node_modules/minimatch": {
-            "version": "10.2.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-            "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+            "version": "10.2.6",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+            "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
-                "brace-expansion": "^5.0.5"
+                "brace-expansion": "^5.0.8"
             },
             "engines": {
                 "node": "18 || 20 || >=22"
@@ -1125,9 +1176,9 @@
             }
         },
         "node_modules/@eslint/plugin-kit": {
-            "version": "0.7.2",
-            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
-            "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
+            "version": "0.7.3",
+            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.3.tgz",
+            "integrity": "sha512-IkO+/KEUvwbVpiURZg+P7zF74z5Jxe0UgJxVni+RtoHQ6IZieXaO02kmadomap/q+l6bc/jdPGGqTjhuZnuz1Q==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -1202,9 +1253,9 @@
             }
         },
         "node_modules/@hono/node-server": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.0.tgz",
-            "integrity": "sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.1.tgz",
+            "integrity": "sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==",
             "license": "MIT",
             "engines": {
                 "node": ">=20"
@@ -1312,9 +1363,9 @@
             }
         },
         "node_modules/@jridgewell/sourcemap-codec": {
-            "version": "1.5.5",
-            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
-            "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+            "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
             "dev": true,
             "license": "MIT"
         },
@@ -1329,6 +1380,30 @@
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
         },
+        "node_modules/@keyv/bigmap": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.3.1.tgz",
+            "integrity": "sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "hashery": "^1.4.0",
+                "hookified": "^1.15.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "peerDependencies": {
+                "keyv": "^5.6.0"
+            }
+        },
+        "node_modules/@keyv/serialize": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
+            "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@mdn/browser-compat-data": {
             "version": "8.0.8",
             "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-8.0.8.tgz",
@@ -1337,19 +1412,19 @@
             "license": "CC0-1.0"
         },
         "node_modules/@microsoft/api-extractor": {
-            "version": "7.59.0",
-            "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.59.0.tgz",
-            "integrity": "sha512-KDYV8kSVjmG8JJWVg1f1aKxteNG1IQ44D07Rjhlcci8wlqrSFNhUfgv7dJhwT0W2h3NDIL5Vz2f+/DfO4OpDHw==",
+            "version": "7.59.1",
+            "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.59.1.tgz",
+            "integrity": "sha512-GjRUqx1MTY7xuH36urwASkfBPzrdxYG+irVeV7C9JEdRtn509AgMmwit/BhvztQzIoFk9vhFDTVYOp2cjw+9Uw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@microsoft/api-extractor-model": "7.33.11",
+                "@microsoft/api-extractor-model": "7.33.12",
                 "@microsoft/tsdoc": "~0.16.0",
                 "@microsoft/tsdoc-config": "~0.18.1",
-                "@rushstack/node-core-library": "5.24.0",
+                "@rushstack/node-core-library": "5.24.1",
                 "@rushstack/rig-package": "0.7.3",
-                "@rushstack/terminal": "0.24.3",
-                "@rushstack/ts-command-line": "5.3.13",
+                "@rushstack/terminal": "0.24.4",
+                "@rushstack/ts-command-line": "5.3.14",
                 "diff": "~8.0.2",
                 "minimatch": "10.2.3",
                 "resolve": "~1.22.1",
@@ -1365,15 +1440,15 @@
             }
         },
         "node_modules/@microsoft/api-extractor-model": {
-            "version": "7.33.11",
-            "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.33.11.tgz",
-            "integrity": "sha512-iDu1AtuRC2Z8XVs2SieZieVavF1FXPBX1C9pMexJh8Dx/Dd/3ZZ4nRQp/PU2Vk2rUHWuBz1wOyL4DcuhVnBXwg==",
+            "version": "7.33.12",
+            "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.33.12.tgz",
+            "integrity": "sha512-TdKOYgwf98xLjNW+y3iXIiCf4ZLQbilGAlqkMTTAqqAWfgRXAn9YCSGMsaiB1U7OPRvslUWg6n08EqQPbP93tA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@microsoft/tsdoc": "~0.16.0",
                 "@microsoft/tsdoc-config": "~0.18.1",
-                "@rushstack/node-core-library": "5.24.0"
+                "@rushstack/node-core-library": "5.24.1"
             },
             "engines": {
                 "node": ">=20.9.0"
@@ -1470,9 +1545,9 @@
             }
         },
         "node_modules/@oxc-project/types": {
-            "version": "0.148.0",
-            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.148.0.tgz",
-            "integrity": "sha512-Nm4s/jB+4FpFsPhWGEC4h7rzksesmtnMXomo6rCMcg/b8zLQuOziRgkCS1fxDCXOlJB/6Q8oABOZ/OP6RIPj9A==",
+            "version": "0.149.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.149.0.tgz",
+            "integrity": "sha512-Efcc+iF0j3Bf67YjEqIqWXbX5XddXoK/Mw4K1/JuXwRCZ8N16VR7iT23nlCc9XrveFVh/E5Rqs2StT0V8v9LdA==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -1545,9 +1620,9 @@
             "license": "ISC"
         },
         "node_modules/@pnpm/npm-conf": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-3.0.2.tgz",
-            "integrity": "sha512-h104Kh26rR8tm+a3Qkc5S4VLYint3FE48as7+/5oCEcKR2idC/pF1G6AhIXKI+eHPJa/3J9i5z0Al47IeGHPkA==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-3.0.3.tgz",
+            "integrity": "sha512-//0sR/cow/s4ICQaYoAobOl4aU8cjU6x/V24V7XkKotb9+O+3zySIYp146vpaobYHnxa4pZX8NkV54Z5AwbDKA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2091,9 +2166,9 @@
             "license": "MIT"
         },
         "node_modules/@rolldown/binding-android-arm-eabi": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm-eabi/-/binding-android-arm-eabi-1.2.7.tgz",
-            "integrity": "sha512-EypzgnYCwyVY4NDHKzGmNJT5b+XaQEBniHxsMdeIQLB/tcCzZnhqrzHpZFbX9iaxx+5RiB8caATBtfvZP7zVxQ==",
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm-eabi/-/binding-android-arm-eabi-1.2.8.tgz",
+            "integrity": "sha512-tN5aztYkKCte4i5SIrrz5yK/HMjEuCqCSCJa418jOV8tZ1cBY3YF2otxB1ktPxzsLA1BeTqwapK0bfjxNvHJVw==",
             "cpu": [
                 "arm"
             ],
@@ -2108,9 +2183,9 @@
             }
         },
         "node_modules/@rolldown/binding-android-arm64": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.7.tgz",
-            "integrity": "sha512-l17HE9EweWaqJZhuUuNBN/FzM62xw+DECVnJyvMsxn8vJFAGLy5QfLDoYAcronkAN8VxKZHezDpulHDPx95vFw==",
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.8.tgz",
+            "integrity": "sha512-dIYTWl9XprMUiQFoc55KUyk/oS8SKYH3zFl0LTR7RT0Xj4hgSVyuJcroH8JUu8RcpF8fTB6E0aOwCkZoYPcDSQ==",
             "cpu": [
                 "arm64"
             ],
@@ -2125,9 +2200,9 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-arm64": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.7.tgz",
-            "integrity": "sha512-8ED8ELFvHXc6OCETIn4gXObPiaR6bckM/ipXtbzlPVDRMBfEGjCKgO90F9YtfdpDatVx/ZQw7aZ1vUMf/+T3Mw==",
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.8.tgz",
+            "integrity": "sha512-PCSDQGXD2IyTEFrcgPyBM8jJuGmrbCMuoIOXdbEGVemruKACXoLQJrb+A45Z0L5t1RQkdfJprAYPkikbh7dzdA==",
             "cpu": [
                 "arm64"
             ],
@@ -2142,9 +2217,9 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-x64": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.7.tgz",
-            "integrity": "sha512-/WPripjtiAIZ2tWY7ddijORT0Ujg87wxWW/qcoFVCKAWVDPhtY0xr7Dj0M3GyNGz60jGwTElhro/mkF9dT7dDQ==",
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.8.tgz",
+            "integrity": "sha512-Uk7lRsGhPFHVX/sAUC6D5H9Ol30dFHd6iquokll2th3LpdJ3F5CzQB+7DHn0Ri2mG+U7k2zXiPHDrwZenXhwSA==",
             "cpu": [
                 "x64"
             ],
@@ -2159,9 +2234,9 @@
             }
         },
         "node_modules/@rolldown/binding-freebsd-x64": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.7.tgz",
-            "integrity": "sha512-14DI4NcqpvbICxSnGLx3PmtDaWqRP/KGSGb6C+JLLVPeZRl6dKdHba3pGsqT3vpdTqhEYIPG0MMQ8c0xYqoJxA==",
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.8.tgz",
+            "integrity": "sha512-DjszaTEVogPqA5bYzsEeqDCQxbcp2fexQwKcRspYji2yzR68fCf+e4fx6kBSRDwX5/brZaHw/hWS9+A/+/w9sQ==",
             "cpu": [
                 "x64"
             ],
@@ -2176,9 +2251,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.7.tgz",
-            "integrity": "sha512-bxrWIRvHWQvbJwi+VIie/kDJmQxcNE6xxWwZdqF/ExVAigtHkv54WTLQPb+QsZdnFy18fg7JPfWGL0RH6vwIlQ==",
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.8.tgz",
+            "integrity": "sha512-zmwa7FTmdzB6aaEEuuls18H6Ap5JmJPSoPTuXixeJZV6tG40SyLkApQtz1g8ptZtiEKqj9OM0oNLPh1AgvE31Q==",
             "cpu": [
                 "arm"
             ],
@@ -2193,13 +2268,16 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-gnu": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.7.tgz",
-            "integrity": "sha512-toOY2BChBZyuxU7OYX6Tn389di4IzAqPTycVcci0O7FSfBqzRB3RZn+K5Is6ANf4tmgRd/K1yZTsNTXbkXsnLg==",
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.8.tgz",
+            "integrity": "sha512-KdYQDPHwJVnbFwdTGMgxsI9SqblBlz6STGM+w1We/d5B8OWWidYH0MwkU/uA1wM5fIpO2MkOVxXrNzzuZhw9ew==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2210,13 +2288,16 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-musl": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.7.tgz",
-            "integrity": "sha512-lAIXTH/aiLRLxsTgQvfhjo4K1ydWIp00+V0voOr9beb/9ZmkUFrSIb03dXNFRgMNvkE6oGsF10ioQ6UsI+vS5Q==",
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.8.tgz",
+            "integrity": "sha512-jFJTifHnNPY+yzOoNZQfSIysrVyXzEQPhPnOUjmD1bcQGHH6s7c8cViKWar8YplQImE5N9JRqMCLrM2CdxOrZA==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2227,13 +2308,16 @@
             }
         },
         "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.7.tgz",
-            "integrity": "sha512-kdnwS28Pkenp/mZMRwjXXXwxQ7pIsm+bF919LUK93BOyhcLsrVKdP2p9fxpiPNPAbNuch8ypQt0pm2P2LYCAGg==",
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.8.tgz",
+            "integrity": "sha512-FhiOziBDWPBjbcmRzfLyIJnaP7AVMFXT7YCXPjXxj7wKU3vx24RjrCNN/zjvVa+N2vVoHJwCoUBvsrN/DG3zIA==",
             "cpu": [
                 "ppc64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2244,13 +2328,16 @@
             }
         },
         "node_modules/@rolldown/binding-linux-s390x-gnu": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.7.tgz",
-            "integrity": "sha512-516OdsyLdr5E65paF3yBF55t8mfm9+gmtCsK3xI7XKXIT7EfRlHhxL8K/NR6Hu8BWSgF5+1w74lTL0+nxcc8Qw==",
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.8.tgz",
+            "integrity": "sha512-WnHfADMzOV2Y55wlx1hzzQnar/wDt/VdvWSD99r18Mz9ylNieIGOkRx3UV21h7m/eJvjySYJkO26VvGNFkwsIQ==",
             "cpu": [
                 "s390x"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2261,13 +2348,16 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-gnu": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.7.tgz",
-            "integrity": "sha512-r8/z8n7GFaYRln3xmP1Cxy0HH/HLM0uBUPkEuSVEfKGDA89M0FsZRZJRSwe/tJjRx+fpH/gjorfhB8tmEbSFLA==",
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.8.tgz",
+            "integrity": "sha512-H9tRr5ibfXFVLxbPOseVewewFpl28zcEdjRDt2FTUZU7odxP0gEv1ki4/kGmcGOh78oRwZuuQllGLZ9zTJp84g==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2278,13 +2368,16 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-musl": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.7.tgz",
-            "integrity": "sha512-pAsE8iiDxUg1xBqdhrTfg45AVDVpirjz00sblEYClGNNcMnDb+e8beQgqIAw6LvauX/APvgxUnwrgun/YYGBhw==",
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.8.tgz",
+            "integrity": "sha512-UefiqfM3D6IVNlZ8tSGs9+Ejjud2T+oxO0IHADU45Y+lyEjD2dVFyZHbkfX0LUb5Zugo/oIv1eCO/KVYhgYJYA==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2295,9 +2388,9 @@
             }
         },
         "node_modules/@rolldown/binding-openharmony-arm64": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.7.tgz",
-            "integrity": "sha512-lTcIYmmnQQA8Or/2DatS6oSqcdLHvendjS+zLu+FwgToynWMRSmQdpM65fTANJgIS4mjbMOo5KT2lnT9SAb96w==",
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.8.tgz",
+            "integrity": "sha512-637Ke4kWSy6rp9cxQ9gMOXlxPgIw/c1beASV4M//3+9I4uwBVOOl74G+e3zyU3u19U7RkRl/HuewixZ/Z6+Rjg==",
             "cpu": [
                 "arm64"
             ],
@@ -2312,9 +2405,9 @@
             }
         },
         "node_modules/@rolldown/binding-win32-arm64-msvc": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.7.tgz",
-            "integrity": "sha512-e3Gu3WxbNk/UqQhxqU7YIYO+9ZBvWNz3U+h/qRFosscMFzdRPbXYSaSWgSnklv2fz1TgzBTcti2z35c/7irsHw==",
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.8.tgz",
+            "integrity": "sha512-xWBkPOF1Q9k/Gv1nQXnVdLxKu74jXppuOM4Z3mnypVUJJJwLsMl7hNJGRAUJoG8A5MgOI1ACKM+wBFxSJzKy4A==",
             "cpu": [
                 "arm64"
             ],
@@ -2329,9 +2422,9 @@
             }
         },
         "node_modules/@rolldown/binding-win32-x64-msvc": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.7.tgz",
-            "integrity": "sha512-W/jg5qoRSqjsEv0+dZi4e687mcHqmVuU0P4fK6qS/xjetW2Gmc1W8j//z5nAeNcC8Ttm0hV46IjcYeuVwYhuiw==",
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.8.tgz",
+            "integrity": "sha512-uz2ZvfgXbxqNwijjjbxrnvALwpyODDcgc1T1N8N3rf/DXKQmaFwmB4LX4yyjggpwN2obdQLb2rgirX5ffCWYng==",
             "cpu": [
                 "x64"
             ],
@@ -2376,9 +2469,9 @@
             }
         },
         "node_modules/@rushstack/node-core-library": {
-            "version": "5.24.0",
-            "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.24.0.tgz",
-            "integrity": "sha512-g/Z47ZwARn/VkTnHcyJslrR26erRf1G5JbqPlfGZGBCrOcrEt8fTQXXDVhUDDNl/g/v3TXI1dNiAAT5FEks8BA==",
+            "version": "5.24.1",
+            "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.24.1.tgz",
+            "integrity": "sha512-ZlOrzv92MwnsCXA45qWfDj4L/kTasKghXezu+M2WmdtkbnXyPnZSCovfeBZx1Yc5qm+LkElbLw6IeSSWZDhZUg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2443,13 +2536,13 @@
             }
         },
         "node_modules/@rushstack/terminal": {
-            "version": "0.24.3",
-            "resolved": "https://registry.npmjs.org/@rushstack/terminal/-/terminal-0.24.3.tgz",
-            "integrity": "sha512-KxphDhPGC4xDrKg8O4yrWCEpPMi87aJc1iycXqMVh1dLgV0M34hiH9ZTgWjBRmcrT/OIHoOeWf48npcQFzgp+g==",
+            "version": "0.24.4",
+            "resolved": "https://registry.npmjs.org/@rushstack/terminal/-/terminal-0.24.4.tgz",
+            "integrity": "sha512-3fRBWK0IMY293lBx5ycgit1DTMUi+nhOjALHlrIad9hQsqzM9Ak+XdBI1gJ/tZPxW+LraeAc4SsmMdcOflBmAQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@rushstack/node-core-library": "5.24.0",
+                "@rushstack/node-core-library": "5.24.1",
                 "@rushstack/problem-matcher": "0.2.1",
                 "supports-color": "~8.1.1"
             },
@@ -2466,13 +2559,13 @@
             }
         },
         "node_modules/@rushstack/ts-command-line": {
-            "version": "5.3.13",
-            "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-5.3.13.tgz",
-            "integrity": "sha512-+jNbxhh8CkrZYxMk9X3GRYM2+Myr1xCCj+eHbJ9Vp+PCdNHS0TUl5QQFT6UbM/aTFRCzs5jiBTKYzBRpe5uYbQ==",
+            "version": "5.3.14",
+            "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-5.3.14.tgz",
+            "integrity": "sha512-lT2JKZk2dukBMp4GFOh4RaDfVzpZehGgQOGpzpSliUn317NgEmOOCXyd7/d0eU46HHsbRxizP83GAm39s0lAlg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@rushstack/terminal": "0.24.3",
+                "@rushstack/terminal": "0.24.4",
                 "@types/argparse": "1.0.38",
                 "argparse": "~1.0.9",
                 "string-argv": "~0.3.1"
@@ -2650,6 +2743,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2667,6 +2763,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2684,6 +2783,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2701,6 +2803,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2739,72 +2844,6 @@
             "engines": {
                 "node": ">=14.0.0"
             }
-        },
-        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
-            "version": "1.11.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@emnapi/wasi-threads": "1.2.2",
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
-            "version": "1.11.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
-            "version": "1.2.2",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
-            "version": "1.1.4",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@tybys/wasm-util": "^0.10.1"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/Brooooooklyn"
-            },
-            "peerDependencies": {
-                "@emnapi/core": "^1.7.1",
-                "@emnapi/runtime": "^1.7.1"
-            }
-        },
-        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
-            "version": "0.10.2",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
-            "version": "2.8.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "0BSD",
-            "optional": true
         },
         "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
             "version": "4.3.3",
@@ -2958,9 +2997,9 @@
             }
         },
         "node_modules/@types/chrome": {
-            "version": "0.2.8",
-            "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.2.8.tgz",
-            "integrity": "sha512-dznDYMiJUyuc7b+78PxnWhaGOonmbX/OmcWu7NE42sg/yTLJMYnJ7Uah40SLPNFiCh8reqcthk7vOva2+MSvzw==",
+            "version": "0.2.9",
+            "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.2.9.tgz",
+            "integrity": "sha512-6rXrDPkkWv4D2Q23HqT+iED4voODU5CpOSc2VFgKyecSFItuEsIBvz9CY6jUQ3dd+Q7zo1bnCE9pKRMtkYut5g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3028,19 +3067,19 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "26.4.1",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.1.tgz",
-            "integrity": "sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA==",
+            "version": "26.5.1",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-26.5.1.tgz",
+            "integrity": "sha512-CzNm2FezW4VR/LjG6yUdiEgLE/rAQ9Slj5gCu/C2VrdcW7I0ahNZ8DRbHT7zOZ6r3ONgd/bsQIeSaoDGrd1C6g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "undici-types": "~8.3.0"
+                "undici-types": "~8.9.0"
             }
         },
         "node_modules/@types/react": {
-            "version": "19.2.18",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
-            "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
+            "version": "19.3.0",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-19.3.0.tgz",
+            "integrity": "sha512-N0rFCuH9YoxG9/m61l9MfpJKfmLOVU0em7ipIz6TRgSSkvReLB9vL85GB+yr8Bs5leqpvg96JSwF4ZS1s4viQg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3048,13 +3087,13 @@
             }
         },
         "node_modules/@types/react-dom": {
-            "version": "19.2.7",
-            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.7.tgz",
-            "integrity": "sha512-I8bPpDLcHBv1qiIiXDCy71Rt8eQDKJP0sMSWJphDdAcdqiJ1sGpZamavoEIRZmYzjia9LuEb2HlYdDpmoENpvQ==",
+            "version": "19.3.0",
+            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.3.0.tgz",
+            "integrity": "sha512-ZI7bU42mZXXKHn/qNLEw2IrbiINU7X5+vfgdixBHkCNpYWXjKgfQ/P+uyGb5CjOLB9UcnTeg3rylQtV2hym44Q==",
             "dev": true,
             "license": "MIT",
             "peerDependencies": {
-                "@types/react": "^19.2.0"
+                "@types/react": "^19.3.0"
             }
         },
         "node_modules/@types/whatwg-mimetype": {
@@ -3075,17 +3114,17 @@
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.69.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.69.0.tgz",
-            "integrity": "sha512-t5jQTKPIgVW1PE6dR6H6Qz5gm8zjMlX5/2gRaOGd9eO6V7J+tQc6iWKukEe7dY8u9HyYasQ0yfF0/FSSTEO2gA==",
+            "version": "8.70.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.70.0.tgz",
+            "integrity": "sha512-/v8HZt6RlyIZxB3ntehELOcUcfxKPVGWXnQdJuHRmzrqgF8nQypcC/oxGW+Ot4VGKDq81XugPKxx0n5PBtf9PA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.12.2",
-                "@typescript-eslint/scope-manager": "8.69.0",
-                "@typescript-eslint/type-utils": "8.69.0",
-                "@typescript-eslint/utils": "8.69.0",
-                "@typescript-eslint/visitor-keys": "8.69.0",
+                "@typescript-eslint/scope-manager": "8.70.0",
+                "@typescript-eslint/type-utils": "8.70.0",
+                "@typescript-eslint/utils": "8.70.0",
+                "@typescript-eslint/visitor-keys": "8.70.0",
                 "ignore": "^7.0.5",
                 "natural-compare": "^1.4.0",
                 "ts-api-utils": "^2.5.0"
@@ -3098,15 +3137,15 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "@typescript-eslint/parser": "^8.69.0",
+                "@typescript-eslint/parser": "^8.70.0",
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
                 "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
-            "version": "7.0.8",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.8.tgz",
-            "integrity": "sha512-YYNsSlXBjMk92SKnkwvB5LOVSa6OznlFUGcsvrFgNJbJCd0M1XKeFVRc8ZByeCqz32FivYNHJVooLmdqrmvp/Q==",
+            "version": "7.0.9",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.9.tgz",
+            "integrity": "sha512-brTTsvFRt5C1gGHtPst/281UjPD5t9fBqbgoMPlVWy11ZLTPfu7HxK4ZYqO9H7o/yC9rSTCI85EaQ4OoY12qYw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3114,16 +3153,16 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.69.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.69.0.tgz",
-            "integrity": "sha512-l4b0DhWioGg6Gt2ebGlvfkFMOjRsauxtsnDRwUSRX1qHq3HdTfQHV8wW9zEXeciai6HfeaKOedQn2Zoofx3WBw==",
+            "version": "8.70.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.70.0.tgz",
+            "integrity": "sha512-zYvrmj9Yxd63UGaXw+kdt6A0F0s0qveJyuatIM77bYC2DE4pgmg7a50u8LR7PRtXd0x+h+Tl3eXabGm06SWd3Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.69.0",
-                "@typescript-eslint/types": "8.69.0",
-                "@typescript-eslint/typescript-estree": "8.69.0",
-                "@typescript-eslint/visitor-keys": "8.69.0",
+                "@typescript-eslint/scope-manager": "8.70.0",
+                "@typescript-eslint/types": "8.70.0",
+                "@typescript-eslint/typescript-estree": "8.70.0",
+                "@typescript-eslint/visitor-keys": "8.70.0",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -3139,14 +3178,14 @@
             }
         },
         "node_modules/@typescript-eslint/project-service": {
-            "version": "8.69.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.69.0.tgz",
-            "integrity": "sha512-yi4obFrHMmnsesWehHbkg9zMA7Jt8cXT+mKM08G999pH1yT6nqgsHx7MYm0uY1wAj8CqiBXYRJ7WAT0QdQHQXg==",
+            "version": "8.70.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.70.0.tgz",
+            "integrity": "sha512-hFHbTNqhU9G+2eKFXCBVb1tjFT/LceiJ4+HfLO4pTpDI0KHi6iajpcFFkaSQ9gXmCh7n82A0PthaayEdN6mspQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.69.0",
-                "@typescript-eslint/types": "^8.69.0",
+                "@typescript-eslint/tsconfig-utils": "^8.70.0",
+                "@typescript-eslint/types": "^8.70.0",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -3161,14 +3200,14 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.69.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.69.0.tgz",
-            "integrity": "sha512-ewfspqWvSxKSOaplqAUNbaSFO0eB6w1EtQ+esfYFRm3614Ty4uNtExkcbgd6nWsXphbqKyf9ZYdbZdv2xEoWEQ==",
+            "version": "8.70.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.70.0.tgz",
+            "integrity": "sha512-8nP3Kwh5hlgZ4FicGvmznAmJe8UL4sdU8tLukrPaMuQmDuk4Y8xYfzu/aYZW4xT2JCgc7H/TpDI5cGlxcWJSqQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.69.0",
-                "@typescript-eslint/visitor-keys": "8.69.0"
+                "@typescript-eslint/types": "8.70.0",
+                "@typescript-eslint/visitor-keys": "8.70.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3179,9 +3218,9 @@
             }
         },
         "node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.69.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.69.0.tgz",
-            "integrity": "sha512-xNqK7YTDZsLniQMV/4rpFR8Z5JlqeRvVjuG1YgF/mdPVH84HSD19L8CczMA0qg2RfwEV231GHH3VnToJDo4MfQ==",
+            "version": "8.70.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.70.0.tgz",
+            "integrity": "sha512-adnkeeNq9Sq1sUf4+FRVc0KdgYghzsgFpZSQVZVvY0LCuUuN0FnQgyGzCJeC4fW1cdXseBAjU2EOqUIjbNcZUw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3196,15 +3235,15 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.69.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.69.0.tgz",
-            "integrity": "sha512-ZfoJAVg3JZndQEpEl9petVlxau3lRuElc4HRMuAlLCf8to04/iHz692RUSNmXKDjEuJmIL+KZ2/BsOcBc16dsA==",
+            "version": "8.70.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.70.0.tgz",
+            "integrity": "sha512-NUMKIhYVaVIVLnRL9CRt+VVcuLgSHUCpXn4/+K8wql+vdInUzvx8BjUO1oJ7cG9shjFJKtF8F8Hh2kCh3/KBVw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.69.0",
-                "@typescript-eslint/typescript-estree": "8.69.0",
-                "@typescript-eslint/utils": "8.69.0",
+                "@typescript-eslint/types": "8.70.0",
+                "@typescript-eslint/typescript-estree": "8.70.0",
+                "@typescript-eslint/utils": "8.70.0",
                 "debug": "^4.4.3",
                 "ts-api-utils": "^2.5.0"
             },
@@ -3221,9 +3260,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.69.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.69.0.tgz",
-            "integrity": "sha512-K3VrubUPhlo9VDBS6QdI8YB5j7ClpqLRdefcz6PFrhnwicehBweqQ9Evhl4l+FYz0HdDmMqIiSX0aldGRYtDCA==",
+            "version": "8.70.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.70.0.tgz",
+            "integrity": "sha512-asTOIYhDg4zdzOScCyaytrsV3cR6B4ecPQlXw/dJIm7J/MZTtCtfVII9JD8Geh4jTCrK/Xe6cg5UevoleMcoJQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3235,16 +3274,16 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.69.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.69.0.tgz",
-            "integrity": "sha512-AdFkgqck3Vudb/kWnxlyafU/4aBhHrbQ9locP2N4psXTy5mOBg0SHJumnLvx7r6g1gV4DKvUFwV2nJZBoqOD8w==",
+            "version": "8.70.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.70.0.tgz",
+            "integrity": "sha512-d9NmHMPEKQ7QCLLm1jI3zmoQBwT5KwFYjXBJ9ymZfKCUU+5rmTRykKAFvH5Qn/ZCds3CEAFS9OC9M/jkl0X2bA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/project-service": "8.69.0",
-                "@typescript-eslint/tsconfig-utils": "8.69.0",
-                "@typescript-eslint/types": "8.69.0",
-                "@typescript-eslint/visitor-keys": "8.69.0",
+                "@typescript-eslint/project-service": "8.70.0",
+                "@typescript-eslint/tsconfig-utils": "8.70.0",
+                "@typescript-eslint/types": "8.70.0",
+                "@typescript-eslint/visitor-keys": "8.70.0",
                 "debug": "^4.4.3",
                 "minimatch": "^10.2.2",
                 "semver": "^7.7.3",
@@ -3263,16 +3302,16 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.69.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.69.0.tgz",
-            "integrity": "sha512-tUbx60BBqQa31kXF5MCsOOLL5E/WzUuxIn7YpAvq+eaUlqvk8/NXnXMBNAdLCr0icjkzem7iUA5QqWHe/hJ1aw==",
+            "version": "8.70.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.70.0.tgz",
+            "integrity": "sha512-oZmtKJz/4fufZ2p3+Cn3ijEojcdfR+1zYDH2xKYrEly0dR/Q/1xUPRCOlKGxod78nWlU2UnDe09GZ3TaknBFGA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.9.1",
-                "@typescript-eslint/scope-manager": "8.69.0",
-                "@typescript-eslint/types": "8.69.0",
-                "@typescript-eslint/typescript-estree": "8.69.0"
+                "@typescript-eslint/scope-manager": "8.70.0",
+                "@typescript-eslint/types": "8.70.0",
+                "@typescript-eslint/typescript-estree": "8.70.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3287,13 +3326,13 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.69.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.69.0.tgz",
-            "integrity": "sha512-+rmdgPA+EXkNgKYvHvFfhrs35utXbwaC5PGpDquSXcoXQDKUA5UjV0LmTucG/4JXkM31BTu4TilHtrN8IVBe8w==",
+            "version": "8.70.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.70.0.tgz",
+            "integrity": "sha512-BoC8PiO4Hkdo0TVJh9Ntxr5MxPDI7/oFsrygN5ADelFSeXG/qgNuucIGA+L5Z6JpPTE/uRfcTWtscjbUaufepQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.69.0",
+                "@typescript-eslint/types": "8.70.0",
                 "eslint-visitor-keys": "^5.0.0"
             },
             "engines": {
@@ -3514,13 +3553,16 @@
             }
         },
         "node_modules/@webext-core/isolated-element": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/@webext-core/isolated-element/-/isolated-element-1.1.5.tgz",
-            "integrity": "sha512-4m6oP8Vzm/68YO1QmkUOZqqUcmyBtA53tji2g00/nYXE3E3IceYgeub7eIqvXDV2Z7xU6cm6qO1IMt4XFVwtvQ==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@webext-core/isolated-element/-/isolated-element-3.0.0.tgz",
+            "integrity": "sha512-PmSIBMSe+rFw6eXzpJoV+glc1HPO40clcT9FJ7rSfCQzNewK8/nQZoBYWen2cMqdXdBNM9to/IbNNu5mdQLaPg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "is-potential-custom-element-name": "^1.0.1"
+            },
+            "engines": {
+                "node": "*"
             }
         },
         "node_modules/@webext-core/match-patterns": {
@@ -3534,9 +3576,9 @@
             }
         },
         "node_modules/@wxt-dev/browser": {
-            "version": "0.1.42",
-            "resolved": "https://registry.npmjs.org/@wxt-dev/browser/-/browser-0.1.42.tgz",
-            "integrity": "sha512-BSb0H09i4+0WlqFnN7LnZW0M6uCPH9KndciGx7mwOFKRVjNCorqwPk3hiVB58yQ+cyJNpDvYWL6IoPBxvP8qEA==",
+            "version": "0.2.9",
+            "resolved": "https://registry.npmjs.org/@wxt-dev/browser/-/browser-0.2.9.tgz",
+            "integrity": "sha512-I//1sxt6sSd2Ouj48Q7NfXvGFEKbQAL0wf4I/7sxduMx6S0i5xhJqDUkPCCUj42QnnbTpzybI0TA6OIz9NfMgA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3562,15 +3604,14 @@
             }
         },
         "node_modules/@wxt-dev/storage": {
-            "version": "1.2.8",
-            "resolved": "https://registry.npmjs.org/@wxt-dev/storage/-/storage-1.2.8.tgz",
-            "integrity": "sha512-GWCFKgF5+d7eslOxUDFC70ypA9njupmJb1nQM8uZoX0J3sWT2BO5xJLzb1sYahWAfID9p2BMtnUBN1lkWxPsbQ==",
+            "version": "1.2.9",
+            "resolved": "https://registry.npmjs.org/@wxt-dev/storage/-/storage-1.2.9.tgz",
+            "integrity": "sha512-dh9TJwvLBM2x4wyy9nE7eYE3wA8pgz1TXSyz7RbdjkJxLfFfWkbeIqiU7VkGy7Vx8sJBmQjoSpk9zSUb3Bjy0Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@wxt-dev/browser": "^0.1.37",
-                "async-mutex": "^0.5.0",
-                "dequal": "^2.0.3"
+                "@wxt-dev/browser": ">=0.1",
+                "superlock": "^1.3.2"
             },
             "funding": {
                 "url": "https://github.com/sponsors/wxt-dev"
@@ -3590,9 +3631,9 @@
             }
         },
         "node_modules/acorn": {
-            "version": "8.16.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-            "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+            "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -3806,6 +3847,13 @@
                 "node": ">=12"
             }
         },
+        "node_modules/addons-linter/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/addons-linter/node_modules/eslint": {
             "version": "9.39.4",
             "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
@@ -3945,12 +3993,49 @@
                 "url": "https://opencollective.com/eslint"
             }
         },
+        "node_modules/addons-linter/node_modules/file-entry-cache": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+            "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "flat-cache": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/addons-linter/node_modules/flat-cache": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+            "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "flatted": "^3.2.9",
+                "keyv": "^4.5.4"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
         "node_modules/addons-linter/node_modules/json-schema-traverse": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/addons-linter/node_modules/keyv": {
+            "version": "4.5.4",
+            "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+            "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "json-buffer": "3.0.1"
+            }
         },
         "node_modules/addons-linter/node_modules/minimatch": {
             "version": "3.1.5",
@@ -3963,6 +4048,21 @@
             },
             "engines": {
                 "node": "*"
+            }
+        },
+        "node_modules/addons-linter/node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/addons-linter/node_modules/strip-ansi": {
@@ -3989,6 +4089,24 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/addons-linter/node_modules/wrap-ansi": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
             }
         },
         "node_modules/addons-linter/node_modules/yargs": {
@@ -4079,9 +4197,9 @@
             }
         },
         "node_modules/adm-zip": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
-            "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.1.tgz",
+            "integrity": "sha512-Xwrja8nx9e5o2N1my4DsKCeKpdrnACyr1wtbPxBDgGzKzKyE9kRtBFA8mWldI+RVlD7CBZNWY/wQ2+ydwOR6kQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4162,10 +4280,55 @@
                 "string-width": "^4.1.0"
             }
         },
+        "node_modules/ansi-align/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/ansi-align/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/ansi-align/node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/ansi-align/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/ansi-regex": {
-            "version": "6.2.2",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-            "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+            "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4199,9 +4362,9 @@
             }
         },
         "node_modules/argue-cli": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/argue-cli/-/argue-cli-3.1.0.tgz",
-            "integrity": "sha512-DhBpBfXL4SS2uC0N922MMajKR3CdrTG0u2or1PNYgXMsrSzViJrbtvT0nCLlLGUI0plam/ZZCs7aAauHtW9thw==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/argue-cli/-/argue-cli-3.2.0.tgz",
+            "integrity": "sha512-VipTB0gXgGIFO2Rg9yEVN5wLt2AurJcZqDbgmYSwPwsykhLrQhs240/bfceev4w68lI8JshoOJIk9uW7tFzROw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4253,16 +4416,6 @@
             "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/async-mutex": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
-            "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "tslib": "^2.4.0"
-            }
         },
         "node_modules/atomic-sleep": {
             "version": "1.0.0",
@@ -4334,9 +4487,9 @@
             }
         },
         "node_modules/body-parser/node_modules/content-type": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
-            "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+            "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
             "license": "MIT",
             "engines": {
                 "node": ">=18"
@@ -4405,24 +4558,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/boxen/node_modules/wrap-ansi": {
-            "version": "9.0.2",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
-            "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^6.2.1",
-                "string-width": "^7.0.0",
-                "strip-ansi": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
             }
         },
         "node_modules/brace-expansion": {
@@ -4519,6 +4654,13 @@
                 }
             }
         },
+        "node_modules/c12/node_modules/confbox": {
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
+            "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/cac": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/cac/-/cac-7.0.0.tgz",
@@ -4527,6 +4669,20 @@
             "license": "MIT",
             "engines": {
                 "node": ">=20.19.0"
+            }
+        },
+        "node_modules/cacheable": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.5.0.tgz",
+            "integrity": "sha512-60cyAOytib/OzBw1JNSoSV/boK1AtHryDIjvVBk7XbN4ugfkM3+Sry7fEjNgPMGgOjuaZPAp8ruZ0Cxafwyq9g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@cacheable/memory": "^2.2.0",
+                "@cacheable/utils": "^2.5.0",
+                "hookified": "^1.15.0",
+                "keyv": "^5.6.0",
+                "qified": "^0.10.1"
             }
         },
         "node_modules/call-bind-apply-helpers": {
@@ -4692,35 +4848,6 @@
                 "node": ">=12.13.0"
             }
         },
-        "node_modules/chrome-launcher/node_modules/is-docker": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-            "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "is-docker": "cli.js"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/chrome-launcher/node_modules/is-wsl": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-            "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-docker": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/citty": {
             "version": "0.2.2",
             "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.2.tgz",
@@ -4785,24 +4912,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/cliui/node_modules/wrap-ansi": {
-            "version": "9.0.2",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
-            "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^6.2.1",
-                "string-width": "^7.0.0",
-                "strip-ansi": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
             }
         },
         "node_modules/clone": {
@@ -4954,6 +5063,24 @@
                 "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
+        "node_modules/concurrently/node_modules/string-width": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+            "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^10.3.0",
+                "get-east-asian-width": "^1.0.0",
+                "strip-ansi": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/concurrently/node_modules/supports-color": {
             "version": "10.2.2",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
@@ -4967,10 +5094,28 @@
                 "url": "https://github.com/chalk/supports-color?sponsor=1"
             }
         },
+        "node_modules/concurrently/node_modules/yargs": {
+            "version": "18.0.0",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+            "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cliui": "^9.0.1",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "string-width": "^7.2.0",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^22.0.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=23"
+            }
+        },
         "node_modules/confbox": {
-            "version": "0.2.4",
-            "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
-            "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.3.1.tgz",
+            "integrity": "sha512-cKUSoKa8YxFZZSmraVi7onONx3amu77ngK3kGpsYHDH7drPwCRkQE1RYMPlLRrMtnciRj274XNRxcHxnKmDSnA==",
             "dev": true,
             "license": "MIT"
         },
@@ -5003,22 +5148,6 @@
                 "dot-prop": "^9.0.0",
                 "graceful-fs": "^4.2.11",
                 "xdg-basedir": "^5.1.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/configstore/node_modules/dot-prop": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-9.0.0.tgz",
-            "integrity": "sha512-1gxPBJpI/pcjQhKgIU91II6Wkay+dLcN3M6rf2uwP8hRur3HtQXjVrdAK3sjC0piaEuxzMwjXChcETiJl47lAQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "type-fest": "^4.18.2"
             },
             "engines": {
                 "node": ">=18"
@@ -5086,9 +5215,9 @@
             }
         },
         "node_modules/conventional-commits-parser": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-7.1.0.tgz",
-            "integrity": "sha512-DPp6hkUjvwIivxbkrTiLXeRswNv1A/4GFA2X6scXma0AMa9632V3TwxmrlkUIEtUktiM3Ln+RrSH2xlP3/jUTw==",
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-7.1.2.tgz",
+            "integrity": "sha512-O+x4N2yH+ijvqWlIyTHsXTAP+algNWgGbjY2duCe8w2vUMvUB95cLRslCPfTMQyLAKlet3bhZTdu6ozn4M+QJQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5343,9 +5472,9 @@
             }
         },
         "node_modules/default-browser": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
-            "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+            "version": "5.5.1",
+            "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.1.tgz",
+            "integrity": "sha512-m1pAzaJgZ/gssEqlOhJkPJp8Xly7QyW6xcrkUa2KKcDeDSEMP7X8xipU3snUcfisTQx0w1AGae+9UtJSfVnXGw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5414,16 +5543,6 @@
                 "node": ">= 0.8"
             }
         },
-        "node_modules/dequal": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-            "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/destr": {
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
@@ -5464,6 +5583,19 @@
             },
             "funding": {
                 "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+            }
+        },
+        "node_modules/dom-serializer/node_modules/entities": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
             }
         },
         "node_modules/domelementtype": {
@@ -5508,6 +5640,22 @@
             },
             "funding": {
                 "url": "https://github.com/fb55/domutils?sponsor=1"
+            }
+        },
+        "node_modules/dot-prop": {
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-9.0.0.tgz",
+            "integrity": "sha512-1gxPBJpI/pcjQhKgIU91II6Wkay+dLcN3M6rf2uwP8hRur3HtQXjVrdAK3sjC0piaEuxzMwjXChcETiJl47lAQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "type-fest": "^4.18.2"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/dotenv": {
@@ -5613,9 +5761,9 @@
             }
         },
         "node_modules/enhanced-resolve": {
-            "version": "5.24.3",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.3.tgz",
-            "integrity": "sha512-PwKooW9JUzh5chmYfHM3IQl5OkK2u2Nm011MgeZrss3JmFraUx/fqrf78kk8GUMYoibx/14MdwTl/1WKkG7TpQ==",
+            "version": "5.25.0",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.25.0.tgz",
+            "integrity": "sha512-ghq3mhs649mvbarTCAlZn2wRhbfHmzAFiKxoWA14B3VtqnxtZt+wz8BroKXU0tF3GiJsnUldjVncQGZ8qk4rdA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5627,9 +5775,9 @@
             }
         },
         "node_modules/entities": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+            "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
             "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
@@ -5678,9 +5826,9 @@
             }
         },
         "node_modules/es-module-lexer": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
-            "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+            "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
             "dev": true,
             "license": "MIT"
         },
@@ -5759,9 +5907,9 @@
             }
         },
         "node_modules/eslint": {
-            "version": "10.9.1",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.9.1.tgz",
-            "integrity": "sha512-9VaAkDURekixUQJy0oJYl2DcN6oKMfxay7XzaGYAWQwsb6qfKf+x76R2k1L8kb1boc+FyCAaTA9GmiKaaiaF+A==",
+            "version": "10.10.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.10.0.tgz",
+            "integrity": "sha512-NPXn6r5zl4uET1DAVPaOwzX3rut4c0wcmw3dWJAfOsTM5+TogXo0DDjz8pwm/hL8cyVNpHqeK4JpN0NjnyFFNw==",
             "dev": true,
             "license": "MIT",
             "workspaces": [
@@ -5773,7 +5921,7 @@
                 "@eslint/config-array": "^0.23.5",
                 "@eslint/config-helpers": "^0.7.0",
                 "@eslint/core": "^1.2.1",
-                "@eslint/plugin-kit": "^0.7.2",
+                "@eslint/plugin-kit": "^0.7.3",
                 "@humanfs/node": "^0.16.6",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@humanwhocodes/retry": "^0.4.2",
@@ -5788,7 +5936,7 @@
                 "esquery": "^1.7.0",
                 "esutils": "^2.0.2",
                 "fast-deep-equal": "^3.1.3",
-                "file-entry-cache": "^8.0.0",
+                "file-entry-cache": "11.1.5 || >11.1.6 <12",
                 "find-up": "^5.0.0",
                 "glob-parent": "^6.0.2",
                 "ignore": "^5.2.0",
@@ -5828,16 +5976,16 @@
             }
         },
         "node_modules/eslint-plugin-react-dom": {
-            "version": "5.18.7",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-react-dom/-/eslint-plugin-react-dom-5.18.7.tgz",
-            "integrity": "sha512-5FQO4K9l1QElGmDrsWrbd5RDO+4DXO0TNOcED+y5z5j8VP2pFAIWSzrZ9nkNtVeu746mjlKDlUPtag7IFN5EFQ==",
+            "version": "5.19.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-react-dom/-/eslint-plugin-react-dom-5.19.0.tgz",
+            "integrity": "sha512-QxWdjdPxQUI3SSMYR7WyrLew7pQzlOn5P3R5raWh2PiyavaBUbkfJhSJ307l1AaJOVLy5JeIB2Rl4bivwHAOIQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@eslint-react/ast": "5.18.7",
-                "@eslint-react/eslint": "5.18.7",
-                "@eslint-react/jsx": "5.18.7",
-                "@eslint-react/shared": "5.18.7",
+                "@eslint-react/ast": "5.19.0",
+                "@eslint-react/eslint": "5.19.0",
+                "@eslint-react/jsx": "5.19.0",
+                "@eslint-react/shared": "5.19.0",
                 "@typescript-eslint/types": "^8.69.0",
                 "@typescript-eslint/utils": "^8.69.0",
                 "compare-versions": "^6.1.1"
@@ -5851,17 +5999,17 @@
             }
         },
         "node_modules/eslint-plugin-react-jsx": {
-            "version": "5.18.7",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-react-jsx/-/eslint-plugin-react-jsx-5.18.7.tgz",
-            "integrity": "sha512-T/rRA7YD9RiE0sGghsF95aeao3e/MbQlFIuu+AwPMiEOqWAcSIwTLC9d068dNy1l+OhW1NFnjO0pdT7yA+b1xA==",
+            "version": "5.19.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-react-jsx/-/eslint-plugin-react-jsx-5.19.0.tgz",
+            "integrity": "sha512-Upvpe50vpPi5jWvLqtBXoZEwaCz1pzszzoukK7qf0g1A6ZJ+XDJhi3yKmPQWBlp9c4GOwzwPuXGU5C2e8cHMbQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@eslint-react/ast": "5.18.7",
-                "@eslint-react/core": "5.18.7",
-                "@eslint-react/eslint": "5.18.7",
-                "@eslint-react/jsx": "5.18.7",
-                "@eslint-react/shared": "5.18.7",
+                "@eslint-react/ast": "5.19.0",
+                "@eslint-react/core": "5.19.0",
+                "@eslint-react/eslint": "5.19.0",
+                "@eslint-react/jsx": "5.19.0",
+                "@eslint-react/shared": "5.19.0",
                 "@typescript-eslint/types": "^8.69.0",
                 "@typescript-eslint/utils": "^8.69.0"
             },
@@ -5874,17 +6022,17 @@
             }
         },
         "node_modules/eslint-plugin-react-naming-convention": {
-            "version": "5.18.7",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-react-naming-convention/-/eslint-plugin-react-naming-convention-5.18.7.tgz",
-            "integrity": "sha512-dn07yLg+7eNQLT1Os4oUharamZuEI8MAwveZTuAhHnJRAh/sf1ppsHaxZCwM4dYQaXSmO0IprSw/GYroK8bn+w==",
+            "version": "5.19.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-react-naming-convention/-/eslint-plugin-react-naming-convention-5.19.0.tgz",
+            "integrity": "sha512-H9ko2t+KYPBDOfr29D5hDAT6CXucHJKGQscI+/ndSmkBl9K/KaGWdhFiCzQPi5S2YwPkjrcuaSXIp/n8+PA5GA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@eslint-react/ast": "5.18.7",
-                "@eslint-react/core": "5.18.7",
-                "@eslint-react/eslint": "5.18.7",
-                "@eslint-react/shared": "5.18.7",
-                "@eslint-react/var": "5.18.7",
+                "@eslint-react/ast": "5.19.0",
+                "@eslint-react/core": "5.19.0",
+                "@eslint-react/eslint": "5.19.0",
+                "@eslint-react/shared": "5.19.0",
+                "@eslint-react/var": "5.19.0",
                 "@typescript-eslint/types": "^8.69.0",
                 "@typescript-eslint/utils": "^8.69.0",
                 "ts-pattern": "^5.9.0"
@@ -5898,17 +6046,17 @@
             }
         },
         "node_modules/eslint-plugin-react-rsc": {
-            "version": "5.18.7",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-react-rsc/-/eslint-plugin-react-rsc-5.18.7.tgz",
-            "integrity": "sha512-9RR1a7RAc7M+JUparCBuUPwaZBnmrCGJwlyoGQ59f4CPpaft1aagiuOpG/nCkwSPMz6lYrR7+HAkeZo9r9vaeQ==",
+            "version": "5.19.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-react-rsc/-/eslint-plugin-react-rsc-5.19.0.tgz",
+            "integrity": "sha512-XdfkB2XRS0b1WBkuxnRsWmhivNaBOLAIohBqWQItQycuket6wVliqSY+Q1NcTst4PdJ1bYzLuMgSXYsgwJMV7Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@eslint-react/ast": "5.18.7",
-                "@eslint-react/core": "5.18.7",
-                "@eslint-react/eslint": "5.18.7",
-                "@eslint-react/shared": "5.18.7",
-                "@eslint-react/var": "5.18.7",
+                "@eslint-react/ast": "5.19.0",
+                "@eslint-react/core": "5.19.0",
+                "@eslint-react/eslint": "5.19.0",
+                "@eslint-react/shared": "5.19.0",
+                "@eslint-react/var": "5.19.0",
                 "@typescript-eslint/types": "^8.69.0",
                 "@typescript-eslint/utils": "^8.69.0"
             },
@@ -5921,17 +6069,17 @@
             }
         },
         "node_modules/eslint-plugin-react-web-api": {
-            "version": "5.18.7",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-react-web-api/-/eslint-plugin-react-web-api-5.18.7.tgz",
-            "integrity": "sha512-Bhr+p3rVk05uXPw78Jlj/S6uw7fxQ+JuRJuLTkW5tnVaFx+6MnqxSuEJhSmg17cd26JBg4Jt0rFktsSqU+820w==",
+            "version": "5.19.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-react-web-api/-/eslint-plugin-react-web-api-5.19.0.tgz",
+            "integrity": "sha512-wCNdYVHgdLmCikLicH6kfO6EE1SKzi63FlhLLGMGzzEAyvudvyfKI0+ZXDkFyjolvKXLQW6Thb8EeAFbHTZksw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@eslint-react/ast": "5.18.7",
-                "@eslint-react/core": "5.18.7",
-                "@eslint-react/eslint": "5.18.7",
-                "@eslint-react/shared": "5.18.7",
-                "@eslint-react/var": "5.18.7",
+                "@eslint-react/ast": "5.19.0",
+                "@eslint-react/core": "5.19.0",
+                "@eslint-react/eslint": "5.19.0",
+                "@eslint-react/shared": "5.19.0",
+                "@eslint-react/var": "5.19.0",
                 "@typescript-eslint/types": "^8.69.0",
                 "@typescript-eslint/utils": "^8.69.0",
                 "birecord": "^0.1.2",
@@ -5946,18 +6094,18 @@
             }
         },
         "node_modules/eslint-plugin-react-x": {
-            "version": "5.18.7",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-react-x/-/eslint-plugin-react-x-5.18.7.tgz",
-            "integrity": "sha512-48+mi+4m6YEdkd4p485fuAfLJFEhnCZ5Vo4wPtLY/hCyF795HI79wdT/Pbumr6Oe+H39zBAczXIpw5h3dc1yuw==",
+            "version": "5.19.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-react-x/-/eslint-plugin-react-x-5.19.0.tgz",
+            "integrity": "sha512-HoweOyYhar8G2QEukOctSaK87Y3AzB3bn4ES+0VVhcNOOqBFphRaWqcvoNN8JE+5AKOhhpuzjVKY6DnGPCcAMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@eslint-react/ast": "5.18.7",
-                "@eslint-react/core": "5.18.7",
-                "@eslint-react/eslint": "5.18.7",
-                "@eslint-react/jsx": "5.18.7",
-                "@eslint-react/shared": "5.18.7",
-                "@eslint-react/var": "5.18.7",
+                "@eslint-react/ast": "5.19.0",
+                "@eslint-react/core": "5.19.0",
+                "@eslint-react/eslint": "5.19.0",
+                "@eslint-react/jsx": "5.19.0",
+                "@eslint-react/shared": "5.19.0",
+                "@eslint-react/var": "5.19.0",
                 "@typescript-eslint/scope-manager": "^8.69.0",
                 "@typescript-eslint/type-utils": "^8.69.0",
                 "@typescript-eslint/types": "^8.69.0",
@@ -6046,13 +6194,13 @@
             "license": "MIT"
         },
         "node_modules/eslint/node_modules/minimatch": {
-            "version": "10.2.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-            "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+            "version": "10.2.6",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+            "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
-                "brace-expansion": "^5.0.5"
+                "brace-expansion": "^5.0.8"
             },
             "engines": {
                 "node": "18 || 20 || >=22"
@@ -6181,18 +6329,18 @@
             }
         },
         "node_modules/eventsource-parser": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
-            "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.1.tgz",
+            "integrity": "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==",
             "license": "MIT",
             "engines": {
                 "node": ">=18.0.0"
             }
         },
         "node_modules/expect-type": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
-            "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+            "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -6243,11 +6391,12 @@
             }
         },
         "node_modules/express-rate-limit": {
-            "version": "8.5.2",
-            "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
-            "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+            "version": "8.7.0",
+            "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.7.0.tgz",
+            "integrity": "sha512-hOwV7WOxXfjRpAM1DSJWZDXx3GhplwD8IfwuwvogD8i1Qnkgosw/H45s4ZnFAUHDAhPjlY9hLBvJhKmGMyY26g==",
             "license": "MIT",
             "dependencies": {
+                "debug": "^4.4.3",
                 "ip-address": "^10.2.0"
             },
             "engines": {
@@ -6261,9 +6410,9 @@
             }
         },
         "node_modules/exsolve": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
-            "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.1.tgz",
+            "integrity": "sha512-9U/jZUgjnSGyntRr6y5Muu1MJcwFl6kPu7k8qLF0IMNfLqvw0NZ4nnVDq0RVoZ0RvCyumib4Ez3KYrVfilrw+g==",
             "dev": true,
             "license": "MIT"
         },
@@ -6329,22 +6478,19 @@
             }
         },
         "node_modules/file-entry-cache": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
-            "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+            "version": "11.1.5",
+            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.5.tgz",
+            "integrity": "sha512-+PFTHITI08JIGhnNpGNI8T8inUpgZfk3GNEqfT9R2zZV2iFXg3CvqzSl/uEhs7TSGujYRELEANyDvS8Fj7+S7Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "flat-cache": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=16.0.0"
+                "flat-cache": "^6.1.23"
             }
         },
         "node_modules/filesize": {
-            "version": "11.0.17",
-            "resolved": "https://registry.npmjs.org/filesize/-/filesize-11.0.17.tgz",
-            "integrity": "sha512-oHLTvMLw6imZUl1se/RBQrFlyy50nXce4sU7yGR6Qc0JgCwqnfiFsAnEwotdGmfKLD7SArGUk2/5STU0k8LOBQ==",
+            "version": "11.0.23",
+            "resolved": "https://registry.npmjs.org/filesize/-/filesize-11.0.23.tgz",
+            "integrity": "sha512-EzB9Km94xm3V7szupSlcGVJpkvXWuNtSZmr7qBoj229q7lEJEEYGMk8gwGnA4ZTAGQmHZigTDEIuOfCQXec1fQ==",
             "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
@@ -6430,23 +6576,21 @@
             }
         },
         "node_modules/flat-cache": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
-            "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+            "version": "6.1.23",
+            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.23.tgz",
+            "integrity": "sha512-f++BY9pTk+983xK1FLzlLpmM0i0z+jHmx3QESGkURMXujQZz1k5wzwX6hjnQ8goaD0B+sYnDK1yZ6MTyZfUaqA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "flatted": "^3.2.9",
-                "keyv": "^4.5.4"
-            },
-            "engines": {
-                "node": ">=16"
+                "cacheable": "^2.5.0",
+                "flatted": "^3.4.2",
+                "hookified": "^1.15.0"
             }
         },
         "node_modules/flatted": {
-            "version": "3.4.2",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
-            "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+            "version": "3.4.4",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
+            "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
             "dev": true,
             "license": "ISC"
         },
@@ -6460,13 +6604,13 @@
             }
         },
         "node_modules/framer-motion": {
-            "version": "12.42.2",
-            "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.42.2.tgz",
-            "integrity": "sha512-5XY9luDiu0oHfHBjpDthFMh0ES+122w6p/papSJBweMkO8Sn+PW2QaEgRblQBpWFnuvZS5qvarpt/hO2pjGmnw==",
+            "version": "12.43.0",
+            "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.43.0.tgz",
+            "integrity": "sha512-1eaL3RvR/kAlbG7UYcpMptEyzPoENO0c6w7ZnB3/hh2vSAz/6uGAFn6fdoqTBguNstf3MsFhJHsD/0DHiclG+g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "motion-dom": "^12.42.2",
+                "motion-dom": "^12.43.0",
                 "motion-utils": "^12.39.0",
                 "tslib": "^2.4.0"
             },
@@ -6497,9 +6641,9 @@
             }
         },
         "node_modules/fs-extra": {
-            "version": "11.3.5",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
-            "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
+            "version": "11.3.6",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.6.tgz",
+            "integrity": "sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6661,9 +6805,9 @@
             }
         },
         "node_modules/giget": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/giget/-/giget-3.2.0.tgz",
-            "integrity": "sha512-GvHTWcykIR/fP8cj8dMpuMMkvaeJfPvYnhq0oW+chSeIr+ldX21ifU2Ms6KBoyKZQZmVaUAAhQ2EZ68KJF8a7A==",
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/giget/-/giget-3.3.1.tgz",
+            "integrity": "sha512-r+mvuDjrjMpsdw46Kmeydb8bdHm7wOKw8wNBtTndkjbPjgAp5oUJUxRE76wZFknxIPokfWvep2qSXK37aXE6zg==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -6682,6 +6826,13 @@
             "engines": {
                 "node": ">=10.13.0"
             }
+        },
+        "node_modules/glob-to-regexp": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+            "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+            "dev": true,
+            "license": "BSD-2-Clause"
         },
         "node_modules/global-directory": {
             "version": "5.0.0",
@@ -6732,9 +6883,9 @@
             "license": "ISC"
         },
         "node_modules/happy-dom": {
-            "version": "20.13.2",
-            "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.13.2.tgz",
-            "integrity": "sha512-VC9HoEaT3Jf3K/1g/GjMYGAZCCg+ULgGVcXJlAeSzdTj8mIoPJRp14KVclP5gpUcF/kauuaVB2ri2/WxXbl4vg==",
+            "version": "20.14.5",
+            "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.14.5.tgz",
+            "integrity": "sha512-x/RzkpWO40bTjIoT30iQtt64FLLmH/iRcUCN2X//bLx7H3ifkdfPXyqsro/OYtqzIAhiLMMA7mmiOR9C3NOKjQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6748,19 +6899,6 @@
             },
             "engines": {
                 "node": ">=20.0.0"
-            }
-        },
-        "node_modules/happy-dom/node_modules/entities": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
-            "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "engines": {
-                "node": ">=0.12"
-            },
-            "funding": {
-                "url": "https://github.com/fb55/entities?sponsor=1"
             }
         },
         "node_modules/has-flag": {
@@ -6785,6 +6923,19 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/hashery": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/hashery/-/hashery-1.5.1.tgz",
+            "integrity": "sha512-iZyKG96/JwPz1N55vj2Ie2vXbhu440zfUfJvSwEqEbeLluk7NnapfGqa7LH0mOsnDxTF85Mx8/dyR6HfqcbmbQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "hookified": "^1.15.0"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
         "node_modules/hasown": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
@@ -6798,9 +6949,9 @@
             }
         },
         "node_modules/hono": {
-            "version": "4.13.1",
-            "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz",
-            "integrity": "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==",
+            "version": "4.13.7",
+            "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.7.tgz",
+            "integrity": "sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==",
             "license": "MIT",
             "engines": {
                 "node": ">=16.9.0"
@@ -6810,6 +6961,13 @@
             "version": "6.1.1",
             "resolved": "https://registry.npmjs.org/hookable/-/hookable-6.1.1.tgz",
             "integrity": "sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/hookified": {
+            "version": "1.15.1",
+            "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.15.1.tgz",
+            "integrity": "sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==",
             "dev": true,
             "license": "MIT"
         },
@@ -6838,19 +6996,6 @@
                 "domhandler": "^5.0.3",
                 "domutils": "^3.2.2",
                 "entities": "^7.0.1"
-            }
-        },
-        "node_modules/htmlparser2/node_modules/entities": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
-            "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "engines": {
-                "node": ">=0.12"
-            },
-            "funding": {
-                "url": "https://github.com/fb55/entities?sponsor=1"
             }
         },
         "node_modules/http-errors": {
@@ -6904,9 +7049,9 @@
             }
         },
         "node_modules/iconv-lite": {
-            "version": "0.7.2",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-            "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+            "version": "0.7.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+            "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
             "license": "MIT",
             "dependencies": {
                 "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -6937,16 +7082,17 @@
             }
         },
         "node_modules/image-size": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/image-size/-/image-size-2.0.2.tgz",
-            "integrity": "sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==",
+            "name": "image-size-next",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/image-size-next/-/image-size-next-2.1.1.tgz",
+            "integrity": "sha512-n+DFjUct+G9mxZck+lvzqrTsqBJvSHMs6iEo//W5iAgRV7oUbrh1JWmKgAEpmyRB5lw6plIQizS1wK1dvrsvAw==",
             "dev": true,
             "license": "MIT",
             "bin": {
-                "image-size": "bin/image-size.js"
+                "image-size-next": "bin/image-size-next.js"
             },
             "engines": {
-                "node": ">=16.x"
+                "node": ">=18"
             }
         },
         "node_modules/immediate": {
@@ -7033,9 +7179,9 @@
             }
         },
         "node_modules/ip-address": {
-            "version": "10.5.0",
-            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
-            "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
+            "version": "10.7.0",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.7.0.tgz",
+            "integrity": "sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA==",
             "license": "MIT",
             "engines": {
                 "node": ">= 12"
@@ -7074,16 +7220,16 @@
             }
         },
         "node_modules/is-docker": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
-            "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+            "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
             "dev": true,
             "license": "MIT",
             "bin": {
                 "is-docker": "cli.js"
             },
             "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+                "node": ">=8"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -7165,6 +7311,22 @@
             },
             "engines": {
                 "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-inside-container/node_modules/is-docker": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+            "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "is-docker": "cli.js"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -7273,19 +7435,16 @@
             "license": "MIT"
         },
         "node_modules/is-wsl": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
-            "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+            "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "is-inside-container": "^1.0.0"
+                "is-docker": "^2.0.0"
             },
             "engines": {
-                "node": ">=16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+                "node": ">=8"
             }
         },
         "node_modules/isarray": {
@@ -7326,9 +7485,9 @@
             "license": "MIT"
         },
         "node_modules/jose": {
-            "version": "6.2.3",
-            "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
-            "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+            "version": "6.2.12",
+            "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.12.tgz",
+            "integrity": "sha512-9NiFmJEex0sy2Dk58j2UGBSHgUs2ypF9eZSu4L6vjOX3Dp96Sw1F3uL+H+D1sx02jZZdzUT0HgvCy59CuvXcWw==",
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/panva"
@@ -7513,13 +7672,13 @@
             }
         },
         "node_modules/keyv": {
-            "version": "4.5.4",
-            "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
-            "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+            "version": "5.6.0",
+            "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+            "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "json-buffer": "3.0.1"
+                "@keyv/serialize": "^1.1.1"
             }
         },
         "node_modules/kolorist": {
@@ -7736,6 +7895,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -7757,6 +7919,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -7778,6 +7943,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -7799,6 +7967,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -7862,16 +8033,16 @@
             "license": "MIT"
         },
         "node_modules/linkedom": {
-            "version": "0.18.12",
-            "resolved": "https://registry.npmjs.org/linkedom/-/linkedom-0.18.12.tgz",
-            "integrity": "sha512-jalJsOwIKuQJSeTvsgzPe9iJzyfVaEJiEXl+25EkKevsULHvMJzpNqwvj1jOESWdmgKDiXObyjOYwlUqG7wo1Q==",
+            "version": "0.18.13",
+            "resolved": "https://registry.npmjs.org/linkedom/-/linkedom-0.18.13.tgz",
+            "integrity": "sha512-ES/o9qotMpzpN2MHs+Iq/JcVoOj8Fa5wiQYrTdFpvAnwXL0g66XHHUc9WUMk6nAlBtGsFQ24ne+SYnvnaQ2FSw==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
-                "css-select": "^5.1.0",
+                "css-select": "^7.0.0",
                 "cssom": "^0.5.0",
                 "html-escaper": "^3.0.3",
-                "htmlparser2": "^10.0.0",
+                "htmlparser2": "^10.1.0",
                 "uhyphen": "^0.2.0"
             },
             "engines": {
@@ -7886,16 +8057,166 @@
                 }
             }
         },
+        "node_modules/linkedom/node_modules/boolbase": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-2.0.0.tgz",
+            "integrity": "sha512-DkVaaQHymRhpYEYo9x1oo7Q7B0Y6KJUsjm3c9eTyFDby4MHLBTwZ6ZDWBel5zrYxj1WsZgC5oLpiz+93MluXeA==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/fb55"
+            }
+        },
+        "node_modules/linkedom/node_modules/css-select": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/css-select/-/css-select-7.0.0.tgz",
+            "integrity": "sha512-snmjEVXy+1LnwXdxhYvTMj1d9tOh4HxkA1YmoayVBeeyR2C14Pum7fcxJIm4SswYspVy866eYNwlH6xC3/VH5g==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "boolbase": "^2.0.0",
+                "css-what": "^8.0.0",
+                "domhandler": "^6.0.1",
+                "domutils": "^4.0.2",
+                "nth-check": "^3.0.1"
+            },
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/fb55"
+            }
+        },
+        "node_modules/linkedom/node_modules/css-what": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/css-what/-/css-what-8.0.0.tgz",
+            "integrity": "sha512-DH0Bqq3DNp5tdOReuNyAA+Ev4Y2GS5FMbZpeTLP6C4CDi0h5nL0BmUPChXw3o/qbHLDWHl49sbNqQVY7bMSDdw==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/fb55"
+            }
+        },
+        "node_modules/linkedom/node_modules/dom-serializer": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-3.1.1.tgz",
+            "integrity": "sha512-4MEa38/QexBob6gFNwu+EGdWvhJ1OKuNwdYY3Y3NyeWDQfnGeDYQUDfIRzWu5B5gsv03so2Uxd28YC6zrsx3Lw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "domelementtype": "^3.0.0",
+                "domhandler": "^6.0.0",
+                "entities": "^8.0.0"
+            },
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+            }
+        },
+        "node_modules/linkedom/node_modules/domelementtype": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-3.0.0.tgz",
+            "integrity": "sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fb55"
+                }
+            ],
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=20.19.0"
+            }
+        },
+        "node_modules/linkedom/node_modules/domhandler": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-6.0.1.tgz",
+            "integrity": "sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "domelementtype": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/fb55/domhandler?sponsor=1"
+            }
+        },
+        "node_modules/linkedom/node_modules/domutils": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-4.0.2.tgz",
+            "integrity": "sha512-qI4JLRKnSzqFqr7hAlS5xQDusBCjKSEG4t4+7aNrIQMHBcsC2TGEhuyABJdYkgSewL57PNLYEiibY2iPKhKpaA==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "dom-serializer": "^3.0.0",
+                "domelementtype": "^3.0.0",
+                "domhandler": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/fb55/domutils?sponsor=1"
+            }
+        },
+        "node_modules/linkedom/node_modules/entities": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-8.1.0.tgz",
+            "integrity": "sha512-kxL7msIffSuh9aaFAMD7rxAIuTRMAHMeBtgHW2yUdWw732ZNh4MehkF2gdjvtdmikkaIP9bFDDJOPlsvm7avrA==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
+        "node_modules/linkedom/node_modules/nth-check": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-3.0.1.tgz",
+            "integrity": "sha512-GX0gsdbGVCgnRgbeGaubfjpBXyYRWOOCVeYh08bSQvDZqxz5ndXs1OTfAt/h36G1xvI94YIspsI0sVFqAV9+RQ==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "boolbase": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/fb55/nth-check?sponsor=1"
+            }
+        },
         "node_modules/lint-staged": {
-            "version": "17.4.1",
-            "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.4.1.tgz",
-            "integrity": "sha512-FmJeudcalbSfg1du+JCfvi5vS6Qt08KgbfLWiHinbef+2JJwUZwAWVoaO1AcJVUTWPfk0t30PMQNwPAeCzYQ+Q==",
+            "version": "17.5.1",
+            "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.5.1.tgz",
+            "integrity": "sha512-7EDuco1xnBMeVpvAbeMq1U5KXwJGLmY8q6l+Ye78r36C4mPc+Vg1Z2SK8gHyRTyvPro90A0q5/FAZ+Au23d6QQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "picomatch": "^4.0.7",
                 "string-argv": "^0.3.2",
-                "tinyexec": "^1.3.0"
+                "tinyexec": "^1.3.1"
             },
             "bin": {
                 "lint-staged": "bin/lint-staged.js"
@@ -8008,9 +8329,9 @@
             "license": "MIT"
         },
         "node_modules/lucide-react": {
-            "version": "1.40.0",
-            "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.40.0.tgz",
-            "integrity": "sha512-MaG+8WnOXkDWz9XeElj7TnQ890tTZUB0a36i03aRRCKGWE6e7jJpmdCvtxxuxcjjdqyN6m4sL6qlHVuSUDtYgg==",
+            "version": "1.45.0",
+            "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.45.0.tgz",
+            "integrity": "sha512-yH1ubCAduho9UR7oJhRXIQXogksRILBiTuZC4/bQIGeB9JOkxMlSuEHyyZpo1Z3S0yWJO2KTSUZbjiNvVxeOUw==",
             "dev": true,
             "license": "ISC",
             "peerDependencies": {
@@ -8028,14 +8349,14 @@
             }
         },
         "node_modules/magicast": {
-            "version": "0.5.3",
-            "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
-            "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+            "version": "0.5.5",
+            "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.5.tgz",
+            "integrity": "sha512-UicdXN8zQ3JHlxVq+28afMXPr1z7WNY6+7EJnzTdQWkTAlMLF5fNCCKxJHBQwGaNGR11581EiQmQzx73+MvszA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/parser": "^7.29.3",
-                "@babel/types": "^7.29.0",
+                "@babel/parser": "^7.29.7",
+                "@babel/types": "^7.29.7",
                 "source-map-js": "^1.2.1"
             }
         },
@@ -8083,12 +8404,16 @@
             "license": "CC0-1.0"
         },
         "node_modules/media-typer": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
-            "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+            "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/merge-descriptors": {
@@ -8154,13 +8479,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/mitt": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
-            "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/mlly": {
             "version": "1.8.2",
             "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
@@ -8194,13 +8512,13 @@
             }
         },
         "node_modules/motion": {
-            "version": "12.42.2",
-            "resolved": "https://registry.npmjs.org/motion/-/motion-12.42.2.tgz",
-            "integrity": "sha512-Atvv11yUKIid41cVrRBDVX5m8tF8kNpExRSlbpt6APClhDjtwQssgFHhQzejxw7/7YYbjHSPKBVbHo05BuJT5Q==",
+            "version": "12.43.0",
+            "resolved": "https://registry.npmjs.org/motion/-/motion-12.43.0.tgz",
+            "integrity": "sha512-BQgQbSa9Hn3/mtbib0MK53y6JSANa+YKUKlaYnWzAVDH424RYQ5LVpV3pNiWH00BA2z4ojsSdMzqT7g2FQwjuQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "framer-motion": "^12.42.2",
+                "framer-motion": "^12.43.0",
                 "tslib": "^2.4.0"
             },
             "peerDependencies": {
@@ -8221,9 +8539,9 @@
             }
         },
         "node_modules/motion-dom": {
-            "version": "12.42.2",
-            "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.42.2.tgz",
-            "integrity": "sha512-5gIMWLp/PycBtJRJWRgjxke5n8dlvkSn2DrYW+tr3XcqAZY1xZh6BJyooJXCM8wdfM7wfMjkBJNLge1CKPUIRA==",
+            "version": "12.43.0",
+            "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.43.0.tgz",
+            "integrity": "sha512-azKON4d9S65PEoFUiQTMTgPheEmzf2QngdRc50AKfJp9Q9mmcBVw22c8eMq9k8kxOFHdL7+WZY7N/5F/lwiDag==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8294,9 +8612,9 @@
             }
         },
         "node_modules/nanoid": {
-            "version": "3.3.18",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
-            "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+            "version": "3.3.19",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.19.tgz",
+            "integrity": "sha512-Y2tUNy4ouw6tq5oDSKeQYGOyhkUBhNOcGV/02KC+6kd9eDGqdZd++mjMiIDilrBYvjEnCYvVtsuHCuP+okSfug==",
             "dev": true,
             "funding": [
                 {
@@ -8320,12 +8638,32 @@
             "license": "MIT"
         },
         "node_modules/negotiator": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
-            "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.1.0.tgz",
+            "integrity": "sha512-NMPBRMJgiQHjbd8phG3Vebdx4kZ1H121rbl5IkMqeOsahptB9BKo/d7oJ3zTXqTgagn2bWlNSXkh0QUGM31RYg==",
+            "license": "MIT",
+            "dependencies": {
+                "content-type": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/negotiator/node_modules/content-type": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+            "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
             "license": "MIT",
             "engines": {
-                "node": ">= 0.6"
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/next-themes": {
@@ -8363,15 +8701,15 @@
             }
         },
         "node_modules/nypm": {
-            "version": "0.6.6",
-            "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.6.tgz",
-            "integrity": "sha512-vRyr0r4cbBapw07Xw8xrj9Teq3o7MUD35rSaTcanDbW+aK2XHDgJFiU6ZTj2GBw7Q12ysdsyFss+Vdz4hQ0Y6Q==",
+            "version": "0.6.10",
+            "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.10.tgz",
+            "integrity": "sha512-W72Hrj1petq+b3Hk2aAC+9zswetlIFTnDW4s5djseZh2nYqBbyQLOtj472HwcbcWykPBUW1WpWpjOd4nK6gMRw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "citty": "^0.2.2",
                 "pathe": "^2.0.3",
-                "tinyexec": "^1.1.1"
+                "tinyexec": "^1.3.1"
             },
             "bin": {
                 "nypm": "dist/cli.mjs"
@@ -8402,20 +8740,23 @@
             }
         },
         "node_modules/obug": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
-            "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/obug/-/obug-2.2.1.tgz",
+            "integrity": "sha512-XrsrhT5sybtKI6wakr2SPOlGZWWYbUXZ7a0jT8/QOeAPau+1X/bSegNe5YR75oJmEZQbKningirmGOEJCIk61Q==",
             "dev": true,
             "funding": [
                 "https://github.com/sponsors/sxzz",
                 "https://opencollective.com/debug"
             ],
-            "license": "MIT"
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.20.0"
+            }
         },
         "node_modules/ohash": {
-            "version": "2.0.11",
-            "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
-            "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+            "version": "2.0.12",
+            "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.12.tgz",
+            "integrity": "sha512-65S/5gk9YSsaRjcyf7Nfa6h/d3E8/1gslpXfI4W7Dxn/oap8IKRuNT5VXkLQ1YFKIEg4apRY4Pj6aiwFzrDdmw==",
             "dev": true,
             "license": "MIT"
         },
@@ -8796,21 +9137,21 @@
             }
         },
         "node_modules/pkg-types": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.1.tgz",
-            "integrity": "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==",
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.3.tgz",
+            "integrity": "sha512-j/lCFdcppV0JxWpCEITdbDltBxPP6cHT+yNJ6Go2OgoSA9518X847X9z0p6LtA4Nc16+eQzCZjRrWanTGvHJ5w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "confbox": "^0.2.4",
-                "exsolve": "^1.0.8",
+                "confbox": "^0.3.1",
+                "exsolve": "^1.1.1",
                 "pathe": "^2.0.3"
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.26",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
-            "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+            "version": "8.5.28",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.28.tgz",
+            "integrity": "sha512-RRuzqDtt5Y9h3quz5hWhK+TPnsmVs6WwSU6LkJMeY4HstUEDuYTG8UJSdawMRzmzAtV+KEoG8N3Qg2qLy5vM/A==",
             "dev": true,
             "funding": [
                 {
@@ -8828,7 +9169,7 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.17",
+                "nanoid": "^3.3.18",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },
@@ -8976,6 +9317,26 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/qified": {
+            "version": "0.10.1",
+            "resolved": "https://registry.npmjs.org/qified/-/qified-0.10.1.tgz",
+            "integrity": "sha512-+Owyggi9IxT1ePKGafcI87ubSmxol6smwJ+RAHDQlx9+9cPwFWDiKFFCPuWhr9ignlGpZ9vDQLw67N4dcTVFEA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "hookified": "^2.1.1"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/qified/node_modules/hookified": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/hookified/-/hookified-2.2.0.tgz",
+            "integrity": "sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/qs": {
             "version": "6.16.0",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
@@ -9017,12 +9378,16 @@
             "license": "MIT"
         },
         "node_modules/range-parser": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-            "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+            "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
             "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/raw-body": {
@@ -9074,20 +9439,20 @@
             }
         },
         "node_modules/rc9": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/rc9/-/rc9-3.0.1.tgz",
-            "integrity": "sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/rc9/-/rc9-3.1.0.tgz",
+            "integrity": "sha512-ufjkNVzbRHKcCOmTahZkmVsyc3W+MSk3jY03m+a7tGHkIsdVMG9l10/3HvFbWkkKzY5VFp3pkRsIo/UYgmFL7Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "defu": "^6.1.6",
+                "defu": "^6.1.7",
                 "destr": "^2.0.5"
             }
         },
         "node_modules/react": {
-            "version": "19.2.8",
-            "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
-            "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
+            "version": "19.3.0",
+            "resolved": "https://registry.npmjs.org/react/-/react-19.3.0.tgz",
+            "integrity": "sha512-E8LUcbtBWt20bbl2YoHfx4ZDBdxVTfOKtCZn9cDSJ4l6/nuoApcpIBcj47t2wZoVX8g2ZHuMHbiShgCR1T5Sog==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -9095,16 +9460,16 @@
             }
         },
         "node_modules/react-dom": {
-            "version": "19.2.8",
-            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
-            "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
+            "version": "19.3.0",
+            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.3.0.tgz",
+            "integrity": "sha512-JDk8dgif51OjFoDE70+OT9ICyYr+69HlmihNwp1+Nsfbna3t5sIiCa9ZJktDmQ4/1b/rn26hIAR2uYXDMr5r0Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "scheduler": "^0.27.0"
+                "scheduler": "^0.28.0"
             },
             "peerDependencies": {
-                "react": "^19.2.8"
+                "react": "^19.3.0"
             }
         },
         "node_modules/readable-stream": {
@@ -9131,9 +9496,9 @@
             "license": "MIT"
         },
         "node_modules/readdirp": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
-            "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.1.1.tgz",
+            "integrity": "sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -9245,13 +9610,13 @@
             }
         },
         "node_modules/rolldown": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.7.tgz",
-            "integrity": "sha512-g0EtLvBjTUB7jhyV0S/TCup3v/XSVl45vUIGbOGU4QPiyjTenCe4mKuFvW9fEgYmS2Fo42AUssRmNuMziXdrig==",
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.8.tgz",
+            "integrity": "sha512-Z67nTmhZe7anqnM/EjI392w5i/ANUinjip7QYsOyN37oayduxt3ksdX0hf5OOamkAd53BiIHfbfSzfUmzKFQqQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@oxc-project/types": "=0.148.0",
+                "@oxc-project/types": "=0.149.0",
                 "@rolldown/pluginutils": "^1.0.0"
             },
             "bin": {
@@ -9261,21 +9626,21 @@
                 "node": "^20.19.0 || >=22.12.0"
             },
             "optionalDependencies": {
-                "@rolldown/binding-android-arm-eabi": "1.2.7",
-                "@rolldown/binding-android-arm64": "1.2.7",
-                "@rolldown/binding-darwin-arm64": "1.2.7",
-                "@rolldown/binding-darwin-x64": "1.2.7",
-                "@rolldown/binding-freebsd-x64": "1.2.7",
-                "@rolldown/binding-linux-arm-gnueabihf": "1.2.7",
-                "@rolldown/binding-linux-arm64-gnu": "1.2.7",
-                "@rolldown/binding-linux-arm64-musl": "1.2.7",
-                "@rolldown/binding-linux-ppc64-gnu": "1.2.7",
-                "@rolldown/binding-linux-s390x-gnu": "1.2.7",
-                "@rolldown/binding-linux-x64-gnu": "1.2.7",
-                "@rolldown/binding-linux-x64-musl": "1.2.7",
-                "@rolldown/binding-openharmony-arm64": "1.2.7",
-                "@rolldown/binding-win32-arm64-msvc": "1.2.7",
-                "@rolldown/binding-win32-x64-msvc": "1.2.7"
+                "@rolldown/binding-android-arm-eabi": "1.2.8",
+                "@rolldown/binding-android-arm64": "1.2.8",
+                "@rolldown/binding-darwin-arm64": "1.2.8",
+                "@rolldown/binding-darwin-x64": "1.2.8",
+                "@rolldown/binding-freebsd-x64": "1.2.8",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.2.8",
+                "@rolldown/binding-linux-arm64-gnu": "1.2.8",
+                "@rolldown/binding-linux-arm64-musl": "1.2.8",
+                "@rolldown/binding-linux-ppc64-gnu": "1.2.8",
+                "@rolldown/binding-linux-s390x-gnu": "1.2.8",
+                "@rolldown/binding-linux-x64-gnu": "1.2.8",
+                "@rolldown/binding-linux-x64-musl": "1.2.8",
+                "@rolldown/binding-openharmony-arm64": "1.2.8",
+                "@rolldown/binding-win32-arm64-msvc": "1.2.8",
+                "@rolldown/binding-win32-x64-msvc": "1.2.8"
             }
         },
         "node_modules/rough-notation": {
@@ -9372,9 +9737,9 @@
             }
         },
         "node_modules/scheduler": {
-            "version": "0.27.0",
-            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
-            "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.28.0.tgz",
+            "integrity": "sha512-juorfCmIkIw8tT+p5BXSm6PJjQF/ycEYmKyzURCIt/RaZIhL+PulbQ9Yu2z1HdOJDdqDTlxA1+xKBmHXJsczAw==",
             "dev": true,
             "license": "MIT"
         },
@@ -9570,9 +9935,9 @@
             "license": "ISC"
         },
         "node_modules/simple-icons": {
-            "version": "16.29.0",
-            "resolved": "https://registry.npmjs.org/simple-icons/-/simple-icons-16.29.0.tgz",
-            "integrity": "sha512-4H94f5ZgcCcgJroc902TFlFdgPu2IU2eD7+WebN2Z14xKYrKHeJ4UQcZwzgSuH4Rgzw+jp7sbHl40NefuIEYsg==",
+            "version": "16.30.0",
+            "resolved": "https://registry.npmjs.org/simple-icons/-/simple-icons-16.30.0.tgz",
+            "integrity": "sha512-YX/HmgEqjpn5Zs3myzKp8ek5Ti+TdrkvNWn9skGLetg9tOg0cTjYizj9ESAYJn4xwc0GQYVGzQxBELDfbxq7WQ==",
             "dev": true,
             "funding": [
                 {
@@ -9694,9 +10059,9 @@
             }
         },
         "node_modules/std-env": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
-            "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+            "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
             "dev": true,
             "license": "MIT"
         },
@@ -9735,48 +10100,20 @@
             "license": "MIT"
         },
         "node_modules/string-width": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "version": "8.2.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+            "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
+                "get-east-asian-width": "^1.5.0",
+                "strip-ansi": "^7.1.2"
             },
             "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/string-width/node_modules/ansi-regex": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/string-width/node_modules/emoji-regex": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/string-width/node_modules/strip-ansi": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
+                "node": ">=20"
             },
-            "engines": {
-                "node": ">=8"
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/strip-ansi": {
@@ -9849,22 +10186,22 @@
             }
         },
         "node_modules/strip-literal": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
-            "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-4.0.0.tgz",
+            "integrity": "sha512-PaqAvfUZKBwc/SLmNZtHmzK+v19Z4O4eS3cKPeGvbIv/U3pnyEq4Tuw3/4v/FwfM8VQaEawsyCcOQ0P+kpwWWw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "js-tokens": "^9.0.1"
+                "js-tokens": "^10.0.0"
             },
             "funding": {
                 "url": "https://github.com/sponsors/antfu"
             }
         },
         "node_modules/strip-literal/node_modules/js-tokens": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
-            "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+            "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
             "dev": true,
             "license": "MIT"
         },
@@ -9925,9 +10262,9 @@
             }
         },
         "node_modules/tailwind-merge": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
-            "integrity": "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==",
+            "version": "3.7.0",
+            "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.7.0.tgz",
+            "integrity": "sha512-XPPUyAc+cvspz3lHTcR/QgPfW2A0lv/xQNIjX3HGhLR+Nq2lHaLq5MtTesHn8GUr3W3DguT2KT5x3NVgRtYwmA==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -10155,9 +10492,9 @@
             }
         },
         "node_modules/type-is/node_modules/content-type": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
-            "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+            "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
             "license": "MIT",
             "engines": {
                 "node": ">=18"
@@ -10182,16 +10519,16 @@
             }
         },
         "node_modules/typescript-eslint": {
-            "version": "8.69.0",
-            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.69.0.tgz",
-            "integrity": "sha512-B3MltX0VqjUBNEe3b3sSuiRbfa6XrfHFtBiPamjT5AsW/dfq+y+bc0wyuS9DxAS1LyzCxRp2+rxzpLUvqM2BvA==",
+            "version": "8.70.0",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.70.0.tgz",
+            "integrity": "sha512-P/W5cz70/cQAuKfY3xwQMWWTV7BvJ0mAQmi+9mBcsVPaBUpd6Ohpa+fECv9rBFrQcig86jAiNBFNWUqnTjr4pw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/eslint-plugin": "8.69.0",
-                "@typescript-eslint/parser": "8.69.0",
-                "@typescript-eslint/typescript-estree": "8.69.0",
-                "@typescript-eslint/utils": "8.69.0"
+                "@typescript-eslint/eslint-plugin": "8.70.0",
+                "@typescript-eslint/parser": "8.70.0",
+                "@typescript-eslint/typescript-estree": "8.70.0",
+                "@typescript-eslint/utils": "8.70.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -10230,33 +10567,33 @@
             }
         },
         "node_modules/undici-types": {
-            "version": "8.3.0",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
-            "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+            "version": "8.9.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.9.0.tgz",
+            "integrity": "sha512-KTDyRTYX8sWmKXAikPHHSyc63CRPETMctyjKFupcC6OBLXT3xsN0e9aF7m+mIXutFWpUXuedtowG7iLOzp0kQg==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/unimport": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/unimport/-/unimport-6.3.0.tgz",
-            "integrity": "sha512-M+Dxk5W9WRd+8j56W9tp8lGW/dmMc7g5zj7BWQnEjKQhryBstqsi1V0izb0zHwSkEN8cSYV7K75/bykairV2tA==",
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/unimport/-/unimport-6.5.0.tgz",
+            "integrity": "sha512-t0KLJLRbebz3f7NrQe+vy2ObeugVeM1XqI2oeYnauddmHSglYj3U6bxOJ65IbXmOFkcAGFJK2OyGH7aqHPM6Ug==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "acorn": "^8.16.0",
+                "acorn": "^8.18.0",
                 "escape-string-regexp": "^5.0.0",
                 "estree-walker": "^3.0.3",
-                "local-pkg": "^1.1.2",
-                "magic-string": "^0.30.21",
+                "local-pkg": "^1.2.1",
+                "magic-string": "^1.2.3",
                 "mlly": "^1.8.2",
                 "pathe": "^2.0.3",
-                "picomatch": "^4.0.4",
-                "pkg-types": "^2.3.1",
+                "picomatch": "^4.0.7",
+                "pkg-types": "^2.3.3",
                 "scule": "^1.3.0",
-                "strip-literal": "^3.1.0",
-                "tinyglobby": "^0.2.16",
-                "unplugin": "^3.0.0",
-                "unplugin-utils": "^0.3.1"
+                "strip-literal": "^4.0.0",
+                "tinyglobby": "^0.2.17",
+                "unplugin": "^3.3.0",
+                "unplugin-utils": "^0.3.2"
             },
             "engines": {
                 "node": ">=18.12.0"
@@ -10297,19 +10634,69 @@
                 "@types/estree": "^1.0.0"
             }
         },
+        "node_modules/unimport/node_modules/magic-string": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.3.1.tgz",
+            "integrity": "sha512-rm91zr2Ou+XueDTohjQQjdQEcYM6zVi8KVUCG8Ec3vHwUEKrhSdCNyfuIywkA6hcCAteIn0ZOtAHA6eGpiX+Pg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.6.0"
+            }
+        },
         "node_modules/unimport/node_modules/unplugin": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-3.0.0.tgz",
-            "integrity": "sha512-0Mqk3AT2TZCXWKdcoaufeXNukv2mTrEZExeXlHIOZXdqYoHHr4n51pymnwV8x2BOVxwXbK2HLlI7usrqMpycdg==",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-3.3.0.tgz",
+            "integrity": "sha512-qa66K+crbfyE6JK10GjvbJeRrOsuC/JpbnHctfyp/i4oBTxWOzJfRZyDiOk1PtErMFRu8JhsU/wPvOdBNWe5Rg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/remapping": "^2.3.5",
-                "picomatch": "^4.0.3",
+                "picomatch": "^4.0.4",
                 "webpack-virtual-modules": "^0.6.2"
             },
             "engines": {
                 "node": "^20.19.0 || >=22.12.0"
+            },
+            "peerDependencies": {
+                "@farmfe/core": "*",
+                "@rspack/core": "*",
+                "bun-types-no-globals": "*",
+                "esbuild": "*",
+                "rolldown": "*",
+                "rollup": "*",
+                "unloader": "*",
+                "vite": "*",
+                "webpack": "*"
+            },
+            "peerDependenciesMeta": {
+                "@farmfe/core": {
+                    "optional": true
+                },
+                "@rspack/core": {
+                    "optional": true
+                },
+                "bun-types-no-globals": {
+                    "optional": true
+                },
+                "esbuild": {
+                    "optional": true
+                },
+                "rolldown": {
+                    "optional": true
+                },
+                "rollup": {
+                    "optional": true
+                },
+                "unloader": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": true
+                },
+                "webpack": {
+                    "optional": true
+                }
             }
         },
         "node_modules/universalify": {
@@ -10348,9 +10735,9 @@
             }
         },
         "node_modules/unplugin-dts": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/unplugin-dts/-/unplugin-dts-1.0.3.tgz",
-            "integrity": "sha512-/GR887wfG4r1cWyt1UZsLRuMIjsmEbGkS9yJrz+0dsToHAYUD5CTyP3JMGVLv25j9K0mJcwAVvZno/aTuSUvNg==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/unplugin-dts/-/unplugin-dts-1.1.0.tgz",
+            "integrity": "sha512-KZJ+qk+lmd9dJY/PJvDRFL9BUtVubKDiX7Ai/X6mlkCArcQNzwmupKjVqHbRA42uqO5ZfFRFc+o8/OCbQ1GonQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -10358,6 +10745,7 @@
                 "@volar/typescript": "^2.4.26",
                 "compare-versions": "^6.1.1",
                 "debug": "^4.4.0",
+                "glob-to-regexp": "0.4.1",
                 "kolorist": "^1.8.0",
                 "local-pkg": "^1.1.1",
                 "magic-string": "^0.30.17",
@@ -10402,14 +10790,14 @@
             }
         },
         "node_modules/unplugin-utils": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/unplugin-utils/-/unplugin-utils-0.3.1.tgz",
-            "integrity": "sha512-5lWVjgi6vuHhJ526bI4nlCOmkCIF3nnfXkCMDeMJrtdvxTs6ZFCM8oNufGTsDbKv/tJ/xj8RpvXjRuPBZJuJog==",
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/unplugin-utils/-/unplugin-utils-0.3.2.tgz",
+            "integrity": "sha512-xVToRh2CTmLk2HnEG7ac4rl1MJTT3RFkpS8B++/SnB0kXvuaavD+n3m/vrzyWQOdJNSZQACnbz01pnppbwV5BA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "pathe": "^2.0.3",
-                "picomatch": "^4.0.3"
+                "picomatch": "^4.0.4"
             },
             "engines": {
                 "node": ">=20.19.0"
@@ -10491,9 +10879,9 @@
             }
         },
         "node_modules/use-sync-external-store": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
-            "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.7.0.tgz",
+            "integrity": "sha512-6L+EeigHMQhdaIPNIFUKwfWJSwWFQ8gJbJ2DLOs5sDIegTwR9fRxvnM3uciHKjIZhFz+KAv2emhWMRvDmMcY8A==",
             "dev": true,
             "license": "MIT",
             "peerDependencies": {
@@ -10517,16 +10905,16 @@
             }
         },
         "node_modules/vite": {
-            "version": "8.2.2",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.2.tgz",
-            "integrity": "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==",
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.3.0.tgz",
+            "integrity": "sha512-lhZBVvEHefgE+HQZC9O7EBJgCU/nVzFNl7vkS4RE0APtWLP02/8QVIkQtzBxPquh7lq5/78NHipTj7ODQ6XuyQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "lightningcss": "^1.33.0",
-                "picomatch": "^4.0.5",
-                "postcss": "^8.5.26",
-                "rolldown": "~1.2.4",
+                "picomatch": "^4.0.7",
+                "postcss": "^8.5.28",
+                "rolldown": "~1.2.6",
                 "tinyglobby": "^0.2.17"
             },
             "bin": {
@@ -10543,7 +10931,7 @@
             },
             "peerDependencies": {
                 "@types/node": "^20.19.0 || >=22.12.0",
-                "@vitejs/devtools": "^0.4.0 || ^0.5.0",
+                "@vitejs/devtools": "^0.7.1",
                 "esbuild": "^0.27.0 || ^0.28.0",
                 "jiti": ">=1.21.0",
                 "less": "^4.0.0",
@@ -10747,6 +11135,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -10768,6 +11159,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -10789,6 +11183,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -10810,6 +11207,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -10956,9 +11356,9 @@
             }
         },
         "node_modules/vscode-uri": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
-            "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.2.0.tgz",
+            "integrity": "sha512-m2gXo3bn0G1kT9InzMf07fTbqMbGtyckj3bH5ktLO+1Ssv+yiATZ4dhwaQv9UZWxJh6E9IFGnQyjgWVDWVBDrg==",
             "dev": true,
             "license": "MIT"
         },
@@ -11037,6 +11437,22 @@
                 "node": ">=8"
             }
         },
+        "node_modules/web-ext/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
         "node_modules/web-ext/node_modules/cliui": {
             "version": "8.0.1",
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -11051,6 +11467,13 @@
             "engines": {
                 "node": ">=12"
             }
+        },
+        "node_modules/web-ext/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/web-ext/node_modules/jose": {
             "version": "5.9.6",
@@ -11080,6 +11503,21 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/web-ext/node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/web-ext/node_modules/strip-ansi": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -11091,6 +11529,24 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/web-ext/node_modules/wrap-ansi": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
             }
         },
         "node_modules/web-ext/node_modules/yargs": {
@@ -11257,13 +11713,12 @@
             }
         },
         "node_modules/wouter": {
-            "version": "3.10.0",
-            "resolved": "https://registry.npmjs.org/wouter/-/wouter-3.10.0.tgz",
-            "integrity": "sha512-zTfddD80zc2/J5l8JKcdvzOK6AwP0kpyHEI3DxRN2bn8U1oJPnrSVm8v+X3WwDamvLAOxTO7ZvkxkpRWlyeJ1Q==",
+            "version": "3.11.0",
+            "resolved": "https://registry.npmjs.org/wouter/-/wouter-3.11.0.tgz",
+            "integrity": "sha512-xyMLHhytdGhIjXVRcSjeYbXd7TR1lrxVTPLGBWmmyW52ZuWVQ1jXmsgoJ4G5s4tjloJCq7h4i2eREljWUQ4+/A==",
             "dev": true,
             "license": "Unlicense",
             "dependencies": {
-                "mitt": "^3.0.1",
                 "regexparam": "^3.0.0",
                 "use-sync-external-store": "^1.0.0"
             },
@@ -11272,60 +11727,39 @@
             }
         },
         "node_modules/wrap-ansi": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "version": "9.0.2",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+            "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "ansi-styles": "^4.0.0",
-                "string-width": "^4.1.0",
-                "strip-ansi": "^6.0.0"
+                "ansi-styles": "^6.2.1",
+                "string-width": "^7.0.0",
+                "strip-ansi": "^7.1.0"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
             }
         },
-        "node_modules/wrap-ansi/node_modules/ansi-regex": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/wrap-ansi/node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+        "node_modules/wrap-ansi/node_modules/string-width": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+            "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "color-convert": "^2.0.1"
+                "emoji-regex": "^10.3.0",
+                "get-east-asian-width": "^1.0.0",
+                "strip-ansi": "^7.1.0"
             },
             "engines": {
-                "node": ">=8"
+                "node": ">=18"
             },
             "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/wrap-ansi/node_modules/strip-ansi": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/wrappy": {
@@ -11335,10 +11769,9 @@
             "license": "ISC"
         },
         "node_modules/ws": {
-            "version": "8.21.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-            "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
-            "dev": true,
+            "version": "8.21.3",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+            "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
             "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"
@@ -11368,6 +11801,22 @@
             },
             "engines": {
                 "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/wsl-utils/node_modules/is-wsl": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+            "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-inside-container": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=16"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -11487,9 +11936,9 @@
             }
         },
         "node_modules/yaml": {
-            "version": "2.9.0",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-            "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+            "version": "2.9.1",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.1.tgz",
+            "integrity": "sha512-3NxN8+78OdzbT7C/WjGsyfPAtJaN3FNDsWxv7Y7mcDsT/oOmgW8BpyQQFFBnvZE3j9Y2Sdz1ULFLezL7Eb2yFw==",
             "dev": true,
             "license": "ISC",
             "optional": true,
@@ -11504,16 +11953,16 @@
             }
         },
         "node_modules/yargs": {
-            "version": "18.0.0",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
-            "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+            "version": "18.1.0",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.1.0.tgz",
+            "integrity": "sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "cliui": "^9.0.1",
                 "escalade": "^3.1.1",
                 "get-caller-file": "^2.0.5",
-                "string-width": "^7.2.0",
+                "string-width": "^8.2.1",
                 "y18n": "^5.0.5",
                 "yargs-parser": "^22.0.0"
             },
@@ -11529,24 +11978,6 @@
             "license": "ISC",
             "engines": {
                 "node": "^20.19.0 || ^22.12.0 || >=23"
-            }
-        },
-        "node_modules/yargs/node_modules/string-width": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-            "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "emoji-regex": "^10.3.0",
-                "get-east-asian-width": "^1.0.0",
-                "strip-ansi": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/yauzl": {
@@ -11587,9 +12018,9 @@
             }
         },
         "node_modules/zod": {
-            "version": "4.5.1",
-            "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.1.tgz",
-            "integrity": "sha512-P3GqeAEOEDqKvafVGLezbg+39YW/ze4xrD4qdS0adOY8eoI3zfjv1PQM4UwQzgT8mZKXEbqtVt8K+ZKGqkMFKg==",
+            "version": "4.6.4",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-4.6.4.tgz",
+            "integrity": "sha512-AXSD6hvGdvRjajG/l1cC+d6IrhH+sjmPKtYeQdJIK8MFJl3LyClzS+o/YsVC+zQZPupAaeH5skwwm8YqYH7BqA==",
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
@@ -11693,27 +12124,6 @@
             },
             "engines": {
                 "node": ">=20"
-            }
-        },
-        "packages/mcp/node_modules/ws": {
-            "version": "8.21.3",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
-            "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=10.0.0"
-            },
-            "peerDependencies": {
-                "bufferutil": "^4.0.1",
-                "utf-8-validate": ">=5.0.2"
-            },
-            "peerDependenciesMeta": {
-                "bufferutil": {
-                    "optional": true
-                },
-                "utf-8-validate": {
-                    "optional": true
-                }
             }
         },
         "packages/page-agent": {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
         "vitest": "^4.1.11"
     },
     "overrides": {
-        "typescript": "^6.0.3"
+        "typescript": "^6.0.3",
+        "image-size": "npm:image-size-next@^2.1.1"
     },
     "lint-staged": {
         "*.{js,ts,cjs,cts,mjs,mts}": [


### PR DESCRIPTION
## Summary

Resolves all critical and high severity vulnerabilities reported by `npm audit`.

### What changed

1. Ran `npm audit fix` to apply automatically-fixable upgrades.
2. Added a root-level npm override for the unmaintained `image-size` package, replacing it with the community-maintained fork `image-size-next@^2.1.1`, which fixes:
   - CVE-2025-71329 (JXL/HEIF infinite-loop DoS)
   - CVE-2025-71330 (ICNS infinite-loop DoS)

`image-size` is a transitive dependency of the extension tooling chain (`wxt` → `web-ext` → `addons-linter`). The latest published `image-size@2.0.2` is still affected and the project is no longer maintained, so an override to the compatible `image-size-next` fork is the targeted remediation.

### Verification

- `npm audit` now reports **0 vulnerabilities**.
- `npm run typecheck` passes.
- `npm test` passes (69 tests across page-controller, llms, core, extension).
- `npm run build:libs` passes.
- `npm run build:ext` passes (WXT + web-ext extension zip builds successfully).

### Before / After

| Severity | Before | After |
|----------|--------|-------|
| Critical | 0* | 0 |
| High | 4 | 0 |
| Moderate | 2 | 0 |
| Low | 0 | 0 |
| **Total** | **6** | **0** |

*Note: the original audit on the stale local branch showed 3 critical `shell-quote` advisories; these were resolved by `npm audit fix` after pulling latest `main`. The remaining 4 high advisories in `image-size` are resolved by this PR's override.

---

Fixes dependency security advisories in extension build tooling.